### PR TITLE
chore: release v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.0] - 2026-01-12
+
+### Added
+
+- **PEM certificate support**: `CertificateAuth::from_pem()` constructor for users with PEM-formatted certificates (common in Linux/Kubernetes environments)
+- **Decimal support for Money types**: Money, SmallMoney, and MoneyN columns now return `rust_decimal::Decimal` when the `decimal` feature is enabled, preventing precision loss in financial applications
+
+### Fixed
+
+- **VARCHAR decoding for non-UTF8 encodings**: Fixed incorrect decoding of VARCHAR columns with legacy encodings (GBK, Shift-JIS, etc.) where the UTF-8 fast-path would incorrectly accept valid UTF-8 byte sequences that were actually non-UTF8 encoded data
+- **Security vulnerabilities**: Updated dependencies to resolve RUSTSEC-2026-0001 (rkyv) and RUSTSEC-2026-0002 (lru)
+
+### Changed
+
+- Money type parsing consolidated into single `parse_money_value()` helper function
+
 ## [0.5.2] - 2026-01-04
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2232,7 +2232,7 @@ dependencies = [
 
 [[package]]
 name = "mssql-auth"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "aes 0.8.4",
  "async-trait",
@@ -2263,7 +2263,7 @@ dependencies = [
 
 [[package]]
 name = "mssql-client"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -2295,7 +2295,7 @@ dependencies = [
 
 [[package]]
 name = "mssql-codec"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "bytes",
  "futures-core",
@@ -2311,7 +2311,7 @@ dependencies = [
 
 [[package]]
 name = "mssql-derive"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2320,7 +2320,7 @@ dependencies = [
 
 [[package]]
 name = "mssql-driver-pool"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "mssql-client",
@@ -2334,7 +2334,7 @@ dependencies = [
 
 [[package]]
 name = "mssql-testing"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "bytes",
  "mssql-client",
@@ -2347,7 +2347,7 @@ dependencies = [
 
 [[package]]
 name = "mssql-tls"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "rustls",
  "thiserror",
@@ -2360,7 +2360,7 @@ dependencies = [
 
 [[package]]
 name = "mssql-types"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -4160,7 +4160,7 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tds-protocol"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "bitflags 2.10.0",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/*", "xtask"]
 exclude = ["fuzz"]  # Fuzz tests have their own workspace (required by cargo-fuzz)
 
 [workspace.package]
-version = "0.5.2"
+version = "0.6.0"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT OR Apache-2.0"
@@ -14,15 +14,15 @@ categories = ["database"]
 
 [workspace.dependencies]
 # Internal crates (version required for crates.io publishing)
-tds-protocol = { version = "0.5.2", path = "crates/tds-protocol" }
-mssql-tls = { version = "0.5.2", path = "crates/mssql-tls" }
-mssql-codec = { version = "0.5.2", path = "crates/mssql-codec" }
-mssql-types = { version = "0.5.2", path = "crates/mssql-types" }
-mssql-auth = { version = "0.5.2", path = "crates/mssql-auth" }
-mssql-driver-pool = { version = "0.5.2", path = "crates/mssql-pool" }
-mssql-client = { version = "0.5.2", path = "crates/mssql-client" }
-mssql-derive = { version = "0.5.2", path = "crates/mssql-derive" }
-mssql-testing = { version = "0.5.2", path = "crates/mssql-testing" }
+tds-protocol = { version = "0.6.0", path = "crates/tds-protocol" }
+mssql-tls = { version = "0.6.0", path = "crates/mssql-tls" }
+mssql-codec = { version = "0.6.0", path = "crates/mssql-codec" }
+mssql-types = { version = "0.6.0", path = "crates/mssql-types" }
+mssql-auth = { version = "0.6.0", path = "crates/mssql-auth" }
+mssql-driver-pool = { version = "0.6.0", path = "crates/mssql-pool" }
+mssql-client = { version = "0.6.0", path = "crates/mssql-client" }
+mssql-derive = { version = "0.6.0", path = "crates/mssql-derive" }
+mssql-testing = { version = "0.6.0", path = "crates/mssql-testing" }
 
 # Async runtime
 tokio = { version = "1.48", features = ["full"] }


### PR DESCRIPTION
## Summary

Release v0.6.0 with the following changes:

### Added
- **PEM certificate support**: `CertificateAuth::from_pem()` constructor for users with PEM-formatted certificates (common in Linux/Kubernetes environments)
- **Decimal support for Money types**: Money, SmallMoney, and MoneyN columns now return `rust_decimal::Decimal` when the `decimal` feature is enabled, preventing precision loss in financial applications

### Fixed
- **VARCHAR decoding for non-UTF8 encodings**: Fixed incorrect decoding of VARCHAR columns with legacy encodings (GBK, Shift-JIS, etc.) where the UTF-8 fast-path would incorrectly accept valid UTF-8 byte sequences that were actually non-UTF8 encoded data
- **Security vulnerabilities**: Updated dependencies to resolve RUSTSEC-2026-0001 (rkyv) and RUSTSEC-2026-0002 (lru)

### Changed
- Money type parsing consolidated into single `parse_money_value()` helper function

## Test plan
- [ ] CI pipeline passes all checks
- [ ] Squash-merge to main
- [ ] After merge, run `just tag` to create v0.6.0 tag
- [ ] Push tag to trigger automated release workflow