### PR TITLE
feat(client): make TLS dependencies optional via `tls` feature flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **PEM certificate support**: `CertificateAuth::from_pem()` constructor for users with PEM-formatted certificates (common in Linux/Kubernetes environments)
 - **Decimal support for Money types**: Money, SmallMoney, and MoneyN columns now return `rust_decimal::Decimal` when the `decimal` feature is enabled, preventing precision loss in financial applications
+- **Optional TLS feature**: TLS dependencies are now behind the `tls` feature flag (enabled by default). Disable for `Encrypt=no_tls` connections to reduce binary size (~2-3 MB) and speed up compilation. Useful for enterprise internal networks, Kubernetes clusters, and legacy SQL Server environments
 
 ### Fixed
 

--- a/crates/mssql-client/Cargo.toml
+++ b/crates/mssql-client/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["sql-server", "mssql", "database", "async", "tokio"]
 categories = ["database", "asynchronous"]
 
 [features]
-default = ["chrono", "uuid", "decimal", "encoding"]
+default = ["chrono", "uuid", "decimal", "encoding", "tls"]
 chrono = ["mssql-types/chrono", "dep:chrono"]
 uuid = ["mssql-types/uuid"]
 decimal = ["mssql-types/decimal", "dep:rust_decimal"]
@@ -28,10 +28,15 @@ always-encrypted = ["mssql-auth/always-encrypted"]
 # Enables proper handling of non-ASCII text in VARCHAR/CHAR columns with
 # locale-specific encodings (Japanese Shift_JIS, Chinese GB18030/Big5, Korean EUC-KR, etc.)
 encoding = ["tds-protocol/encoding", "mssql-types/encoding"]
+# TLS/SSL encryption support (enabled by default)
+# Disable this feature for environments where TLS is not needed (enterprise internal networks,
+# legacy SQL Server instances, or development environments) to reduce binary size and compile time.
+# When disabled, only `Encrypt=no_tls` connections are supported.
+tls = ["dep:mssql-tls"]
 
 [dependencies]
 tds-protocol = { workspace = true }
-mssql-tls = { workspace = true }
+mssql-tls = { workspace = true, optional = true }
 mssql-codec = { workspace = true }
 mssql-types = { workspace = true }
 mssql-auth = { workspace = true }
@@ -109,7 +114,8 @@ harness = false
 [package.metadata.cargo-machete]
 # tokio-test and mssql-derive are dev-dependencies for tests
 # opentelemetry_sdk and tracing-opentelemetry are behind the otel feature flag
-ignored = ["tokio-test", "mssql-derive", "opentelemetry_sdk", "tracing-opentelemetry"]
+# mssql-tls is behind the tls feature flag
+ignored = ["tokio-test", "mssql-derive", "opentelemetry_sdk", "tracing-opentelemetry", "mssql-tls"]
 
 [lints]
 workspace = true

--- a/crates/mssql-client/src/config.rs
+++ b/crates/mssql-client/src/config.rs
@@ -3,6 +3,7 @@
 use std::time::Duration;
 
 use mssql_auth::Credentials;
+#[cfg(feature = "tls")]
 use mssql_tls::TlsConfig;
 use tds_protocol::version::TdsVersion;
 
@@ -289,7 +290,8 @@ pub struct Config {
     /// Authentication credentials.
     pub credentials: Credentials,
 
-    /// TLS configuration.
+    /// TLS configuration (only available when `tls` feature is enabled).
+    #[cfg(feature = "tls")]
     pub tls: TlsConfig,
 
     /// Application name (shown in SQL Server management tools).
@@ -373,6 +375,7 @@ impl Default for Config {
             port: 1433,
             database: None,
             credentials: Credentials::sql_server("", ""),
+            #[cfg(feature = "tls")]
             tls: TlsConfig::default(),
             application_name: "mssql-client".to_string(),
             connect_timeout: timeouts.connect_timeout,
@@ -586,7 +589,10 @@ impl Config {
     #[must_use]
     pub fn trust_server_certificate(mut self, trust: bool) -> Self {
         self.trust_server_certificate = trust;
-        self.tls = self.tls.trust_server_certificate(trust);
+        #[cfg(feature = "tls")]
+        {
+            self.tls = self.tls.trust_server_certificate(trust);
+        }
         self
     }
 
@@ -594,7 +600,10 @@ impl Config {
     #[must_use]
     pub fn strict_mode(mut self, enabled: bool) -> Self {
         self.strict_mode = enabled;
-        self.tls = self.tls.strict_mode(enabled);
+        #[cfg(feature = "tls")]
+        {
+            self.tls = self.tls.strict_mode(enabled);
+        }
         if enabled {
             self.tds_version = TdsVersion::V8_0;
         }
@@ -630,7 +639,10 @@ impl Config {
         // If TDS 8.0 is requested, automatically enable strict mode
         if version.is_tds_8() {
             self.strict_mode = true;
-            self.tls = self.tls.strict_mode(true);
+            #[cfg(feature = "tls")]
+            {
+                self.tls = self.tls.strict_mode(true);
+            }
         }
         self
     }

--- a/crates/mssql-client/src/error.rs
+++ b/crates/mssql-client/src/error.rs
@@ -120,6 +120,7 @@ pub enum Error {
     Cancelled,
 }
 
+#[cfg(feature = "tls")]
 impl From<mssql_tls::TlsError> for Error {
     fn from(e: mssql_tls::TlsError) -> Self {
         Error::Tls(e.to_string())


### PR DESCRIPTION
## Summary

Resolves #47

TLS dependencies (rustls, webpki, etc.) are now behind an optional `tls` feature that is enabled by default. This allows users who only need `Encrypt=no_tls` connections to reduce binary size by ~2-3 MB and improve compilation times.

### Changes

- Add `tls` feature to mssql-client Cargo.toml (default enabled)
- Make mssql-tls dependency optional
- Wrap all TLS-related types, imports, and code paths with `#[cfg(feature = "tls")]`
- Add compile-time errors when TLS is required but feature is disabled
- Create dedicated `connect_no_tls` method for plain TCP connections

### Use Cases

- Enterprise internal networks with disabled encryption
- Kubernetes clusters with service mesh encryption (TLS handled at mesh layer)
- Legacy SQL Server environments
- Development/testing environments

### Usage

```toml
# With TLS (default)
mssql-client = "0.6"

# Without TLS
mssql-client = { version = "0.6", default-features = false, features = ["chrono", "uuid", "decimal", "encoding"] }
```

## Test plan

- [x] Compile without TLS feature: `cargo check -p mssql-client --no-default-features --features "chrono,uuid,decimal,encoding"`
- [x] Compile with TLS feature (default): `cargo check -p mssql-client`
- [x] Run tests: `cargo test -p mssql-client --lib` (152 tests pass)
- [x] No warnings in either configuration