### PR TITLE
Release v0.8.0

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -3,15 +3,15 @@
 
 [advisories]
 ignore = [
-    # rustls-pemfile unmaintained - used indirectly, migration pending upstream
+    # rustls-pemfile unmaintained - direct dep of mssql-auth for cert parsing
+    # Migration to rustls-pki-types PemObject pending
     "RUSTSEC-2025-0134",
-    # astral-tokio-tar PAX extension validation - only used by testcontainers for testing
-    # Dev-only crate (mssql-testing, publish = false). Fix only in 0.6.1-rc1 (pre-release).
-    # Supersedes the previous RUSTSEC-2025-0111 (tokio-tar) ignore — testcontainers
-    # migrated from tokio-tar to astral-tokio-tar.
-    "RUSTSEC-2026-0066",
     # RSA timing side-channel (Marvin Attack) - no fix available yet
     # Our RSA usage is local (CEK unwrapping, SSPI auth), not network-observable
     # Tracking: https://github.com/RustCrypto/RSA/issues/390
     "RUSTSEC-2023-0071",
+    # rand 0.8.5 unsoundness with custom logger + rand::rng() during ThreadRng reseeding
+    # log feature not enabled on our rand 0.8; unsoundness conditions cannot be met
+    # Blocked on rsa 0.10 stable. Tracking: #21
+    "RUSTSEC-2026-0097",
 ]

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,67 @@
+# Code owners for rust-mssql-driver
+#
+# Lines listed here auto-request review from the specified owners when a PR
+# touches matching paths. The last matching line wins — so more specific
+# rules (deeper in the file) override earlier, broader rules.
+#
+# See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-security/customizing-your-repository/about-code-owners
+#
+# NOTE: Currently the project has a single maintainer (@jkindrix). This file
+# is structured to make expanding the maintainer set cheap — add more handles
+# (or GitHub teams like @praxiomlabs/protocol-reviewers) as they come on board.
+
+# Catch-all: every PR gets reviewed by the primary maintainer by default.
+* @jkindrix
+
+# Protocol layer — TDS wire format and parsing logic. Changes here can break
+# compatibility with SQL Server silently, so they deserve extra scrutiny.
+/crates/tds-protocol/        @jkindrix
+
+# Authentication and credential handling. Security-critical.
+/crates/mssql-auth/          @jkindrix
+
+# TLS layer. Security-critical.
+/crates/mssql-tls/           @jkindrix
+
+# Connection pool. Concurrency and resource lifecycle.
+/crates/mssql-pool/          @jkindrix
+
+# Main client API — public surface area.
+/crates/mssql-client/        @jkindrix
+
+# Type conversions — SQL ↔ Rust type mapping correctness matters for data integrity.
+/crates/mssql-types/         @jkindrix
+
+# Proc macros.
+/crates/mssql-derive/        @jkindrix
+
+# Test infrastructure (not published).
+/crates/mssql-testing/       @jkindrix
+
+# Build automation.
+/xtask/                      @jkindrix
+/Justfile                    @jkindrix
+
+# CI / CD workflows. Changes here can affect every future release, so any
+# workflow change should get maintainer review.
+/.github/workflows/          @jkindrix
+/.github/CODEOWNERS          @jkindrix
+/.github/dependabot.yml      @jkindrix
+
+# Release and security policy documents — any edit here should be deliberate.
+/RELEASING.md                @jkindrix
+/SECURITY.md                 @jkindrix
+/STABILITY.md                @jkindrix
+/CODE_OF_CONDUCT.md          @jkindrix
+/CONTRIBUTING.md             @jkindrix
+/MAINTAINERS.md              @jkindrix
+
+# Dependency and supply-chain policy.
+/deny.toml                   @jkindrix
+/.cargo/audit.toml           @jkindrix
+/docs/DEPENDENCY_POLICY.md   @jkindrix
+
+# Project-level config. Version bumps, workspace membership, etc.
+/Cargo.toml                  @jkindrix
+/Cargo.lock                  @jkindrix
+/rust-toolchain.toml         @jkindrix

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,155 @@
+name: 🐛 Bug report
+description: Report a bug in rust-mssql-driver
+labels: ["bug", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug report. The more specific you can be, the
+        faster we can reproduce and fix the issue.
+
+        **Before filing:** please check [existing issues](https://github.com/praxiomlabs/rust-mssql-driver/issues?q=is%3Aissue) to avoid duplicates, and consult [docs.rs](https://docs.rs/mssql-client) in case the behavior you're seeing is documented.
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: A clear, concise description of the bug.
+      placeholder: "Calling `Client::query()` with a parameterized SELECT returns Err(Protocol(...)) when the parameter is NULL."
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction steps
+      description: Minimal code that reproduces the bug. Include the connection string form (with credentials redacted), the SQL, and the Rust code calling into the driver.
+      render: rust
+      placeholder: |
+        use mssql_client::{Client, Config};
+
+        #[tokio::main]
+        async fn main() -> Result<(), Box<dyn std::error::Error>> {
+            let config = Config::from_connection_string(
+                "Server=localhost;Database=test;User Id=sa;Password=REDACTED;TrustServerCertificate=true"
+            )?;
+            let mut client = Client::connect(config).await?;
+
+            // ... trigger the bug here
+            let rows = client.query("SELECT @p1", &[&None::<i32>]).await?;
+
+            Ok(())
+        }
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What you expected to happen.
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: What actually happened. Include the full error (if any) and relevant log output.
+      render: text
+    validations:
+      required: true
+
+  - type: input
+    id: driver-version
+    attributes:
+      label: Driver version
+      description: Version of `mssql-client` (or other workspace crate) you're using.
+      placeholder: "0.7.0"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: features
+    attributes:
+      label: Feature flags enabled
+      description: Which cargo features are you using? (Select all that apply.)
+      multiple: true
+      options:
+        - default
+        - tls
+        - chrono
+        - uuid
+        - decimal
+        - json
+        - encoding
+        - zeroize
+        - otel
+        - sspi-auth
+        - integrated-auth
+        - azure-identity
+        - cert-auth
+        - always-encrypted
+        - azure-keyvault
+        - windows-certstore
+    validations:
+      required: true
+
+  - type: input
+    id: rust-version
+    attributes:
+      label: Rust version
+      description: Output of `rustc --version`.
+      placeholder: "rustc 1.88.0 (6b00bc388 2025-06-23)"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      options:
+        - Linux
+        - macOS
+        - Windows
+        - Other (specify in additional context)
+    validations:
+      required: true
+
+  - type: input
+    id: sql-server-version
+    attributes:
+      label: SQL Server version and edition
+      description: The target SQL Server version. For Azure SQL, note which offering (DB, Managed Instance, Synapse).
+      placeholder: "SQL Server 2022 Developer Edition (16.0.1000.6)"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: tds-version
+    attributes:
+      label: TDS version
+      description: Which TDS protocol version is in use? Check your connection string or `Config::tds_version`.
+      options:
+        - "8.0 (strict mode / SQL Server 2022+)"
+        - "7.4 (default / SQL Server 2012+)"
+        - "7.3A (SQL Server 2008)"
+        - "7.3B (SQL Server 2008 R2)"
+        - "Not sure"
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs
+      description: |
+        If possible, enable `tracing` at DEBUG level for `mssql_client` and include relevant
+        log output. **Do not include credentials or connection strings with passwords.**
+      render: text
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Anything else we should know? Custom deployments, network constraints, related issues, workarounds you've tried, etc.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,24 @@
+# Issue template configuration
+# See https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository
+
+# Require users to use one of the structured templates below.
+# Blank issues are often underspecified and take longer to triage.
+blank_issues_enabled: false
+
+# Point users at the right place for different kinds of reports.
+contact_links:
+  - name: 🔒 Security vulnerability (private report)
+    url: https://github.com/praxiomlabs/rust-mssql-driver/security/advisories/new
+    about: Report a security vulnerability privately via GitHub Security Advisories. DO NOT open a public issue for security problems — see SECURITY.md for the full policy.
+
+  - name: 💬 Question or usage help
+    url: https://github.com/praxiomlabs/rust-mssql-driver/discussions
+    about: Ask a question, share a use case, or get help using the driver. Start a Discussion for conversational topics.
+
+  - name: 📖 Documentation
+    url: https://docs.rs/mssql-client/latest/mssql_client/
+    about: API documentation on docs.rs. Consult this first — many questions are answered there.
+
+  - name: 🚢 Migration from Tiberius
+    url: https://github.com/praxiomlabs/rust-mssql-driver/blob/main/docs/MIGRATION_FROM_TIBERIUS.md
+    about: Migrating from the Tiberius driver? The migration guide covers API differences, feature parity, and common pitfalls.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,87 @@
+name: ✨ Feature request
+description: Suggest a new feature or enhancement
+labels: ["enhancement", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting a feature! Before filing, please check
+        [existing issues](https://github.com/praxiomlabs/rust-mssql-driver/issues?q=is%3Aissue) in case
+        the same request is already tracked.
+
+        Good feature requests describe the **use case** first and the **proposed API** second.
+        This helps us evaluate alternatives that may solve the same problem.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: The user-facing use case. What are you trying to do? Why can't you do it today?
+      placeholder: |
+        I'm migrating a .NET application that uses SqlClient's `SqlBulkCopy` for high-volume
+        inserts. The Rust driver has `bulk_insert()`, but it doesn't support COLUMN_ENCRYPTION
+        markers for Always Encrypted columns.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What API or behavior would you like to see? Rust code snippets welcome.
+      render: rust
+      placeholder: |
+        // Ideally something like:
+        client
+            .bulk_insert("dbo.SensitiveData")
+            .with_encryption(&[("ssn", &cek_metadata)])
+            .rows(records)
+            .execute()
+            .await?;
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: What workarounds have you tried? What other approaches did you reject and why?
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area of the codebase
+      description: Which part of the driver does this touch? (Select all that apply.)
+      multiple: true
+      options:
+        - Client API (mssql-client)
+        - Connection pool (mssql-driver-pool)
+        - TDS protocol (tds-protocol)
+        - Authentication (mssql-auth)
+        - TLS (mssql-tls)
+        - Type mapping (mssql-types)
+        - Derive macros (mssql-derive)
+        - Build tooling (xtask, Justfile)
+        - Documentation
+        - Not sure
+    validations:
+      required: true
+
+  - type: dropdown
+    id: breaking
+    attributes:
+      label: Would this require a breaking change?
+      description: If you're unsure, select "Not sure" — we'll assess.
+      options:
+        - "No — purely additive"
+        - "Yes — existing API would change"
+        - "Maybe — depends on implementation"
+        - "Not sure"
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Links to related work in other drivers (Tiberius, SqlClient, JDBC, ODBC), relevant SQL Server docs, or anything else.

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,44 @@
+name: ❓ Question
+description: Ask a how-to question (prefer Discussions for conversational topics)
+labels: ["question", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        **First, please check:**
+        - [docs.rs/mssql-client](https://docs.rs/mssql-client/latest/mssql_client/) — the full API reference
+        - [CONNECTION_STRINGS.md](https://github.com/praxiomlabs/rust-mssql-driver/blob/main/docs/CONNECTION_STRINGS.md) — connection string options
+        - [MIGRATION_FROM_TIBERIUS.md](https://github.com/praxiomlabs/rust-mssql-driver/blob/main/docs/MIGRATION_FROM_TIBERIUS.md) — if you're coming from Tiberius
+        - [existing issues](https://github.com/praxiomlabs/rust-mssql-driver/issues?q=is%3Aissue)
+        - [GitHub Discussions](https://github.com/praxiomlabs/rust-mssql-driver/discussions) — for conversational help
+
+        If you've already checked those and still need help, fill in the template below.
+
+  - type: textarea
+    id: question
+    attributes:
+      label: Your question
+      description: What are you trying to figure out?
+    validations:
+      required: true
+
+  - type: textarea
+    id: tried
+    attributes:
+      label: What have you tried?
+      description: Approaches you've already attempted and what happened.
+      render: rust
+
+  - type: input
+    id: driver-version
+    attributes:
+      label: Driver version
+      placeholder: "0.7.0"
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Code snippets, error messages, links to relevant docs, etc.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,103 @@
+<!--
+Thanks for contributing to rust-mssql-driver! Please fill out this template to
+help reviewers understand your change quickly.
+
+If this is your first PR, also see CONTRIBUTING.md for setup and style guidelines.
+-->
+
+## Summary
+
+<!-- One or two sentences: what does this PR do and why? -->
+
+## Linked issues
+
+<!--
+If this PR closes an issue, use "Closes #123". GitHub will auto-close the
+issue when the PR merges. If it relates to an issue without closing it, use
+"Refs #123".
+-->
+
+Closes #
+
+## Type of change
+
+<!-- Check all that apply. -->
+
+- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
+- [ ] ✨ New feature (non-breaking change that adds functionality)
+- [ ] 💥 Breaking change (fix or feature that changes existing API — see breaking-change checklist below)
+- [ ] 📝 Documentation only
+- [ ] 🔧 Refactoring (no behavioral change)
+- [ ] 🚀 Performance improvement
+- [ ] ✅ Test-only change
+- [ ] 🏗️ Build / CI / tooling
+
+## Test plan
+
+<!--
+How did you verify this change works? List the specific commands you ran.
+CI will re-run these on all platforms, but knowing what you tested locally
+helps reviewers focus.
+-->
+
+- [ ] `cargo test --workspace --all-features` passes
+- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings` is clean
+- [ ] `cargo fmt --all --check` is clean
+- [ ] For behavioral changes: new or updated tests cover the change
+- [ ] For integration-affecting changes: ran against live SQL Server (`just sql-server-start` + ignored tests)
+
+## Documentation updates
+
+<!-- Documentation is part of the change, not an afterthought. Check what you've updated. -->
+
+- [ ] Updated rustdoc comments on new/changed public items
+- [ ] Updated CHANGELOG.md `[Unreleased]` section (under Added/Fixed/Changed/Deprecated/Removed/Security)
+- [ ] Updated README.md if the change affects installation, features, or quick-start examples
+- [ ] Updated relevant files in `docs/` if the change affects user-facing behavior
+- [ ] Updated ARCHITECTURE.md if the change introduces an architectural decision (add or update an ADR)
+
+## Breaking changes
+
+<!--
+If this PR introduces a breaking change, expand this section. Otherwise,
+delete everything between the HTML comment markers below.
+-->
+
+<!-- BREAKING-CHANGE-BEGIN
+
+### What breaks
+
+<!-- Describe the specific API surface that changes, removals, or semantic shifts. -->
+
+### Migration guide
+
+<!-- Concrete before/after code for users. -->
+
+```rust
+// Before (0.x.y):
+
+// After (0.x+1.0):
+```
+
+### Pre-1.0 policy check
+
+- [ ] This change is allowed under [STABILITY.md § Pre-1.0 Releases](../blob/main/STABILITY.md#pre-10-releases-0xy)
+      (minor bumps may contain breaking changes pre-1.0)
+- [ ] Documented in CHANGELOG.md under a `### Breaking Changes` heading
+- [ ] **MSRV bumps are NOT a breaking change** per
+      [STABILITY.md § MSRV Increase Policy](../blob/main/STABILITY.md#minimum-supported-rust-version-msrv).
+      If you're bumping MSRV, mark this as a non-breaking "Changed" entry, not a breaking change.
+
+BREAKING-CHANGE-END -->
+
+## Security considerations
+
+<!--
+For any PR that touches authentication, TLS, credential handling, SQL
+generation, parsing untrusted input, or unsafe code blocks: please describe
+the security reasoning. For all other PRs, delete this section.
+-->
+
+## Additional notes
+
+<!-- Anything else reviewers should know: design alternatives considered, trade-offs, related PRs, follow-ups. -->

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -5,9 +5,17 @@ name: Benchmarks
 
 on:
   push:
-    branches: [main]
+    branches: [main, dev]
   pull_request:
     branches: [main]
+  workflow_dispatch:
+
+# Cancel in-progress runs for non-main branches when a new commit arrives.
+# Benchmarks take ~13 minutes; cancelling stale runs saves significant CI time
+# without losing signal (baselines are only stored from main anyway).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,7 +169,7 @@ jobs:
       - name: Generate coverage report
         run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           files: lcov.info
           fail_ci_if_error: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,18 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, dev]
   pull_request:
     branches: [main]
+  # Allow manual triggering from the Actions tab (useful for retrying
+  # after transient failures or validating a branch on-demand).
+  workflow_dispatch:
+
+# Cancel in-progress runs for non-main branches when a new commit arrives.
+# Main always runs to completion so we have a full audit trail per commit.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -230,7 +230,7 @@ jobs:
           fi
 
       - name: Create release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           body_path: release_notes.md
           generate_release_notes: true

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -9,12 +9,15 @@ on:
     - cron: '0 9 * * 1'
   # Allow manual trigger
   workflow_dispatch:
-  # Also run on changes to dependencies
+  # Also run on changes to dependencies (on main AND dev, so we catch
+  # supply-chain changes before they reach a release PR)
   push:
+    branches: [main, dev]
     paths:
       - '**/Cargo.toml'
       - '**/Cargo.lock'
       - 'deny.toml'
+      - '.cargo/audit.toml'
 
 jobs:
   audit:

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -80,7 +80,7 @@ jobs:
       issues: write
     steps:
       - name: Create issue
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const title = '🔒 Security Audit Failed';

--- a/.github/workflows/token-health.yml
+++ b/.github/workflows/token-health.yml
@@ -1,0 +1,149 @@
+# CARGO_REGISTRY_TOKEN health check for rust-mssql-driver
+#
+# Runs weekly (and on-demand) to verify the crates.io API token is still
+# valid. This catches token expiry BEFORE the release workflow tries to
+# publish, which would otherwise fail at tier 0 and require a rerun.
+#
+# Added in response to the v0.7.0 release incident where the token had
+# silently expired between v0.6.0 and v0.7.0, only discovered when the
+# automated publish workflow attempted to upload tds-protocol and was
+# rejected with HTTP 403.
+#
+# The check uses crates.io's /api/v1/me endpoint, which returns the
+# authenticated user's info when the token is valid. This is cheap
+# (single HTTP call), non-destructive (read-only), and unambiguous
+# (a 200 response means the token works for authenticated API calls).
+#
+# On failure, this workflow automatically opens (or updates) a GitHub
+# issue labelled `security` so the token can be rotated before the
+# next release attempt.
+
+name: Token Health Check
+
+on:
+  # Run every Monday at 09:15 UTC (staggered after Security Audit to avoid
+  # both workflows hitting GitHub Actions capacity at the same time).
+  schedule:
+    - cron: '15 9 * * 1'
+  # Allow manual trigger for ad-hoc verification or post-rotation checks.
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  # Required to open/update the notification issue on failure.
+  issues: write
+
+jobs:
+  check-token:
+    name: Verify CARGO_REGISTRY_TOKEN
+    runs-on: ubuntu-latest
+    steps:
+      - name: Call crates.io /api/v1/me with token
+        id: check
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${CARGO_REGISTRY_TOKEN:-}" ]; then
+            echo "::error::CARGO_REGISTRY_TOKEN secret is not set in this repository."
+            echo "status=missing" >> "$GITHUB_OUTPUT"
+            exit 1
+          fi
+
+          # crates.io accepts the token directly in the Authorization header
+          # (no "Bearer " prefix). This matches how cargo itself authenticates.
+          http_code=$(curl -s -o response.json -w "%{http_code}" \
+            -H "Authorization: $CARGO_REGISTRY_TOKEN" \
+            -H "User-Agent: rust-mssql-driver-token-health-check/1.0 (+https://github.com/praxiomlabs/rust-mssql-driver)" \
+            https://crates.io/api/v1/me)
+
+          echo "HTTP status: $http_code"
+
+          if [ "$http_code" = "200" ]; then
+            user=$(jq -r '.user.login // "unknown"' response.json 2>/dev/null || echo "unknown")
+            echo "::notice::Token is valid. Authenticated as crates.io user: $user"
+            echo "status=ok" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "::error::Token check failed with HTTP $http_code."
+          echo "status=failed" >> "$GITHUB_OUTPUT"
+          echo "http_code=$http_code" >> "$GITHUB_OUTPUT"
+
+          # Surface the response body for debugging (truncated to avoid
+          # leaking tokens in edge cases — crates.io never echoes the
+          # token back, but be defensive).
+          head -c 2000 response.json || true
+          exit 1
+
+      - name: Open or update tracking issue on failure
+        if: failure() && steps.check.outputs.status != 'ok'
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const title = '🔒 CARGO_REGISTRY_TOKEN health check failed';
+            const body = [
+              'The weekly `CARGO_REGISTRY_TOKEN` health check workflow failed.',
+              '',
+              'This means the crates.io API token configured as a GitHub',
+              'repository secret can no longer authenticate against the',
+              '`https://crates.io/api/v1/me` endpoint. If left unresolved,',
+              'the next tag push to `v*.*.*` will trigger the release',
+              'workflow which will fail at tier 0 during `cargo publish`.',
+              '',
+              '## How to fix',
+              '',
+              '1. Visit https://crates.io/settings/tokens',
+              '2. Revoke the current `rust-mssql-driver-*` token if it still exists.',
+              '3. Create a new token with `publish-update` scope (plus `publish-new`',
+              '   if any workspace crate has never been published before).',
+              '4. Optionally scope the token to just the 8 published crates:',
+              '   `tds-protocol`, `mssql-types`, `mssql-tls`, `mssql-codec`,',
+              '   `mssql-auth`, `mssql-derive`, `mssql-client`, `mssql-driver-pool`.',
+              '5. Update the `CARGO_REGISTRY_TOKEN` secret at',
+              '   https://github.com/praxiomlabs/rust-mssql-driver/settings/secrets/actions',
+              '6. Re-run this workflow manually via `Actions → Token Health Check → Run workflow`',
+              '   and confirm it goes green.',
+              '7. Close this issue once the check passes.',
+              '',
+              '## Context',
+              '',
+              `- **Workflow run:** ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+              `- **Triggered at:** ${new Date().toISOString()}`,
+              '- **See also:** [RELEASING.md § Token Health](../blob/main/RELEASING.md)',
+              '',
+              '---',
+              '*This issue was automatically created by `.github/workflows/token-health.yml`.*',
+            ].join('\n');
+
+            // Look for an existing open issue with this exact title so we
+            // don't spam a new issue every week if the token stays broken.
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'security',
+              per_page: 100,
+            });
+
+            const match = existing.data.find(i => i.title === title);
+
+            if (match) {
+              console.log(`Updating existing issue #${match.number}`);
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: match.number,
+                body: `Token health check failed again on ${new Date().toISOString()} (run: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}).`,
+              });
+            } else {
+              console.log('Creating new tracking issue');
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body,
+                labels: ['security', 'dependencies'],
+              });
+            }

--- a/.github/workflows/token-health.yml
+++ b/.github/workflows/token-health.yml
@@ -79,7 +79,7 @@ jobs:
 
       - name: Open or update tracking issue on failure
         if: failure() && steps.check.outputs.status != 'ok'
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const title = '🔒 CARGO_REGISTRY_TOKEN health check failed';

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1567,6 +1567,49 @@ impl Default for RedirectConfig {
 
 **Azure-Specific Note:** Connections to Azure SQL Database through the gateway (`*.database.windows.net`) will almost always receive a redirect to an internal compute node (`*.database.windows.net` on port 11000-11999). This is expected behavior and does not indicate a security issue.
 
+### 4.7 Stored Procedure Execution
+
+Stored procedures are called via TDS RPC (Remote Procedure Call) requests using `RpcRequest::named()`. Unlike `sp_executesql` (used for parameterized queries), named RPC calls directly invoke the stored procedure on the server without SQL text parsing.
+
+#### Two-Tier API
+
+| Method | Use Case | Parameters |
+|--------|----------|------------|
+| `call_procedure(name, &[params])` | Simple input-only calls | Positional, auto-named `@p1`, `@p2`, ... |
+| `procedure(name)?.input().output_*().execute()` | Named params, OUTPUT params | Named by caller, output types declared |
+
+Both methods are available on `impl<S: ConnectionState> Client<S>`, meaning they work identically in `Ready` and `InTransaction` states with zero code duplication.
+
+#### TDS Response Token Flow
+
+The server responds to an RPC procedure call with the following token sequence:
+
+```
+[COLMETADATA → ROW(s) → DONEINPROC]    ← per SELECT statement in the proc
+RETURNVALUE(s)                          ← one per OUTPUT parameter
+RETURNSTATUS                            ← procedure RETURN value (i32)
+DONEPROC                                ← final token
+```
+
+The `read_procedure_result()` parser is order-tolerant and accumulative — it handles these tokens in any order and collects them into a `ProcedureResult`:
+
+| Token | Action |
+|-------|--------|
+| `ColMetaData` | Start new result set (save previous if non-empty) |
+| `Row` / `NbcRow` | Parse via `convert_raw_row()`/`convert_nbc_row()`, add to current result set |
+| `DoneInProc` | Save current result set, accumulate `rows_affected` |
+| `ReturnValue` | Decode via `parse_column_value()` using `ColumnData` bridge, push as `OutputParam` |
+| `ReturnStatus` | Store as `return_value: i32` |
+| `DoneProc` | Save remaining result set, break if `!more` |
+
+#### ReturnValue Decoding
+
+`ReturnValue` tokens carry the output parameter value in TYPE_VARBYTE format (the same format used for row column values). To decode, we construct a temporary `ColumnData` from the `ReturnValue`'s `col_type`, `flags`, `user_type`, and `type_info` fields, then call the existing `parse_column_value()` function. This reuses the full type decoding machinery without duplication.
+
+#### Security
+
+All procedure names are validated via `validate_qualified_identifier()` before being sent to the server. This prevents SQL injection through procedure name manipulation. Parameter values are sent as typed RPC parameters (never interpolated into SQL text).
+
 ---
 
 ## 5. Security Architecture

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # Architectural Reference: High-Performance Rust MS SQL Driver
 
 **Version:** 1.6.0
-**Status:** Design Complete (v0.7.0 Released)
+**Status:** Design Complete (v0.8.0 Released)
 **Target Protocol:** MS-TDS 7.3 – 8.0 (SQL Server 2008 – 2025)
 **Toolchain Standard:** Rust 2024 Edition (v1.85+, released February 20, 2025)
 **MSRV Policy:** Rust 1.88.0 (6-month rolling window aligned with Tokio's policy)
@@ -713,7 +713,7 @@ resolver = "2"
 members = ["crates/*", "xtask"]
 
 [workspace.package]
-version = "0.7.0"
+version = "0.8.0"
 edition = "2024"
 rust-version = "1.88"
 license = "MIT OR Apache-2.0"
@@ -746,9 +746,9 @@ opentelemetry-otlp = { version = "0.31", optional = true }
 tracing-opentelemetry = { version = "0.32", optional = true }
 
 # Testing
-criterion = { version = "0.7", features = ["async_tokio"] }
+criterion = { version = "0.8", features = ["async_tokio"] }
 proptest = "1.5"
-testcontainers = "0.25"
+testcontainers = "0.27"
 
 [workspace.lints.rust]
 unsafe_code = "deny"
@@ -2240,6 +2240,7 @@ let client = Client::connect(&connection_string).await?;
 | 1.4.0 | 2025-12-31 | Updated for v0.4.0 release: TDS 7.3 protocol support (SQL Server 2008/2008 R2), TdsVersion configuration, version negotiation |
 | 1.5.0 | 2026-01-01 | Updated for v0.5.0 release: Collation-aware VARCHAR decoding, encoding feature, Column marked non_exhaustive |
 | 1.6.0 | 2026-04-07 | Updated for v0.7.0 release: MSRV bumped to 1.88, SSPI integrated auth wired into client login, RUSTSEC advisories resolved, 33 public enums marked non_exhaustive for semver safety, deprecated APIs removed before 1.0 |
+| 1.7.0 | 2026-04-13 | Updated for v0.8.0 release: Stored procedure support (§4.7), SQL Browser instance resolution, pool test_on_checkin, Azure SDK 0.34, mock TLS cross-platform fix |
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-04-13
+
 ### Added
 
 - **Stored procedure support** with two-tier API:
@@ -22,7 +24,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Transparent integration into `Client::connect()` — no API changes needed
   - Supports `.` as localhost (e.g., `Server=.\SQLEXPRESS`)
   - Requested by @tracker1 in #66
+- **Pool `test_on_checkin` health check** — connections returned to the pool are now health-checked before reuse when enabled (closes #29)
+- `ProcedureResult` and `ResultSet` now implement `Clone`
 - Added `col_type: u8` field and `#[non_exhaustive]` to protocol-level `ReturnValue` struct
+
+### Fixed
+
+- **Mock TLS cross-platform race** — fixed `TlsPreloginWrapper` handshake-to-passthrough race condition that caused test failures on macOS and Windows (closes #70). Root cause: client sends raw TLS before server-side wrapper transitions from PreLogin framing
+- **RUSTSEC-2026-0097** (rand 0.8.5 unsoundness) — added ignore with justification (log feature not enabled, blocked on upstream rsa 0.10 stable)
+- Resolved stale advisory ignore for RUSTSEC-2026-0066 (fixed by testcontainers 0.27 bump)
+- Updated RUSTSEC-2025-0134 ignore reason (rustls-pemfile is a direct dep of mssql-auth, not just transitive via bollard)
+
+### Changed
+
+- **Azure SDK bump**: azure_core/azure_identity 0.30 → 0.34, azure_security_keyvault_keys 0.9 → 0.13
+  - `ClientCertificateCredential::new()` now takes `SecretBytes` instead of `Secret`
+  - Key Vault `unwrap_key()`/`sign()`/`verify()` now require `key_version` as a method parameter
+- Bumped dev dependencies: testcontainers 0.25 → 0.27, criterion 0.7 → 0.8, rustls 0.23.37 → 0.23.38, tokio 1.51.0 → 1.51.1
+- Bumped CI actions: codecov-action v5 → v6, action-gh-release v2 → v3, github-script v8 → v9
+- Extracted `validate_identifier()` and `validate_qualified_identifier()` to shared `validation` module
 
 ## [0.7.0] - 2026-04-07
 
@@ -541,7 +561,8 @@ Initial release of the rust-mssql-driver project.
 - `mssql-derive` - Procedural macros
 - `mssql-testing` - Test infrastructure
 
-[Unreleased]: https://github.com/praxiomlabs/rust-mssql-driver/compare/v0.7.0...HEAD
+[Unreleased]: https://github.com/praxiomlabs/rust-mssql-driver/compare/v0.8.0...HEAD
+[0.8.0]: https://github.com/praxiomlabs/rust-mssql-driver/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/praxiomlabs/rust-mssql-driver/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/praxiomlabs/rust-mssql-driver/compare/v0.5.2...v0.6.0
 [0.5.2]: https://github.com/praxiomlabs/rust-mssql-driver/compare/v0.5.1...v0.5.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Stored procedure support** with two-tier API:
+  - `client.call_procedure("dbo.MyProc", &[&1i32])` — simple convenience for input-only calls
+  - `client.procedure("dbo.MyProc")?.input("@a", &val).output_int("@result").execute()` — full builder with named input/output parameters
+  - `ProcedureResult` type with return value, rows affected, output parameters, and result sets
+  - `ProcedureBuilder` with typed output methods: `output_int`, `output_bigint`, `output_nvarchar`, `output_bit`, `output_float`, `output_decimal`, `output_raw`
+  - Works in both `Ready` and `InTransaction` states
+  - All procedure names validated to prevent SQL injection
+  - Feature scope, API design, and documentation structure informed by PR #71 from @c5soft
+- Added `col_type: u8` field and `#[non_exhaustive]` to protocol-level `ReturnValue` struct
+
 ## [0.7.0] - 2026-04-07
 
 This is a **security + API hardening release**. It resolves seven RUSTSEC

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Works in both `Ready` and `InTransaction` states
   - All procedure names validated to prevent SQL injection
   - Feature scope, API design, and documentation structure informed by PR #71 from @c5soft
+- **SQL Browser instance resolution** for named instances (`host\SQLEXPRESS`):
+  - Automatic TCP port discovery via SQL Server Browser service (UDP 1434)
+  - Transparent integration into `Client::connect()` — no API changes needed
+  - Supports `.` as localhost (e.g., `Server=.\SQLEXPRESS`)
+  - Requested by @tracker1 in #66
 - Added `col_type: u8` field and `#[non_exhaustive]` to protocol-level `ReturnValue` struct
 
 ## [0.7.0] - 2026-04-07

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,20 +130,17 @@ loop {
 
 ### Required Tools
 
-- Rust 1.88+ (2024 Edition)
-- cargo-hakari (workspace-hack management)
-- cargo-deny (dependency auditing)
+- Rust 1.88+ (2024 Edition) — pinned via `rust-toolchain.toml`
+- `just` — task runner used for all development workflows (`just ci-all`, `just release-status`, etc.)
+- `gh` CLI — required for `just release-status` and `just tag` (workflow status checks)
+- `cargo-deny` — dependency auditing
+- `cargo-hack` — feature flag matrix validation
+- `cargo-nextest` — fast test runner (CI uses this)
+- `cargo-audit` — security advisory scanning
+- `cargo-machete` — unused dependency detection
+- `cargo-semver-checks` — semver compliance detection
 
-### cargo-deny + cargo-hakari Interaction
-
-cargo-deny may flag workspace-hack as unused. Add to `deny.toml`:
-
-```toml
-[bans]
-skip = [
-    { name = "workspace-hack", reason = "cargo-hakari managed crate" }
-]
-```
+Run `just setup-tools` to install all of the above with pinned versions compatible with our MSRV.
 
 ### Version Constraint Policy
 
@@ -156,6 +153,64 @@ tokio = "1.48"           # >=1.48.0, <2.0.0
 # Avoid
 tokio = "=1.48.0"        # Exact pin - blocks security updates
 ```
+
+See [`docs/DEPENDENCY_POLICY.md`](docs/DEPENDENCY_POLICY.md) for the full dependency management policy: when to add a new dep, when to take a bump, when to bump MSRV for a security fix, and how advisory ignores are managed.
+
+## Process and Governance
+
+This is an actively maintained project with documented processes for contributions, releases, and incident response. When working in this repository as an AI assistant, these documents are the source of truth:
+
+### Contributor-facing documents
+
+- [`README.md`](README.md) — project overview and quick start
+- [`CONTRIBUTING.md`](CONTRIBUTING.md) — contribution guidelines, commit format, review process
+- [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md) — community standards (Rust Code of Conduct)
+- [`MAINTAINERS.md`](MAINTAINERS.md) — current maintainers and contact channels
+- [`.github/CODEOWNERS`](.github/CODEOWNERS) — auto-review routing for PRs
+- [`.github/ISSUE_TEMPLATE/`](.github/ISSUE_TEMPLATE/) — structured issue templates (bug / feature / question)
+- [`.github/pull_request_template.md`](.github/pull_request_template.md) — PR checklist including **MSRV bumps are NOT breaking** note
+
+### Release and policy documents
+
+- [`RELEASING.md`](RELEASING.md) — the Cardinal Rules, the tier-based publish order, the Lessons Learned section (including the v0.5.1 and v0.7.0 incidents), and the Token Health section
+- [`STABILITY.md`](STABILITY.md) — API stability guarantees, MSRV Increase Policy (**authoritative: MSRV bumps are NOT breaking changes**), supported versions
+- [`SECURITY.md`](SECURITY.md) — security policy, threat model, supported versions for security fixes
+- [`docs/VERSION_REFS.md`](docs/VERSION_REFS.md) — comprehensive checklist of every file that must agree on version/MSRV at release time
+- [`docs/DEPENDENCY_POLICY.md`](docs/DEPENDENCY_POLICY.md) — when and how to take dep bumps, handle advisories, bump MSRV
+
+### Release observability tooling
+
+These just recipes and xtask commands were added post-v0.7.0 specifically to make releases reliable:
+
+- `just release-status` — dashboard: dev↔main divergence, last tag, CI/Security/Benchmarks/Token Health status, open PRs (bot vs contributor), issue count, local working copy state
+- `just release-preflight` — sequential gate check: working copy clean, version refs, audit, deny, wip-check, metadata, URLs, tier-0 publish dry-run
+- `just release-check` — comprehensive release validation (includes `release-preflight` gates plus full CI + feature-flag check + panic audit + doc consistency + typos + machete)
+- `just doc-consistency` — runs `scripts/check-doc-consistency.sh` to verify MSRV references agree across all files, CHANGELOG matches workspace version, deny.toml and audit.toml ignore lists are in sync, and the STABILITY.md ↔ CONTRIBUTING.md MSRV policy contradiction can never be reintroduced
+- `just ci-status-all` — verify CI + Security Audit + Benchmarks all passed on main HEAD (required before tagging per Cardinal Rule #2)
+- `just tag` — create an annotated release tag (reverifies workflows green)
+- `cargo xtask release-notes [--since <tag>]` — generate a CHANGELOG draft from conventional commits since the last tag, grouped by type with breaking-change detection
+
+When preparing a release, the canonical path is:
+
+```bash
+just release-status            # what's the state of the world?
+just release-check             # do all the gates pass?
+just ci-status-all             # are all workflows green on main HEAD?
+just tag                       # create the tag (revalidates workflows)
+git push origin vX.Y.Z         # trigger release.yml (publishes to crates.io)
+```
+
+Never manually run `cargo publish` — use the automated workflow. Never cancel the release workflow mid-publish. See RELEASING.md for the full Cardinal Rules.
+
+### CI/CD workflows
+
+- `.github/workflows/ci.yml` — runs on main, dev, PRs to main. Cross-platform matrix (Linux / macOS / Windows). Has `workflow_dispatch` for manual reruns.
+- `.github/workflows/benchmarks.yml` — runs on main, dev, PRs to main. Performance regression detection.
+- `.github/workflows/security-audit.yml` — weekly schedule + triggers on Cargo.toml/Cargo.lock/deny.toml/audit.toml changes on main or dev.
+- `.github/workflows/token-health.yml` — weekly schedule + manual dispatch. Verifies `CARGO_REGISTRY_TOKEN` secret is still valid. Opens an issue on failure.
+- `.github/workflows/release.yml` — triggered by `v*.*.*` tag push. Publishes all 8 crates to crates.io in tier order with exponential retry.
+
+All workflows use `concurrency: cancel-in-progress` for non-main branches to save CI cycles, while keeping main runs to completion for the full audit trail.
 
 ## OpenTelemetry Dependencies
 
@@ -196,6 +251,38 @@ Key differences for migrators:
 
 ## Document References
 
-- `ARCHITECTURE.md` - Complete architecture specification (v1.2.0)
-- MS-TDS Protocol Spec - Microsoft documentation
-- Tiberius source - `/tmp/tiberius/` (reference only)
+Primary references (in the repository):
+
+- `ARCHITECTURE.md` — Complete architecture specification (includes ADRs and MSRV policy §6.6)
+- `STABILITY.md` — API stability guarantees and the authoritative MSRV Increase Policy
+- `RELEASING.md` — Release process, Cardinal Rules, Lessons Learned (including v0.5.1 and v0.7.0 incidents), Token Health
+- `SECURITY.md` — Security policy and threat model
+- `CONTRIBUTING.md` — Contribution guide, commit format, review process
+- `MAINTAINERS.md` — Maintainer list and contact channels
+- `CODE_OF_CONDUCT.md` — Rust Code of Conduct
+- `docs/DEPENDENCY_POLICY.md` — Dependency management policy
+- `docs/VERSION_REFS.md` — Release-time version reference checklist
+- `docs/MIGRATION_FROM_TIBERIUS.md` — Migration guide from Tiberius
+
+External references:
+
+- MS-TDS Protocol Spec — Microsoft documentation
+- Tiberius source — Reference only (not a dependency)
+
+## Conventions for AI Assistants Working in This Repository
+
+When making changes here, remember:
+
+1. **MSRV bumps are NOT breaking changes.** This is stated authoritatively in STABILITY.md § MSRV Increase Policy. If CONTRIBUTING.md ever contradicts this, STABILITY.md wins — and fix CONTRIBUTING.md as part of your change. The doc consistency linter (`scripts/check-doc-consistency.sh`) catches this contradiction automatically.
+
+2. **Prefer fixing over ignoring** security advisories. Bumping MSRV for a security fix is explicitly permitted. See the v0.7.0 precedent documented in `docs/DEPENDENCY_POLICY.md`.
+
+3. **Use the release recipes.** Don't manually run `cargo publish`, don't manually construct CHANGELOG entries from scratch, don't manually check each file for version drift. `just release-notes`, `just release-status`, `just release-preflight`, and `scripts/check-doc-consistency.sh` exist to prevent exactly the kinds of mistakes that caused past incidents.
+
+4. **Respect the Cardinal Rules** documented in RELEASING.md. They exist because of specific past incidents. Don't work around them — if you find them inconvenient, propose a process change via an issue.
+
+5. **`dev` branch has CI.** Since post-v0.7.0, both `ci.yml` and `benchmarks.yml` trigger on pushes to `dev`. Cross-platform issues will surface there, not just at release PR time. Push to dev confidently — CI will tell you if something broke.
+
+6. **Update CLAUDE.md when you add new infrastructure.** This document is the entry point for future AI assistants working on the repo. Adding a new tool, workflow, or policy without updating CLAUDE.md leaves future sessions flying blind. The Process and Governance section above should reference all the discoverable infrastructure.
+
+7. **Use issue/PR templates.** They ask the right questions. If you're opening an issue or PR, fill out the template completely — it helps the human reviewer and it helps future AI sessions parse the intent.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,6 +126,28 @@ loop {
 }
 ```
 
+### Stored Procedure Execution (v0.8.0)
+
+Two-tier API for calling stored procedures via TDS RPC:
+
+```rust
+// Simple (input-only, positional params):
+let result = client.call_procedure("dbo.MyProc", &[&1i32]).await?;
+
+// Builder (named params, OUTPUT support):
+let result = client.procedure("dbo.CalculateSum")?
+    .input("@a", &10i32)
+    .input("@b", &20i32)
+    .output_int("@result")
+    .execute().await?;
+```
+
+Returns `ProcedureResult` with `return_value`, `rows_affected`, `output_params`, and `result_sets`. All methods on `impl<S: ConnectionState>` — works in both `Ready` and `InTransaction` states.
+
+### SQL Browser Instance Resolution (v0.8.0)
+
+Named instances (e.g., `Server=localhost\SQLEXPRESS`) are automatically resolved via the SQL Server Browser service (UDP 1434). The `crate::browser` module implements the SSRP protocol (MC-SQLR spec). Resolution happens transparently in `Client::connect()` when `config.instance` is `Some`.
+
 ## Development Tooling
 
 ### Required Tools

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,78 @@
+# Code of Conduct
+
+This project follows the [Rust Code of Conduct](https://www.rust-lang.org/policies/code-of-conduct),
+reproduced below with the project's contact information.
+
+## Conduct
+
+**Contact:** [open a private Security Advisory](https://github.com/praxiomlabs/rust-mssql-driver/security/advisories/new)
+for any code-of-conduct violations, or email the maintainers listed in
+[MAINTAINERS.md](MAINTAINERS.md).
+
+- We are committed to providing a friendly, safe and welcoming environment for
+  all, regardless of level of experience, gender identity and expression, sexual
+  orientation, disability, personal appearance, body size, race, ethnicity, age,
+  religion, nationality, or other similar characteristic.
+- On GitHub issues, discussions, and pull requests — and in the Rust community
+  more broadly — please avoid using overtly sexual aliases or other nicknames
+  that might detract from a friendly, safe and welcoming environment for all.
+- Please be kind and courteous. There's no need to be mean or rude.
+- Respect that people have differences of opinion and that every design or
+  implementation choice carries a trade-off and numerous costs. There is
+  seldom a right answer.
+- Please keep unstructured critique to a minimum. If you have solid ideas
+  you want to experiment with, make a fork and see how it works.
+- We will exclude you from interaction if you insult, demean or harass anyone.
+  That is not welcome behavior. We interpret the term "harassment" as including
+  [the definition in the Citizen Code of Conduct](https://github.com/stumpsyn/policies/blob/master/citizen_code_of_conduct.md#what-constitutes-harassment).
+  If you feel that someone has harassed you or otherwise treated you poorly,
+  please reach out via the contact channels above. Whether you're a regular
+  contributor or a newcomer, we care about making this community a safe place
+  for you and we've got your back.
+- Likewise any spamming, trolling, flaming, baiting or other attention-stealing
+  behavior is not welcome.
+
+## Moderation
+
+These are the policies for upholding our community's standards of conduct.
+
+1. Remarks that violate the standards of conduct, including hateful, hurtful,
+   oppressive, or exclusionary remarks, are not allowed. (Cursing is allowed,
+   but never targeting another user, and never in a hateful manner.)
+2. Remarks that moderators find inappropriate, whether listed in the code of
+   conduct or not, are also not allowed.
+3. Moderators will first respond to such remarks with a warning.
+4. If the warning is unheeded, the user will be "kicked," i.e., kicked out of
+   the communication channel to cool off.
+5. If the user comes back and continues to make trouble, they will be banned,
+   i.e., indefinitely excluded.
+6. Moderators may choose at their discretion to un-ban the user if it was a
+   first offense and they offer the offended party a genuine apology.
+7. If a moderator bans someone and you think it was unjustified, please take
+   it up with that moderator, or with a different moderator, **in private**.
+   Complaints about bans in-channel are not allowed.
+8. Moderators are held to a higher standard than other community members. If
+   a moderator creates an inappropriate situation, they should expect less
+   leeway than others.
+
+In the rust-mssql-driver community we strive to go the extra step to look out
+for each other. Don't just aim to be technically unimpeachable — try to be
+your best self. In particular, avoid flirting with offensive or sensitive
+issues, particularly if they're off-topic; this all too often leads to hurt
+feelings and pointless arguments. If someone takes issue with something you
+said or did, resist the urge to be defensive. Just stop doing what it was
+they complained about and apologize. Even if you feel you were
+misinterpreted or unfairly accused, chances are good there was something you
+could've communicated better — remember that it's your responsibility to
+make your fellow contributors comfortable. Everyone wants to get along and
+we are all here first and foremost because we want to build good software.
+You will find that people will be eager to assume good intent and forgive as
+long as you earn their trust.
+
+The enforcement policies listed above apply to all official rust-mssql-driver
+venues, including GitHub repositories under [praxiomlabs](https://github.com/praxiomlabs)
+and any associated discussion forums.
+
+*Adapted from the [Rust Code of Conduct](https://www.rust-lang.org/policies/code-of-conduct),
+which is itself adapted from the [Node.js Policy on Trolling](https://web.archive.org/web/20160911064355/http://blog.izs.me/post/30036893703/policy-on-trolling)
+and the [Contributor Covenant v1.3.0](https://www.contributor-covenant.org/version/1/3/0/).*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,18 +5,37 @@ Thank you for your interest in contributing! This document provides guidelines a
 ## Table of Contents
 
 - [Code of Conduct](#code-of-conduct)
+- [First Contribution (Quick Path)](#first-contribution-quick-path)
 - [Getting Started](#getting-started)
 - [Development Setup](#development-setup)
 - [Making Changes](#making-changes)
 - [Breaking Changes](#breaking-changes)
 - [Pull Request Process](#pull-request-process)
+- [When Your PR Needs Review](#when-your-pr-needs-review)
 - [Coding Standards](#coding-standards)
 - [Testing](#testing)
 - [Documentation](#documentation)
+- [Architecture Decision Records (ADRs)](#architecture-decision-records-adrs)
 
 ## Code of Conduct
 
-This project follows the [Rust Code of Conduct](https://www.rust-lang.org/policies/code-of-conduct). Please be respectful and constructive in all interactions.
+This project follows the [Rust Code of Conduct](https://www.rust-lang.org/policies/code-of-conduct), reproduced in full in [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md). Please be respectful and constructive in all interactions.
+
+Report code-of-conduct violations privately via the [GitHub Security Advisory](https://github.com/praxiomlabs/rust-mssql-driver/security/advisories/new) channel or by contacting the maintainers listed in [MAINTAINERS.md](MAINTAINERS.md).
+
+## First Contribution (Quick Path)
+
+If this is your first time contributing to the project, here's the shortest path from clone to green CI:
+
+1. **Pick an issue.** Browse [open issues](https://github.com/praxiomlabs/rust-mssql-driver/issues) — look for ones labelled `good first issue` if they exist, or ask on an issue for guidance before starting.
+2. **Fork and clone.** See [Getting Started](#getting-started) below.
+3. **Bootstrap your environment.** Run `just bootstrap` (or `just setup-all` if you don't want sudo for Kerberos deps).
+4. **Make your change.** Keep commits small and focused. Use [conventional commit format](#commit-messages).
+5. **Verify locally.** Run `just ci-all` before pushing — this mirrors what CI will run and is your fastest feedback loop.
+6. **Open a PR.** The [PR template](.github/pull_request_template.md) will walk you through what reviewers need to know. File a draft PR if you want early feedback.
+7. **Respond to review.** CODEOWNERS will automatically request review from the right maintainers. See [When Your PR Needs Review](#when-your-pr-needs-review) below.
+
+Don't worry if your first PR needs several rounds of revision — that's normal and expected. We try to keep review feedback kind, specific, and actionable.
 
 ## Getting Started
 
@@ -238,11 +257,29 @@ The project includes custom build commands via `cargo xtask`:
 
 | Command | Purpose |
 |---------|---------|
+| `cargo xtask ci` | Run format, lint, test, and deny checks |
+| `cargo xtask ci-local` | Full CI pipeline locally (mirrors GitHub Actions) |
 | `cargo xtask release <version>` | Bump version across all crates + update CHANGELOG |
+| `cargo xtask release-notes` | Generate a CHANGELOG draft from conventional commits since last tag |
 | `cargo xtask check-features` | Validate all feature flag combinations compile (uses cargo-hack) |
 | `cargo xtask fuzz` | Run fuzz tests on protocol parser |
 | `cargo xtask coverage` | Generate code coverage report |
-| `cargo xtask semver-check` | Check for semver-breaking API changes |
+| `cargo xtask semver` | Check for semver-breaking API changes |
+
+### Release-Adjacent Just Recipes
+
+For maintainers preparing a release (or for contributors who want to understand what release validation looks like):
+
+| Recipe | Purpose |
+|--------|---------|
+| `just release-status` | Dashboard of dev↔main divergence, last tag, open PRs, CI status, token health |
+| `just release-preflight` | Run all Cardinal Rules gate checks in sequence (working copy clean, audit, deny, wip-check, metadata, tier-0 publish dry-run) |
+| `just release-check` | Full release validation: ci-release-all + check-feature-flags + wip-check + panic-audit + version-sync + version-refs-check + doc-consistency + typos + machete + metadata-check + url-check |
+| `just doc-consistency` | Run the documentation consistency linter (`scripts/check-doc-consistency.sh`) — catches MSRV drift, version mismatches, policy contradictions |
+| `just ci-status-all` | Verify all three workflows (CI, Security Audit, Benchmarks) passed on `main` at the current HEAD — required before tagging |
+| `just tag` | Create an annotated release tag (verifies workflows are green first) |
+
+See [RELEASING.md](RELEASING.md) for the full release process and the Cardinal Rules that govern it.
 
 ## Making Changes
 
@@ -369,25 +406,42 @@ In your PR that introduces a breaking change:
 ## Pull Request Process
 
 1. **Before submitting:**
-   - Ensure all tests pass: `cargo test --workspace`
-   - Run lints: `cargo clippy --workspace --all-targets`
+   - Ensure all tests pass: `cargo test --workspace --all-features`
+   - Run lints: `cargo clippy --workspace --all-targets --all-features -- -D warnings`
    - Format code: `cargo fmt --all`
+   - Verify doc consistency: `just doc-consistency`
    - Update documentation if needed
+   - Or simply run `just ci-all` which does all of the above in one command
 
-2. **PR Description should include:**
-   - Summary of changes
-   - Related issue number (if any)
-   - Breaking changes (if any)
-   - Testing performed
+2. **PR Description should use the [template](.github/pull_request_template.md).** The template includes:
+   - Summary and linked issues
+   - Type of change
+   - Test plan checklist
+   - Documentation updates checklist
+   - Breaking changes section (when applicable) with a pointer to STABILITY.md
+   - Security considerations section (for auth/TLS/SQL-gen changes)
 
 3. **Review process:**
    - At least one maintainer approval required
-   - All CI checks must pass
+   - All CI checks must pass (on all three platforms: Linux, macOS, Windows)
    - Breaking changes require additional review
+   - CODEOWNERS automatically requests review from the right maintainers based on which files you touched
 
 4. **After approval:**
    - Squash commits if requested
    - Maintainer will merge
+
+## When Your PR Needs Review
+
+CODEOWNERS automatically requests review from the appropriate maintainers based on the files you touched. You don't need to manually tag anyone — ownership rules in [`.github/CODEOWNERS`](.github/CODEOWNERS) handle that.
+
+**Expected response time**: maintainers aim to respond to new PRs within one week, even if it's just acknowledging the PR is in the review queue. If your PR hasn't received any response after one week, it's reasonable to leave a polite ping comment on the PR.
+
+**If your PR spans multiple areas** (e.g., protocol layer AND auth AND client API), all relevant CODEOWNERS entries will be requested and any one of them can start the review. Reviewers should coordinate via PR comments if the change needs combined expertise.
+
+**For substantial contributions** (roughly, PRs over ~500 lines or touching architectural decisions), consider opening a draft PR early for architectural feedback before polishing the implementation. This avoids situations where a contributor invests significant effort in an approach that doesn't align with the project's direction.
+
+**Large feature PRs**: review will often take longer than small ones. We'd rather take several weeks to review a 2,500-line feature carefully than rush it and merge something that needs significant follow-up. If your feature PR is a non-trivial addition, please be patient and engage constructively with review feedback.
 
 ## Coding Standards
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,6 +51,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloca"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -174,9 +183,9 @@ dependencies = [
 
 [[package]]
 name = "astral-tokio-tar"
-version = "0.5.6"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec179a06c1769b1e42e1e2cbe74c7dcdb3d6383c838454d063eaac5bbb7ebbe5"
+checksum = "3c23f3af104b40a3430ccb90ed5f7bd877a8dc5c26fc92fde51a22b40890dcf9"
 dependencies = [
  "filetime",
  "futures-core",
@@ -542,9 +551,9 @@ dependencies = [
 
 [[package]]
 name = "bollard"
-version = "0.19.4"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87a52479c9237eb04047ddb94788c41ca0d26eaff8b697ecfbb4c32f7fdc3b1b"
+checksum = "ee04c4c84f1f811b017f2fbb7dd8815c976e7ca98593de9c1e2afad0f636bff4"
 dependencies = [
  "async-stream",
  "base64 0.22.1",
@@ -552,7 +561,6 @@ dependencies = [
  "bollard-buildkit-proto",
  "bollard-stubs",
  "bytes",
- "chrono",
  "futures-core",
  "futures-util",
  "hex",
@@ -570,14 +578,13 @@ dependencies = [
  "rand 0.9.2",
  "rustls",
  "rustls-native-certs",
- "rustls-pemfile",
  "rustls-pki-types",
  "serde",
  "serde_derive",
  "serde_json",
- "serde_repr",
  "serde_urlencoded",
  "thiserror",
+ "time",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -602,19 +609,18 @@ dependencies = [
 
 [[package]]
 name = "bollard-stubs"
-version = "1.49.1-rc.28.4.0"
+version = "1.52.1-rc.29.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5731fe885755e92beff1950774068e0cae67ea6ec7587381536fca84f1779623"
+checksum = "0f0a8ca8799131c1837d1282c3f81f31e76ceb0ce426e04a7fe1ccee3287c066"
 dependencies = [
  "base64 0.22.1",
  "bollard-buildkit-proto",
  "bytes",
- "chrono",
  "prost",
  "serde",
  "serde_json",
  "serde_repr",
- "serde_with",
+ "time",
 ]
 
 [[package]]
@@ -937,10 +943,11 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.7.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1c047a62b0cc3e145fa84415a3191f628e980b194c2755aa12300a4e6cbd928"
+checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
 dependencies = [
+ "alloca",
  "anes",
  "cast",
  "ciborium",
@@ -949,6 +956,7 @@ dependencies = [
  "itertools 0.13.0",
  "num-traits",
  "oorandom",
+ "page_size",
  "plotters",
  "rayon",
  "regex",
@@ -961,9 +969,9 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
-version = "0.6.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b1bcc0dc7dfae599d84ad0b1a55f80cde8af3725da8313b528da95ef783e338"
+checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
 dependencies = [
  "cast",
  "itertools 0.13.0",
@@ -1337,13 +1345,12 @@ dependencies = [
 
 [[package]]
 name = "etcetera"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26c7b13d0780cb82722fd59f6f57f925e143427e4a75313a6c77243bf5326ae6"
+checksum = "de48cc4d1c1d97a20fd819def54b890cadde72ed3ad0c614822a0a433361be96"
 dependencies = [
  "cfg-if",
- "home",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1372,6 +1379,17 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "ferroid"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb330bbd4cb7a5b9f559427f06f98a4f853a137c8298f3bd3f8ca57663e21986"
+dependencies = [
+ "portable-atomic",
+ "rand 0.9.2",
+ "web-time",
+]
 
 [[package]]
 name = "ff"
@@ -2795,6 +2813,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3689,9 +3717,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -4052,6 +4080,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "signature"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4308,9 +4346,9 @@ dependencies = [
 
 [[package]]
 name = "testcontainers"
-version = "0.25.2"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f3ac71069f20ecfa60c396316c283fbf35e6833a53dff551a31b5458da05edc"
+checksum = "0bd36b06a2a6c0c3c81a83be1ab05fe86460d054d4d51bf513bc56b3e15bdc22"
 dependencies = [
  "astral-tokio-tar",
  "async-trait",
@@ -4319,7 +4357,10 @@ dependencies = [
  "docker_credential",
  "either",
  "etcetera",
+ "ferroid",
  "futures",
+ "http",
+ "itertools 0.14.0",
  "log",
  "memchr",
  "parse-display",
@@ -4331,7 +4372,6 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util",
- "ulid",
  "url",
 ]
 
@@ -4433,14 +4473,15 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.51.0"
+version = "1.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bd1c4c0fc4a7ab90fc15ef6daaa3ec3b893f004f915f2392557ed23237820cd"
+checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
 dependencies = [
  "bytes",
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
@@ -4770,16 +4811,6 @@ dependencies = [
  "quote",
  "rustc_version",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "ulid"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "470dbf6591da1b39d43c14523b2b469c86879a53e8b758c8e090a470fe7b1fbe"
-dependencies = [
- "rand 0.9.2",
- "web-time",
 ]
 
 [[package]]
@@ -5232,15 +5263,6 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2380,7 +2380,7 @@ dependencies = [
 
 [[package]]
 name = "mssql-auth"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "aes 0.8.4",
  "async-trait",
@@ -2411,7 +2411,7 @@ dependencies = [
 
 [[package]]
 name = "mssql-client"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -2443,7 +2443,7 @@ dependencies = [
 
 [[package]]
 name = "mssql-codec"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "bytes",
  "futures-core",
@@ -2459,7 +2459,7 @@ dependencies = [
 
 [[package]]
 name = "mssql-derive"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2468,7 +2468,7 @@ dependencies = [
 
 [[package]]
 name = "mssql-driver-pool"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "async-trait",
  "mssql-client",
@@ -2482,7 +2482,7 @@ dependencies = [
 
 [[package]]
 name = "mssql-testing"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "bytes",
  "mssql-client",
@@ -2499,7 +2499,7 @@ dependencies = [
 
 [[package]]
 name = "mssql-tls"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "rustls",
  "thiserror",
@@ -2512,7 +2512,7 @@ dependencies = [
 
 [[package]]
 name = "mssql-types"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -4359,7 +4359,7 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tds-protocol"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "bitflags 2.11.0",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,7 +16,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher 0.4.4",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -27,7 +27,7 @@ checksum = "7e713c57c2a2b19159e7be83b9194600d7e8eb3b7c2cd67e671adf47ce189a05"
 dependencies = [
  "cfg-if",
  "cipher 0.5.0-rc.1",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -362,9 +362,9 @@ dependencies = [
 
 [[package]]
 name = "azure_core"
-version = "0.30.1"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f35444aeeb91e29ca82d04dbb8ad904570f837c82093454dc1989c64a33554a7"
+checksum = "688882dc4a96b0ea158299d590fad91c471eced6403fd9a9ea1992c14397f25f"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -375,6 +375,7 @@ dependencies = [
  "rustc_version",
  "serde",
  "serde_json",
+ "tokio",
  "tracing",
  "typespec",
  "typespec_client_core",
@@ -382,9 +383,9 @@ dependencies = [
 
 [[package]]
 name = "azure_core_macros"
-version = "0.4.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f7cc1bbae04cfe11de9e39e2c6dc755947901e0f4e76180ab542b6deb5e15e"
+checksum = "70066e34b8db2c3f0b852c56a99333bd25fdedfb8850cd95dddf930928b47b80"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -394,9 +395,9 @@ dependencies = [
 
 [[package]]
 name = "azure_identity"
-version = "0.30.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f07bb0ee212021e75c3645e82d078e436b4b4184bde1295e9e81fcbcef923af"
+checksum = "be8392bbf0028c43df2f69422825721614f47e12fd601f9056df2c18d35c57e0"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -405,6 +406,7 @@ dependencies = [
  "openssl",
  "pin-project",
  "serde",
+ "serde_json",
  "time",
  "tracing",
  "url",
@@ -412,10 +414,11 @@ dependencies = [
 
 [[package]]
 name = "azure_security_keyvault_keys"
-version = "0.9.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9985e8285beca2893366dbf04b1e4f8aeb7d63189d1ea56945104ca885ccebc5"
+checksum = "6b27ae9d1311253b9ecfbff2dde2752dde54b503005192827dabf4e7ed70cb92"
 dependencies = [
+ "async-lock",
  "async-trait",
  "azure_core",
  "futures",
@@ -745,6 +748,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -933,6 +947,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1069,7 +1092,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f9200d1d13637f15a6acb71e758f64624048d85b31a5fdbfd8eca1e2687d0b7"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
  "digest 0.11.0-rc.3",
  "fiat-crypto",
@@ -1620,6 +1643,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -2180,7 +2204,7 @@ version = "0.2.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d546793a04a1d3049bd192856f804cfe96356e2cf36b54b4e575155babe9f41"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -3363,6 +3387,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3399,6 +3434,12 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_xorshift"
@@ -3530,9 +3571,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.28"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -3550,9 +3591,6 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "rustls-pki-types",
- "serde",
- "serde_json",
- "serde_urlencoded",
  "sync_wrapper",
  "tokio",
  "tokio-native-tls",
@@ -4017,7 +4055,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.10.7",
 ]
 
@@ -4028,7 +4066,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5e046edf639aa2e7afb285589e5405de2ef7e61d4b0ac1e30256e3eab911af9"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.11.0-rc.3",
 ]
 
@@ -4039,7 +4077,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.10.7",
 ]
 
@@ -4050,7 +4088,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1e3878ab0f98e35b2df35fe53201d088299b41a6bb63e3e34dada2ac4abd924"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.11.0-rc.3",
 ]
 
@@ -4764,9 +4802,9 @@ checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "typespec"
-version = "0.10.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44f91ea93fdd5fd4985fcc0a197ed8e8da18705912bef63c9b9b3148d6f35510"
+checksum = "247afbeabe0c383f630d0fdcb4fb92818c31cd3fe5d293335daff8cac79d4e0f"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -4778,17 +4816,17 @@ dependencies = [
 
 [[package]]
 name = "typespec_client_core"
-version = "0.9.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a0f6f7345c3389663551a64fc4dca78fa9689ece758c5ca76e82d6da69349dc"
+checksum = "66166c78ee5b5a03b665a639899414a468f645f58dba3c8154b82d64847d227b"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
+ "bytes",
  "dyn-clone",
  "futures",
- "getrandom 0.3.4",
  "pin-project",
- "rand 0.9.2",
+ "rand 0.10.1",
  "reqwest",
  "serde",
  "serde_json",
@@ -4803,9 +4841,9 @@ dependencies = [
 
 [[package]]
 name = "typespec_macros"
-version = "0.9.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ecee5b05c459ea4cd97df7685db58699c32e070465f88dc806d7c98a5088edc"
+checksum = "d17153fde258b3c862cecffad95e185c0eb83e619e76542c4b3ed9828af840f0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5057,9 +5095,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-streams"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
 dependencies = [
  "futures-util",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/*", "xtask"]
 exclude = ["fuzz"]  # Fuzz tests have their own workspace (required by cargo-fuzz)
 
 [workspace.package]
-version = "0.7.0"
+version = "0.8.0"
 edition = "2024"
 rust-version = "1.88"
 license = "MIT OR Apache-2.0"
@@ -19,15 +19,15 @@ categories = ["database"]
 #   Primary (user-facing): mssql-client (main API), mssql-driver-pool (connection pooling)
 #   Internal (implementation): tds-protocol, mssql-types, mssql-tls, mssql-codec, mssql-auth, mssql-derive
 #   Dev-only (publish = false): mssql-testing
-tds-protocol = { version = "0.7.0", path = "crates/tds-protocol" }
-mssql-tls = { version = "0.7.0", path = "crates/mssql-tls" }
-mssql-codec = { version = "0.7.0", path = "crates/mssql-codec" }
-mssql-types = { version = "0.7.0", path = "crates/mssql-types" }
-mssql-auth = { version = "0.7.0", path = "crates/mssql-auth" }
-mssql-driver-pool = { version = "0.7.0", path = "crates/mssql-pool" }
-mssql-client = { version = "0.7.0", path = "crates/mssql-client" }
-mssql-derive = { version = "0.7.0", path = "crates/mssql-derive" }
-mssql-testing = { version = "0.7.0", path = "crates/mssql-testing" }
+tds-protocol = { version = "0.8.0", path = "crates/tds-protocol" }
+mssql-tls = { version = "0.8.0", path = "crates/mssql-tls" }
+mssql-codec = { version = "0.8.0", path = "crates/mssql-codec" }
+mssql-types = { version = "0.8.0", path = "crates/mssql-types" }
+mssql-auth = { version = "0.8.0", path = "crates/mssql-auth" }
+mssql-driver-pool = { version = "0.8.0", path = "crates/mssql-pool" }
+mssql-client = { version = "0.8.0", path = "crates/mssql-client" }
+mssql-derive = { version = "0.8.0", path = "crates/mssql-derive" }
+mssql-testing = { version = "0.8.0", path = "crates/mssql-testing" }
 
 # Async runtime
 tokio = { version = "1.48", features = ["net", "io-util", "sync", "time", "macros", "rt", "rt-multi-thread"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,9 +78,9 @@ opentelemetry-otlp = "0.31"
 tracing-opentelemetry = "0.32"
 
 # Testing
-criterion = { version = "0.7", features = ["async_tokio"] }
+criterion = { version = "0.8", features = ["async_tokio"] }
 proptest = "1.5"
-testcontainers = "0.25"
+testcontainers = "0.27"
 tokio-test = "0.4"
 
 # Azure authentication (optional)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,9 +85,9 @@ tokio-test = "0.4"
 
 # Azure authentication (optional)
 # Note: Azure SDK crates must be version-aligned
-azure_identity = "0.30"
-azure_core = "0.30"
-azure_security_keyvault_keys = "0.9"
+azure_identity = "0.34"
+azure_core = "0.34"
+azure_security_keyvault_keys = "0.13"
 
 [workspace.lints.rust]
 unsafe_code = "deny"

--- a/Justfile
+++ b/Justfile
@@ -1623,6 +1623,233 @@ typos:
     printf '{{green}}[OK]{{reset}}   Typos check passed\n'
 
 [group('release')]
+[doc("Show release readiness dashboard (dev vs main, dependabot, audit, token)")]
+release-status:
+    #!/usr/bin/env bash
+    set -uo pipefail
+    printf '\n{{bold}}{{blue}}══════ Release Readiness Dashboard ══════{{reset}}\n\n'
+
+    # Require gh CLI for the GitHub API queries
+    if ! command -v gh &> /dev/null; then
+        printf '{{red}}[ERR]{{reset}}  GitHub CLI (gh) is required for release-status.\n'
+        printf '{{cyan}}[INFO]{{reset}} Install: https://cli.github.com/\n'
+        exit 1
+    fi
+
+    REPO="praxiomlabs/rust-mssql-driver"
+
+    # -----------------------------------------------------------------
+    # Current branch and version
+    # -----------------------------------------------------------------
+    CURRENT_BRANCH=$(git branch --show-current)
+    WORKSPACE_VERSION=$(grep -m1 '^version = ' Cargo.toml | sed 's/version = "\(.*\)"/\1/')
+    printf '{{bold}}Current state:{{reset}}\n'
+    printf '  Branch:            %s\n' "$CURRENT_BRANCH"
+    printf '  Workspace version: v%s\n' "$WORKSPACE_VERSION"
+    printf '\n'
+
+    # -----------------------------------------------------------------
+    # Last tag and elapsed time
+    # -----------------------------------------------------------------
+    git fetch --tags --quiet 2>/dev/null || true
+    LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "none")
+    if [ "$LAST_TAG" != "none" ]; then
+        LAST_TAG_DATE=$(git log -1 --format=%cd --date=short "$LAST_TAG" 2>/dev/null || echo "unknown")
+        DAYS_SINCE=$(( ( $(date +%s) - $(git log -1 --format=%ct "$LAST_TAG" 2>/dev/null || echo 0) ) / 86400 ))
+        printf '{{bold}}Last release:{{reset}}\n'
+        printf '  Tag:               %s\n' "$LAST_TAG"
+        printf '  Date:              %s (%d days ago)\n' "$LAST_TAG_DATE" "$DAYS_SINCE"
+    else
+        printf '{{bold}}Last release:{{reset}}\n'
+        printf '  Tag:               none\n'
+    fi
+    printf '\n'
+
+    # -----------------------------------------------------------------
+    # dev vs main divergence
+    # -----------------------------------------------------------------
+    git fetch origin main dev --quiet 2>/dev/null || true
+
+    AHEAD_DEV_OF_MAIN=$(git rev-list --count origin/main..origin/dev 2>/dev/null || echo 0)
+    AHEAD_MAIN_OF_DEV=$(git rev-list --count origin/dev..origin/main 2>/dev/null || echo 0)
+
+    printf '{{bold}}Branch divergence (origin):{{reset}}\n'
+    if [ "$AHEAD_DEV_OF_MAIN" -eq 0 ] && [ "$AHEAD_MAIN_OF_DEV" -eq 0 ]; then
+        printf '  {{green}}[OK]{{reset}}    dev and main are in sync\n'
+    elif [ "$AHEAD_DEV_OF_MAIN" -gt 0 ] && [ "$AHEAD_MAIN_OF_DEV" -eq 0 ]; then
+        printf '  dev is {{cyan}}%s{{reset}} commits ahead of main (release candidate)\n' "$AHEAD_DEV_OF_MAIN"
+    elif [ "$AHEAD_MAIN_OF_DEV" -gt 0 ] && [ "$AHEAD_DEV_OF_MAIN" -eq 0 ]; then
+        printf '  {{yellow}}[WARN]{{reset}} main is %s commits ahead of dev — dev needs to catch up\n' "$AHEAD_MAIN_OF_DEV"
+    else
+        printf '  {{red}}[ERR]{{reset}}  dev and main have diverged: dev+%s, main+%s\n' "$AHEAD_DEV_OF_MAIN" "$AHEAD_MAIN_OF_DEV"
+    fi
+    printf '\n'
+
+    # -----------------------------------------------------------------
+    # Last CI runs on main
+    # -----------------------------------------------------------------
+    printf '{{bold}}Latest workflow runs on main:{{reset}}\n'
+    for WORKFLOW in "CI" "Security Audit" "Benchmarks" "Token Health Check"; do
+        STATUS=$(gh run list --repo "$REPO" --branch main --workflow="$WORKFLOW" --limit 1 --json conclusion,headSha --jq '.[0] // {}' 2>/dev/null)
+        if [ -z "$STATUS" ] || [ "$STATUS" = "{}" ]; then
+            printf '  %-22s {{yellow}}no runs found{{reset}}\n' "$WORKFLOW:"
+            continue
+        fi
+        CONCLUSION=$(echo "$STATUS" | jq -r '.conclusion // "in-progress"')
+        SHA=$(echo "$STATUS" | jq -r '.headSha // "unknown"' | cut -c1-7)
+        case "$CONCLUSION" in
+            success)
+                printf '  %-22s {{green}}✓ passed{{reset}} (commit %s)\n' "$WORKFLOW:" "$SHA"
+                ;;
+            failure)
+                printf '  %-22s {{red}}✗ failed{{reset}} (commit %s)\n' "$WORKFLOW:" "$SHA"
+                ;;
+            *)
+                printf '  %-22s {{yellow}}%s{{reset}} (commit %s)\n' "$WORKFLOW:" "$CONCLUSION" "$SHA"
+                ;;
+        esac
+    done
+    printf '\n'
+
+    # -----------------------------------------------------------------
+    # Open dependabot PRs
+    # -----------------------------------------------------------------
+    printf '{{bold}}Open dependabot PRs:{{reset}}\n'
+    DEPENDABOT_PRS=$(gh pr list --repo "$REPO" --author "dependabot[bot]" --state open --limit 20 --json number,title,statusCheckRollup --jq '.[] | "\(.number)|\(.title)|\([.statusCheckRollup[] | select(.conclusion != null and .conclusion != "SKIPPED" and .conclusion != "SUCCESS")] | length)"' 2>/dev/null || true)
+    if [ -z "$DEPENDABOT_PRS" ]; then
+        printf '  {{green}}[OK]{{reset}}    No open dependabot PRs\n'
+    else
+        echo "$DEPENDABOT_PRS" | while IFS='|' read -r num title failures; do
+            if [ "$failures" = "0" ]; then
+                printf '  #%-4s {{green}}green{{reset}}  %s\n' "$num" "$title"
+            else
+                printf '  #%-4s {{red}}%s failing{{reset}} %s\n' "$num" "$failures" "$title"
+            fi
+        done
+    fi
+    printf '\n'
+
+    # -----------------------------------------------------------------
+    # Open non-bot PRs (contributors)
+    # -----------------------------------------------------------------
+    printf '{{bold}}Open contributor PRs:{{reset}}\n'
+    OTHER_PRS=$(gh pr list --repo "$REPO" --state open --limit 20 --json number,title,author --jq '.[] | select(.author.is_bot == false) | "#\(.number) \(.title) (@\(.author.login))"' 2>/dev/null || true)
+    if [ -z "$OTHER_PRS" ]; then
+        printf '  {{green}}[OK]{{reset}}    No open PRs from contributors\n'
+    else
+        echo "$OTHER_PRS" | while read -r line; do printf '  %s\n' "$line"; done
+    fi
+    printf '\n'
+
+    # -----------------------------------------------------------------
+    # Open issues by age
+    # -----------------------------------------------------------------
+    printf '{{bold}}Open issues:{{reset}}\n'
+    ISSUE_COUNT=$(gh issue list --repo "$REPO" --state open --limit 100 --json number --jq 'length' 2>/dev/null || echo 0)
+    printf '  %s open\n' "$ISSUE_COUNT"
+    printf '\n'
+
+    # -----------------------------------------------------------------
+    # Local working copy state
+    # -----------------------------------------------------------------
+    printf '{{bold}}Local working copy:{{reset}}\n'
+    if git diff-index --quiet HEAD -- 2>/dev/null; then
+        printf '  {{green}}[OK]{{reset}}    Clean (no uncommitted changes)\n'
+    else
+        DIRTY=$(git status --short | wc -l | tr -d ' ')
+        printf '  {{yellow}}[WARN]{{reset}} %s files with uncommitted changes\n' "$DIRTY"
+    fi
+
+    UNPUSHED=$(git log @{u}.. --oneline 2>/dev/null | wc -l | tr -d ' ')
+    if [ "$UNPUSHED" -eq 0 ]; then
+        printf '  {{green}}[OK]{{reset}}    All local commits pushed\n'
+    else
+        printf '  {{yellow}}[WARN]{{reset}} %s unpushed commit(s) on %s\n' "$UNPUSHED" "$CURRENT_BRANCH"
+    fi
+    printf '\n'
+
+    printf '{{bold}}{{blue}}══════════════════════════════════════════{{reset}}\n'
+    printf '{{cyan}}[TIP]{{reset}}  Run {{bold}}just release-preflight{{reset}} to run all release gate checks.\n'
+
+[group('release')]
+[doc("Run all pre-release gate checks in sequence (Cardinal Rules verification)")]
+release-preflight:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    printf '\n{{bold}}{{blue}}══════ Release Preflight ══════{{reset}}\n\n'
+    printf '{{cyan}}[INFO]{{reset}} Running all pre-release gate checks...\n\n'
+
+    FAILED=0
+    run_check() {
+        local name="$1"
+        shift
+        printf '{{bold}}▸ %s{{reset}}\n' "$name"
+        if "$@" > /tmp/preflight-$$.log 2>&1; then
+            printf '  {{green}}[OK]{{reset}}    Passed\n\n'
+        else
+            printf '  {{red}}[ERR]{{reset}}  Failed — output:\n'
+            sed 's/^/    /' /tmp/preflight-$$.log
+            printf '\n'
+            FAILED=1
+        fi
+        rm -f /tmp/preflight-$$.log
+    }
+
+    # Gate 1: working directory clean
+    printf '{{bold}}▸ Working directory clean{{reset}}\n'
+    if git diff-index --quiet HEAD -- 2>/dev/null; then
+        printf '  {{green}}[OK]{{reset}}    Clean\n\n'
+    else
+        printf '  {{red}}[ERR]{{reset}}  Uncommitted changes\n\n'
+        FAILED=1
+    fi
+
+    # Gate 2: version references
+    run_check "Version references consistent" just version-refs-check
+
+    # Gate 3: documentation consistency (will be added by scripts/check-doc-consistency.sh)
+    if [ -x ./scripts/check-doc-consistency.sh ]; then
+        run_check "Doc consistency" ./scripts/check-doc-consistency.sh
+    fi
+
+    # Gate 4: security audit
+    run_check "cargo audit" cargo audit
+
+    # Gate 5: cargo-deny (licenses, bans, advisories)
+    run_check "cargo deny check" cargo deny check
+
+    # Gate 6: WIP markers
+    run_check "No TODO/FIXME in production code" just wip-check
+
+    # Gate 7: metadata
+    run_check "crates.io metadata" just metadata-check
+
+    # Gate 8: repository URLs
+    run_check "Repository URLs" just url-check
+
+    # Gate 9: tier 0 publish dry-run (the only check that hits crates.io index)
+    printf '{{bold}}▸ Tier 0 publish dry-run (tds-protocol){{reset}}\n'
+    if cargo publish -p tds-protocol --dry-run --allow-dirty > /tmp/preflight-$$.log 2>&1; then
+        printf '  {{green}}[OK]{{reset}}    Packaged successfully\n\n'
+    else
+        printf '  {{red}}[ERR]{{reset}}  Packaging failed\n'
+        sed 's/^/    /' /tmp/preflight-$$.log
+        printf '\n'
+        FAILED=1
+    fi
+    rm -f /tmp/preflight-$$.log
+
+    # Summary
+    printf '{{bold}}{{blue}}══════════════════════════════════════════{{reset}}\n'
+    if [ $FAILED -eq 0 ]; then
+        printf '{{green}}[OK]{{reset}}    All preflight gates passed\n'
+        printf '{{cyan}}[NEXT]{{reset}} Review {{bold}}just release-status{{reset}}, then {{bold}}just ci-status-all && just tag{{reset}}\n'
+    else
+        printf '{{red}}[ERR]{{reset}}  One or more preflight gates failed — resolve before tagging\n'
+        exit 1
+    fi
+
+[group('release')]
 [doc("Prepare for release (validates ALL features - REQUIRED before tagging)")]
 release-check: ci-release-all check-feature-flags wip-check panic-audit version-sync version-refs-check typos machete metadata-check url-check
     #!/usr/bin/env bash

--- a/Justfile
+++ b/Justfile
@@ -1849,9 +1849,20 @@ release-preflight:
         exit 1
     fi
 
+[group('lint')]
+[doc("Check documentation consistency (MSRV across files, policy agreement, version inheritance)")]
+doc-consistency:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [ ! -x ./scripts/check-doc-consistency.sh ]; then
+        printf '{{yellow}}[WARN]{{reset}} scripts/check-doc-consistency.sh is missing or not executable\n'
+        exit 0
+    fi
+    ./scripts/check-doc-consistency.sh
+
 [group('release')]
 [doc("Prepare for release (validates ALL features - REQUIRED before tagging)")]
-release-check: ci-release-all check-feature-flags wip-check panic-audit version-sync version-refs-check typos machete metadata-check url-check
+release-check: ci-release-all check-feature-flags wip-check panic-audit version-sync version-refs-check doc-consistency typos machete metadata-check url-check
     #!/usr/bin/env bash
     set -euo pipefail
     printf '\n{{bold}}{{blue}}══════ Release Validation ══════{{reset}}\n\n'

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,92 @@
+# Maintainers
+
+This document lists the current maintainers of rust-mssql-driver, their areas
+of focus, and how to contact them.
+
+## Current Maintainers
+
+| Name | GitHub | Areas |
+|------|--------|-------|
+| Justin Kindrix | [@jkindrix](https://github.com/jkindrix) | All areas (primary maintainer) |
+
+## Responsibilities
+
+Maintainers are responsible for:
+
+1. **Review** — Reviewing pull requests in their areas of ownership (see
+   [`.github/CODEOWNERS`](.github/CODEOWNERS)). Aim for a first response
+   within one week of submission, even if it's just acknowledging that the
+   PR is in the queue.
+
+2. **Triage** — Labeling and prioritizing incoming issues. Closing obvious
+   duplicates. Routing security reports through the private
+   [Security Advisory](https://github.com/praxiomlabs/rust-mssql-driver/security/advisories/new)
+   channel rather than discussing them publicly.
+
+3. **Releases** — Following [RELEASING.md](RELEASING.md) to cut new versions
+   when the dev branch has accumulated meaningful changes. Maintainers must
+   ensure all Cardinal Rules in RELEASING.md are satisfied before pushing a
+   release tag.
+
+4. **Stewardship** — Keeping the project's documented policies (STABILITY.md,
+   SECURITY.md, CODE_OF_CONDUCT.md, this file) honest and up to date. When a
+   policy contradiction is discovered (as we found with MSRV breaking-change
+   policy during the 0.7.0 release), resolve it promptly rather than leaving
+   contradictory guidance in place.
+
+5. **Continuity** — When a maintainer knows they'll be away for an extended
+   period, note it here or in a pinned issue so contributors know what to
+   expect. When a maintainer is no longer active, move them to the
+   **Emeritus Maintainers** section below.
+
+## Contact
+
+- **Bug reports, feature requests, questions:** Use the
+  [issue tracker](https://github.com/praxiomlabs/rust-mssql-driver/issues/new/choose)
+  with the appropriate template, or start a
+  [Discussion](https://github.com/praxiomlabs/rust-mssql-driver/discussions)
+  for conversational topics.
+- **Security vulnerabilities:** Report privately via
+  [GitHub Security Advisories](https://github.com/praxiomlabs/rust-mssql-driver/security/advisories/new).
+  See [SECURITY.md](SECURITY.md) for the full policy.
+- **Code of conduct violations:** Contact the maintainers privately via the
+  same Security Advisory channel. See [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md).
+
+## Becoming a Maintainer
+
+We welcome additional maintainers, especially contributors who have
+demonstrated:
+
+- **Sustained, high-quality contributions** — multiple merged PRs over at
+  least a few months covering meaningful work (not just trivial fixes).
+- **Deep knowledge in a specific area** — e.g., TDS protocol internals, TLS,
+  the connection pool, or authentication strategies. A maintainer doesn't
+  need to know everything; CODEOWNERS lets us scope ownership to specific
+  crates.
+- **Good reviewing judgment** — substantive, kind, actionable feedback on
+  other people's PRs.
+- **Alignment with project values** — the quality-over-speed and
+  correctness-first philosophies described in
+  [CONTRIBUTING.md](CONTRIBUTING.md).
+
+If you think you'd be a good fit, open a Discussion (or email the current
+maintainers via the Security Advisory channel) describing your interest and
+the area you'd like to take ownership of. We'll work with you on a
+trial period, then formalize the role with an update to this file and to
+`.github/CODEOWNERS`.
+
+## Decision Making
+
+Today, decisions are made by the primary maintainer with input from the
+community via issues and PRs. As the project grows, we'll move to a more
+formal governance model — likely a simple "lazy consensus" approach where
+significant decisions are proposed via issues and go through if nobody
+objects within a reasonable window (e.g., one week).
+
+Architectural decisions should be captured as ADRs in
+[ARCHITECTURE.md](ARCHITECTURE.md) following the process described in
+[CONTRIBUTING.md § Architecture Decision Records](CONTRIBUTING.md#architecture-decision-records-adrs).
+
+## Emeritus Maintainers
+
+*None yet.*

--- a/PRODUCTION_READINESS.md
+++ b/PRODUCTION_READINESS.md
@@ -299,6 +299,7 @@ The following are documented as known limitations, acceptable for initial releas
 | 0.5.2 Release | 2026-01-04 | Complete |
 | 0.6.0 Release | 2026-01-12 | Complete |
 | 0.7.0 Release | 2026-04-07 | Complete (security + SSPI + pre-1.0 hardening) |
+| 0.8.0 Release | 2026-04-13 | Complete (stored procs + SQL Browser + pool health) |
 | Test Coverage 60% | TBD | In Progress (46%) |
 | Security Audit | TBD | Not Scheduled |
 | 1.0.0 Release | TBD | Blocked |

--- a/README.md
+++ b/README.md
@@ -315,7 +315,20 @@ Each crate has its own README with crate-specific documentation:
 
 ## Contributing
 
-Contributions are welcome! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
+Contributions are welcome! A few quick pointers:
+
+- **First time?** Read [CONTRIBUTING.md § First Contribution](CONTRIBUTING.md#first-contribution-quick-path) for the shortest path from clone to green CI.
+- **Filing an issue?** Use the [issue templates](https://github.com/praxiomlabs/rust-mssql-driver/issues/new/choose) — they'll ask the right questions so reviewers can help faster.
+- **Opening a PR?** The [PR template](.github/pull_request_template.md) walks you through what reviewers need to know.
+- **Architecture changes?** Review [ARCHITECTURE.md](ARCHITECTURE.md) and the [ADR process](CONTRIBUTING.md#architecture-decision-records-adrs).
+- **Code of Conduct**: We follow the [Rust Code of Conduct](CODE_OF_CONDUCT.md).
+- **Current maintainers** and how to contact them: [MAINTAINERS.md](MAINTAINERS.md).
+
+## Community
+
+- 💬 **Questions and discussions**: [GitHub Discussions](https://github.com/praxiomlabs/rust-mssql-driver/discussions)
+- 🐛 **Bugs and feature requests**: [GitHub Issues](https://github.com/praxiomlabs/rust-mssql-driver/issues)
+- 🔒 **Security vulnerabilities**: [Private Security Advisory](https://github.com/praxiomlabs/rust-mssql-driver/security/advisories/new) — see [SECURITY.md](SECURITY.md)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A high-performance, async Microsoft SQL Server driver for Rust.
 - **Pure Rust TLS** - Uses rustls, no OpenSSL dependency
 - **Modern Rust** - 2024 Edition, MSRV 1.88
 
-### Feature Status (v0.7.x)
+### Feature Status (v0.8.x)
 
 | Feature | Status | Notes |
 |---------|--------|-------|
@@ -38,6 +38,8 @@ A high-performance, async Microsoft SQL Server driver for Rust.
 | Always Encrypted | ✅ | Full support with Azure Key Vault and Windows CertStore providers |
 | Query Cancellation | ✅ | ATTENTION signal support |
 | Collation-Aware Decoding | ✅ | 14+ character encodings |
+| Stored Procedures | ✅ | RPC-based with OUTPUT params |
+| Named Instance Resolution | ✅ | SQL Browser service (UDP 1434) |
 
 ## Installation
 
@@ -45,7 +47,7 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-mssql-client = "0.7"
+mssql-client = "0.8"
 tokio = { version = "1.48", features = ["full"] }
 ```
 
@@ -219,8 +221,8 @@ Enable optional features:
 
 ```toml
 [dependencies]
-mssql-client = { version = "0.7", features = ["otel"] }
-mssql-auth = { version = "0.7", features = ["sspi-auth"] }
+mssql-client = { version = "0.8", features = ["otel"] }
+mssql-auth = { version = "0.8", features = ["sspi-auth"] }
 ```
 
 ## SQL Server Compatibility
@@ -260,6 +262,8 @@ See [STABILITY.md](STABILITY.md) for details on what's considered stable.
 | Prepared statement cache | Automatic LRU | Per-execution |
 | Azure SQL redirects | Automatic | Manual handling |
 | Type-state connections | Yes | No |
+| Stored procedures (RPC) | Yes (OUTPUT params, RETURN value) | No (todo!()) |
+| Named instance resolution | Yes (SQL Browser) | No |
 
 ## Examples
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -2,7 +2,7 @@
 
 Comprehensive guide for releasing new versions of rust-mssql-driver to crates.io.
 
-**Version:** 0.7.0 | **MSRV:** 1.88 | **Edition:** 2024 | **Workspace:** 9 crates
+**Version:** 0.8.0 | **MSRV:** 1.88 | **Edition:** 2024 | **Workspace:** 9 crates
 
 ---
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -955,6 +955,155 @@ This section documents issues encountered in past releases and patterns to avoid
 - Added Cardinal Rule #5 (version refs check) and #6 (never cancel mid-publish)
 - Updated `release-check` to include version-refs-check
 
+### 12. The v0.7.0 Incidents (Token Expiry, Dev-Branch CI Gap, Doc Contradiction)
+
+**Issue**: The v0.7.0 release cycle surfaced three unrelated latent problems
+that had been accumulating since the last release. None were caused by the
+v0.7.0 changes themselves — they were pre-existing drift that only became
+visible under the pressure of a real release.
+
+**What went wrong**:
+
+1. **CARGO_REGISTRY_TOKEN expiry, discovered at publish time.** The release
+   workflow ran all validation jobs successfully (Semver, Test Suite, Docs,
+   Security Audit), then failed on the very first `cargo publish` attempt
+   with `HTTP 403: authentication failed`. Zero crates were published —
+   the cleanest possible failure mode — but it required a manual token
+   rotation and workflow rerun to complete the release. The token had
+   silently expired at some point between v0.6.0 (2026-01-12) and v0.7.0
+   (2026-04-07), and there was no early-warning mechanism.
+
+2. **Two pre-existing latent bugs surfaced at release PR time.** The mock
+   server's `test_mock_server_tls_full_connection` failed on macOS and
+   Windows with "peer closed connection without sending TLS close_notify"
+   because the mock server was dropping the TLS stream without calling
+   `shutdown()`. And `cargo xtask check-features` was running
+   `cargo check -p mssql-driver-pool --no-dev-deps` — but `--no-dev-deps`
+   is a cargo-hack flag, not a cargo flag, which older cargo silently
+   ignored and Rust 1.88's stricter cargo rejects. Both bugs had been
+   latent on `dev` for weeks (or months) without being caught, because
+   CI only ran on `main` and on PRs to `main`. The 42-commit backlog
+   that shipped in v0.7.0 had zero CI coverage between the last
+   main-branch push (2026-01-13) and the release PR (2026-04-07).
+
+3. **CONTRIBUTING.md contradicted STABILITY.md on MSRV policy.** The
+   "Definitely Breaking" list in CONTRIBUTING.md included "Increasing
+   MSRV", but STABILITY.md's explicit "MSRV Increase Policy" section
+   said MSRV bumps are _not_ considered breaking changes. The
+   contradiction had been present since CONTRIBUTING.md was created
+   and was only discovered when deciding how to handle the MSRV bump
+   needed for the `time 0.3.47` security fix.
+
+**Result**: The release shipped successfully but consumed an outsized amount
+of effort verifying, debugging, and re-running. Three separate decision
+points that should have been automated or obvious required manual
+investigation and judgment.
+
+**Solution** (implemented post-v0.7.0 as a release-hygiene sprint):
+
+- **Added `.github/workflows/token-health.yml`** — runs weekly (and
+  on-demand) to verify `CARGO_REGISTRY_TOKEN` still authenticates against
+  `crates.io/api/v1/me`. On failure, opens (or updates) a tracking issue
+  with rotation instructions. Would have surfaced the token problem up to
+  7 days before a real release attempt.
+- **Extended `ci.yml` and `benchmarks.yml` to trigger on pushes to `dev`**,
+  not just `main`. Both latent bugs would have been caught within minutes
+  of landing on `dev` instead of sitting there for weeks. Uses
+  `concurrency: cancel-in-progress` for non-main branches to avoid
+  wasted CI cycles.
+- **Added `workflow_dispatch` to all workflows** so maintainers can
+  manually retrigger after a transient failure or external fix (like
+  the token rotation) without needing to push a dummy commit.
+- **Fixed the mock server TLS shutdown bug properly** (closes #70) —
+  `handle_connection` now calls `tls_stream.shutdown().await` before
+  returning so rustls sends a clean `close_notify` alert. Removed the
+  `#[cfg(target_os = "linux")]` gate on
+  `test_mock_server_tls_full_connection`.
+- **Fixed the `xtask --no-dev-deps` bug** — wrapped the offending
+  invocation with `cargo hack check` like the other feature-matrix
+  commands in that function.
+- **Fixed the CONTRIBUTING.md / STABILITY.md contradiction** — removed
+  "Increasing MSRV" from the breaking-change list and added an explicit
+  non-breaking entry that points at STABILITY.md § MSRV Increase Policy
+  as the authoritative source.
+- **Added `scripts/check-doc-consistency.sh`** — codifies the class of
+  doc-drift bug that produced the CONTRIBUTING.md contradiction.
+  Validates: MSRV consistency across all files, CHANGELOG ↔ Cargo.toml
+  version agreement, STABILITY.md ↔ CONTRIBUTING.md MSRV policy
+  agreement, workspace crate version inheritance, deny.toml ↔
+  `.cargo/audit.toml` ignore-list sync.
+  Wired into `just release-check` via a new `just doc-consistency`
+  recipe.
+- **Added `just release-status`** — one-command dashboard showing
+  dev↔main divergence, last tag age, workflow status (including the
+  new token health check), open PRs grouped by bot vs contributor, and
+  local working-copy state. Answers "should I release?" without
+  needing to remember which commands to run.
+- **Added `just release-preflight`** — sequential gate check that runs
+  every Cardinal Rules verification in order with clear pass/fail
+  reporting.
+- **Added `cargo xtask release-notes`** — generates a CHANGELOG draft
+  from conventional commits since the last tag, grouped by type
+  (feat → Added, fix → Fixed, etc.), with breaking change detection.
+  Reduces the manual CHANGELOG-writing burden by ~80%.
+- **Added issue templates, PR template, CODE_OF_CONDUCT.md, CODEOWNERS,
+  MAINTAINERS.md** — not release-mechanics proper, but the sprint that
+  followed the v0.7.0 incident was the natural time to raise the
+  contributor-facing surface area of the repo. The new PR template
+  includes an explicit "MSRV bumps are NOT a breaking change" note
+  that prevents the exact CONTRIBUTING.md contradiction from being
+  re-introduced by a well-meaning contributor.
+
+---
+
+## Token Health
+
+The `CARGO_REGISTRY_TOKEN` secret authenticates the automated release
+workflow against crates.io. If it expires, is revoked, or is rotated
+without the GitHub secret being updated, the next release attempt will
+fail at tier 0.
+
+### Weekly health check
+
+`.github/workflows/token-health.yml` runs every Monday at 09:15 UTC and
+also supports manual `workflow_dispatch`. It calls
+`https://crates.io/api/v1/me` with the token — a non-destructive
+authenticated GET that returns 200 if and only if the token can perform
+authenticated operations against crates.io.
+
+On failure, the workflow opens (or updates) a tracking issue labelled
+`security` with rotation instructions. The same issue title is reused
+on subsequent failures so the alert is visible without spamming new
+issues every week.
+
+### Manual rotation
+
+1. Visit https://crates.io/settings/tokens
+2. Revoke the previous `rust-mssql-driver-*` token (optional but recommended).
+3. Create a new token with `publish-update` scope. Add `publish-new` only
+   if a workspace crate has never been published before (all 8 currently
+   published crates have `publish-update` coverage).
+4. Optionally scope the new token to just the 8 published crates:
+   `tds-protocol`, `mssql-types`, `mssql-tls`, `mssql-codec`, `mssql-auth`,
+   `mssql-derive`, `mssql-client`, `mssql-driver-pool`.
+5. Copy the token value (shown only once).
+6. Visit https://github.com/praxiomlabs/rust-mssql-driver/settings/secrets/actions
+7. Update the existing `CARGO_REGISTRY_TOKEN` secret.
+8. Manually trigger the Token Health Check workflow
+   (Actions → Token Health Check → Run workflow) to confirm the new
+   token works.
+9. If a release was in flight when the token failed, rerun the failed
+   publish job: `gh run rerun <run-id> --failed`. This was the exact
+   recovery path used during the v0.7.0 release.
+
+### Verification at release time
+
+The `release.yml` workflow will still attempt to publish tier 0 first,
+so a bad token fails loudly at the first upload attempt rather than
+partway through. This means the worst-case failure mode is "zero
+crates published, rerun after rotation" — which is what happened during
+the v0.7.0 release.
+
 ---
 
 ## Automated vs Manual Release

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,8 +4,9 @@
 
 | Version | Supported          |
 | ------- | ------------------ |
+| 0.8.x   | :white_check_mark: |
 | 0.7.x   | :white_check_mark: |
-| 0.6.x   | :white_check_mark: |
+| 0.6.x   | :x: (end of life)  |
 | 0.5.x   | :x: (end of life)  |
 | 0.4.x   | :x: (end of life)  |
 | 0.3.x   | :x: (end of life)  |

--- a/STABILITY.md
+++ b/STABILITY.md
@@ -46,6 +46,12 @@ The following APIs are considered stable and covered by semver guarantees:
 | `Transaction::commit()` | Stable |
 | `Transaction::rollback()` | Stable |
 | `Transaction::save_point()` | Stable |
+| `Client::call_procedure()` | Stable |
+| `Client::procedure()` | Stable |
+| `ProcedureBuilder::input()` | Stable |
+| `ProcedureBuilder::output_*()` | Stable |
+| `ProcedureBuilder::execute()` | Stable |
+| `ProcedureResult` fields | Stable |
 | `Error` enum variants | Stable |
 
 ### mssql-driver-pool

--- a/crates/mssql-auth/src/azure_keyvault.rs
+++ b/crates/mssql-auth/src/azure_keyvault.rs
@@ -56,11 +56,10 @@
 
 use std::sync::Arc;
 
+use azure_core::http::RequestContent;
 use azure_identity::DeveloperToolsCredential;
 use azure_security_keyvault_keys::KeyClient;
-use azure_security_keyvault_keys::models::{
-    EncryptionAlgorithm, KeyClientUnwrapKeyOptions, KeyOperationParameters,
-};
+use azure_security_keyvault_keys::models::{EncryptionAlgorithm, KeyOperationParameters};
 use tracing::{debug, instrument};
 use url::Url;
 
@@ -213,21 +212,22 @@ impl KeyStoreProvider for AzureKeyVaultProvider {
             ..Default::default()
         };
 
-        // Build options with key version if provided
-        let options = key_version.map(|v| KeyClientUnwrapKeyOptions {
-            key_version: Some(v),
-            ..Default::default()
-        });
+        // key_version is required by the Azure SDK 0.13+ API
+        let version = key_version.ok_or_else(|| {
+            EncryptionError::CmkError(
+                "CMK path must include key version (e.g., /keys/<name>/<version>)".into(),
+            )
+        })?;
+
+        // Convert parameters to RequestContent
+        let request_content: RequestContent<KeyOperationParameters> =
+            parameters.try_into().map_err(|e| {
+                EncryptionError::CekDecryptionFailed(format!("Failed to create request: {e}"))
+            })?;
 
         // Call Key Vault unwrap operation
         let result = client
-            .unwrap_key(
-                &key_name,
-                parameters.try_into().map_err(|e| {
-                    EncryptionError::CekDecryptionFailed(format!("Failed to create request: {e}"))
-                })?,
-                options,
-            )
+            .unwrap_key(&key_name, &version, request_content, None)
             .await
             .map_err(|e| {
                 EncryptionError::CekDecryptionFailed(format!("Key Vault unwrap failed: {e}"))
@@ -257,30 +257,25 @@ impl KeyStoreProvider for AzureKeyVaultProvider {
         let client = self.create_client(&vault_url)?;
 
         // Build sign parameters - use RS256 (RSA-SHA256) by default
-        use azure_security_keyvault_keys::models::{
-            KeyClientSignOptions, SignParameters, SignatureAlgorithm,
-        };
+        use azure_security_keyvault_keys::models::{SignParameters, SignatureAlgorithm};
 
         let parameters = SignParameters {
             algorithm: Some(SignatureAlgorithm::Rs256),
             value: Some(data.to_vec()),
         };
 
-        // Build options with key version if provided
-        let options = key_version.map(|v| KeyClientSignOptions {
-            key_version: Some(v),
-            ..Default::default()
-        });
+        // key_version is required by the Azure SDK 0.13+ API
+        let version = key_version.ok_or_else(|| {
+            EncryptionError::CmkError("CMK path must include key version for sign operation".into())
+        })?;
+
+        let request_content: RequestContent<SignParameters> = parameters
+            .try_into()
+            .map_err(|e| EncryptionError::CmkError(format!("Failed to create request: {e}")))?;
 
         // Call Key Vault sign operation
         let result = client
-            .sign(
-                &key_name,
-                parameters.try_into().map_err(|e| {
-                    EncryptionError::CmkError(format!("Failed to create request: {e}"))
-                })?,
-                options,
-            )
+            .sign(&key_name, &version, request_content, None)
             .await
             .map_err(|e| EncryptionError::CmkError(format!("Key Vault sign failed: {e}")))?
             .into_model()
@@ -311,9 +306,7 @@ impl KeyStoreProvider for AzureKeyVaultProvider {
         let client = self.create_client(&vault_url)?;
 
         // Build verify parameters
-        use azure_security_keyvault_keys::models::{
-            KeyClientVerifyOptions, SignatureAlgorithm, VerifyParameters,
-        };
+        use azure_security_keyvault_keys::models::{SignatureAlgorithm, VerifyParameters};
 
         let parameters = VerifyParameters {
             algorithm: Some(SignatureAlgorithm::Rs256),
@@ -321,21 +314,20 @@ impl KeyStoreProvider for AzureKeyVaultProvider {
             signature: Some(signature.to_vec()),
         };
 
-        // Build options with key version if provided
-        let options = key_version.map(|v| KeyClientVerifyOptions {
-            key_version: Some(v),
-            ..Default::default()
-        });
+        // key_version is required by the Azure SDK 0.13+ API
+        let version = key_version.ok_or_else(|| {
+            EncryptionError::CmkError(
+                "CMK path must include key version for verify operation".into(),
+            )
+        })?;
+
+        let request_content: RequestContent<VerifyParameters> = parameters
+            .try_into()
+            .map_err(|e| EncryptionError::CmkError(format!("Failed to create request: {e}")))?;
 
         // Call Key Vault verify operation
         let result = client
-            .verify(
-                &key_name,
-                parameters.try_into().map_err(|e| {
-                    EncryptionError::CmkError(format!("Failed to create request: {e}"))
-                })?,
-                options,
-            )
+            .verify(&key_name, &version, request_content, None)
             .await
             .map_err(|e| EncryptionError::CmkError(format!("Key Vault verify failed: {e}")))?
             .into_model()

--- a/crates/mssql-auth/src/cert_auth.rs
+++ b/crates/mssql-auth/src/cert_auth.rs
@@ -153,7 +153,7 @@ impl CertificateAuth {
             base64::engine::general_purpose::STANDARD.encode(cert_bytes)
         };
 
-        let cert_secret = Secret::new(cert_b64);
+        let cert_secret = azure_core::credentials::SecretBytes::new(cert_b64.into_bytes());
 
         // Create options with password if provided
         // Note: send_certificate_chain is now controlled by AZURE_CLIENT_SEND_CERTIFICATE_CHAIN env var

--- a/crates/mssql-client/src/browser.rs
+++ b/crates/mssql-client/src/browser.rs
@@ -1,0 +1,285 @@
+//! SQL Server Browser service client for named instance resolution.
+//!
+//! When connecting to a named SQL Server instance (e.g., `localhost\SQLEXPRESS`),
+//! the client needs to discover which TCP port the instance is listening on.
+//! The SQL Server Browser service runs on UDP port 1434 and answers these queries
+//! using the SQL Server Resolution Protocol (SSRP), defined in [MC-SQLR].
+//!
+//! [MC-SQLR]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/mc-sqlr/
+//!
+//! # Protocol
+//!
+//! The client sends a `CLNT_UCAST_INST` message (0x04 + instance name + null byte)
+//! and receives a `SVR_RESP` message (0x05 + length + semicolon-delimited data).
+//! The response contains key-value pairs including `tcp;PORT` for the TCP port.
+//!
+//! # Example
+//!
+//! ```rust,ignore
+//! use mssql_client::browser::resolve_instance;
+//! use std::time::Duration;
+//!
+//! let port = resolve_instance("localhost", "SQLEXPRESS", Duration::from_secs(2)).await?;
+//! println!("SQLEXPRESS is on port {}", port);
+//! ```
+
+use std::time::Duration;
+
+use tokio::net::UdpSocket;
+use tokio::time::timeout;
+
+use crate::error::Error;
+
+/// Default timeout for SQL Browser queries.
+const DEFAULT_BROWSER_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// UDP port for the SQL Server Browser service.
+const BROWSER_PORT: u16 = 1434;
+
+/// CLNT_UCAST_INST message type byte.
+const CLNT_UCAST_INST: u8 = 0x04;
+
+/// SVR_RESP message type byte.
+const SVR_RESP: u8 = 0x05;
+
+/// Maximum response size per the MC-SQLR spec (1024 bytes for CLNT_UCAST_INST).
+const MAX_RESPONSE_SIZE: usize = 1024 + 3; // 3 bytes for header (type + length)
+
+/// Resolve a named SQL Server instance to its TCP port via the SQL Browser service.
+///
+/// Sends a `CLNT_UCAST_INST` query to the SQL Server Browser service running
+/// on `host:1434` and parses the response to extract the TCP port number.
+///
+/// # Arguments
+///
+/// * `host` - The hostname or IP address of the SQL Server machine
+/// * `instance` - The instance name (e.g., "SQLEXPRESS")
+/// * `browser_timeout` - How long to wait for the Browser service to respond
+///
+/// # Errors
+///
+/// Returns an error if:
+/// - The Browser service doesn't respond within the timeout
+/// - The instance name is not found in the response
+/// - No TCP port is configured for the instance
+/// - The response is malformed
+///
+/// # Example
+///
+/// ```rust,ignore
+/// let port = resolve_instance("localhost", "SQLEXPRESS", Duration::from_secs(2)).await?;
+/// ```
+pub(crate) async fn resolve_instance(
+    host: &str,
+    instance: &str,
+    browser_timeout: Option<Duration>,
+) -> Result<u16, Error> {
+    let timeout_duration = browser_timeout.unwrap_or(DEFAULT_BROWSER_TIMEOUT);
+
+    // Normalize host: "." means localhost
+    let resolved_host = if host == "." { "127.0.0.1" } else { host };
+
+    let target = format!("{resolved_host}:{BROWSER_PORT}");
+
+    tracing::debug!(
+        host = resolved_host,
+        instance = instance,
+        "querying SQL Browser service at {}",
+        target
+    );
+
+    // Build the CLNT_UCAST_INST request: 0x04 + instance name (ASCII) + 0x00
+    let mut request = Vec::with_capacity(2 + instance.len());
+    request.push(CLNT_UCAST_INST);
+    request.extend_from_slice(instance.as_bytes());
+    request.push(0x00); // null terminator
+
+    // Bind to any available local port for the UDP socket
+    let socket = UdpSocket::bind("0.0.0.0:0")
+        .await
+        .map_err(|e| Error::BrowserResolution {
+            instance: instance.to_string(),
+            reason: format!("failed to bind UDP socket: {e}"),
+        })?;
+
+    // Send the query
+    socket
+        .send_to(&request, &target)
+        .await
+        .map_err(|e| Error::BrowserResolution {
+            instance: instance.to_string(),
+            reason: format!("failed to send to {target}: {e}"),
+        })?;
+
+    // Wait for response with timeout
+    let mut buf = vec![0u8; MAX_RESPONSE_SIZE];
+    let recv_len = timeout(timeout_duration, socket.recv(&mut buf))
+        .await
+        .map_err(|_| Error::BrowserResolution {
+            instance: instance.to_string(),
+            reason: format!(
+                "SQL Browser service at {target} did not respond within {timeout_duration:?}. \
+                 Ensure the SQL Server Browser service is running on the target machine."
+            ),
+        })?
+        .map_err(|e| Error::BrowserResolution {
+            instance: instance.to_string(),
+            reason: format!("failed to receive from {target}: {e}"),
+        })?;
+
+    // Parse the SVR_RESP response
+    parse_browser_response(&buf[..recv_len], instance)
+}
+
+/// Parse a SVR_RESP message and extract the TCP port for the given instance.
+fn parse_browser_response(data: &[u8], instance: &str) -> Result<u16, Error> {
+    // Minimum valid response: 0x05 + 2-byte length + at least some data
+    if data.len() < 3 {
+        return Err(Error::BrowserResolution {
+            instance: instance.to_string(),
+            reason: "response too short".to_string(),
+        });
+    }
+
+    if data[0] != SVR_RESP {
+        return Err(Error::BrowserResolution {
+            instance: instance.to_string(),
+            reason: format!(
+                "unexpected response type: {:#04x} (expected {SVR_RESP:#04x})",
+                data[0]
+            ),
+        });
+    }
+
+    let resp_size = u16::from_le_bytes([data[1], data[2]]) as usize;
+    if data.len() < 3 + resp_size {
+        return Err(Error::BrowserResolution {
+            instance: instance.to_string(),
+            reason: format!(
+                "response truncated: header says {resp_size} bytes but only {} available",
+                data.len() - 3
+            ),
+        });
+    }
+
+    // RESP_DATA is a semicolon-delimited string
+    let resp_data =
+        std::str::from_utf8(&data[3..3 + resp_size]).map_err(|e| Error::BrowserResolution {
+            instance: instance.to_string(),
+            reason: format!("response is not valid UTF-8: {e}"),
+        })?;
+
+    tracing::debug!(
+        instance = instance,
+        response = resp_data,
+        "SQL Browser response received"
+    );
+
+    // Parse semicolon-delimited key-value pairs.
+    // Format: ServerName;VALUE;InstanceName;VALUE;IsClustered;VALUE;Version;VALUE;tcp;PORT;;
+    let parts: Vec<&str> = resp_data.split(';').collect();
+
+    // Find the "tcp" key and extract the port value (next element)
+    let tcp_port = parts
+        .windows(2)
+        .find(|pair| pair[0].eq_ignore_ascii_case("tcp"))
+        .and_then(|pair| pair[1].parse::<u16>().ok());
+
+    match tcp_port {
+        Some(port) => {
+            tracing::info!(
+                instance = instance,
+                port = port,
+                "resolved named instance via SQL Browser"
+            );
+            Ok(port)
+        }
+        None => Err(Error::BrowserResolution {
+            instance: instance.to_string(),
+            reason: format!(
+                "no TCP port found in Browser response. The instance may only support \
+                 Named Pipes. Response: {resp_data}"
+            ),
+        }),
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_browser_response_valid() {
+        // Build a realistic SVR_RESP
+        let resp_data =
+            b"ServerName;MYSERVER;InstanceName;SQLEXPRESS;IsClustered;No;Version;15.0.2000.5;tcp;52000;;";
+        let mut packet = Vec::new();
+        packet.push(SVR_RESP);
+        packet.extend_from_slice(&(resp_data.len() as u16).to_le_bytes());
+        packet.extend_from_slice(resp_data);
+
+        let port = parse_browser_response(&packet, "SQLEXPRESS").unwrap();
+        assert_eq!(port, 52000);
+    }
+
+    #[test]
+    fn test_parse_browser_response_with_named_pipes() {
+        let resp_data = b"ServerName;SRV;InstanceName;INST;IsClustered;No;Version;15.0.0.0;np;\\\\SRV\\pipe\\sql\\query;tcp;49500;;";
+        let mut packet = Vec::new();
+        packet.push(SVR_RESP);
+        packet.extend_from_slice(&(resp_data.len() as u16).to_le_bytes());
+        packet.extend_from_slice(resp_data);
+
+        let port = parse_browser_response(&packet, "INST").unwrap();
+        assert_eq!(port, 49500);
+    }
+
+    #[test]
+    fn test_parse_browser_response_no_tcp() {
+        let resp_data =
+            b"ServerName;SRV;InstanceName;INST;IsClustered;No;Version;15.0.0.0;np;\\\\SRV\\pipe\\sql\\query;;";
+        let mut packet = Vec::new();
+        packet.push(SVR_RESP);
+        packet.extend_from_slice(&(resp_data.len() as u16).to_le_bytes());
+        packet.extend_from_slice(resp_data);
+
+        let result = parse_browser_response(&packet, "INST");
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("no TCP port"), "got: {err}");
+    }
+
+    #[test]
+    fn test_parse_browser_response_too_short() {
+        let result = parse_browser_response(&[0x05, 0x00], "INST");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_parse_browser_response_wrong_type() {
+        let result = parse_browser_response(&[0x04, 0x00, 0x00], "INST");
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("unexpected response type"), "got: {err}");
+    }
+
+    #[test]
+    fn test_parse_browser_response_spec_example() {
+        // Exact example from MC-SQLR spec
+        let packet: Vec<u8> = vec![
+            0x05, 0x58, 0x00, // SVR_RESP header (type=0x05, length=0x0058=88)
+            // "ServerName;ILSUNG1;InstanceName;YUKONSTD;IsClustered;No;Version;9.00.1399.06;tcp;57137;;"
+            0x53, 0x65, 0x72, 0x76, 0x65, 0x72, 0x4e, 0x61, 0x6d, 0x65, 0x3b, 0x49, 0x4c, 0x53,
+            0x55, 0x4e, 0x47, 0x31, 0x3b, 0x49, 0x6e, 0x73, 0x74, 0x61, 0x6e, 0x63, 0x65, 0x4e,
+            0x61, 0x6d, 0x65, 0x3b, 0x59, 0x55, 0x4b, 0x4f, 0x4e, 0x53, 0x54, 0x44, 0x3b, 0x49,
+            0x73, 0x43, 0x6c, 0x75, 0x73, 0x74, 0x65, 0x72, 0x65, 0x64, 0x3b, 0x4e, 0x6f, 0x3b,
+            0x56, 0x65, 0x72, 0x73, 0x69, 0x6f, 0x6e, 0x3b, 0x39, 0x2e, 0x30, 0x30, 0x2e, 0x31,
+            0x33, 0x39, 0x39, 0x2e, 0x30, 0x36, 0x3b, 0x74, 0x63, 0x70, 0x3b, 0x35, 0x37, 0x31,
+            0x33, 0x37, 0x3b, 0x3b,
+        ];
+
+        let port = parse_browser_response(&packet, "YUKONSTD").unwrap();
+        assert_eq!(port, 57137);
+    }
+}

--- a/crates/mssql-client/src/bulk.rs
+++ b/crates/mssql-client/src/bulk.rs
@@ -364,11 +364,11 @@ impl BulkInsertBuilder {
     /// validation, preventing SQL injection.
     pub fn build_insert_bulk_statement(&self) -> Result<String, Error> {
         // Validate table name (may be schema-qualified: dbo.Users, catalog.schema.table)
-        validate_qualified_identifier(&self.table_name)?;
+        crate::validation::validate_qualified_identifier(&self.table_name)?;
 
         // Validate column names
         for col in &self.columns {
-            validate_identifier(&col.name)?;
+            crate::validation::validate_identifier(&col.name)?;
         }
 
         let mut sql = format!("INSERT BULK {}", self.table_name);
@@ -415,7 +415,7 @@ impl BulkInsertBuilder {
         if let Some(ref order) = self.options.order_hint {
             // Validate order hint column names
             for col_name in order {
-                validate_identifier(col_name)?;
+                crate::validation::validate_identifier(col_name)?;
             }
             hints.push(format!("ORDER({})", order.join(", ")));
         }
@@ -448,53 +448,6 @@ fn validate_sql_type(type_str: &str) -> Result<(), Error> {
         return Err(Error::Config(format!(
             "invalid SQL type '{type_str}': contains disallowed characters"
         )));
-    }
-
-    Ok(())
-}
-
-/// Validate a single SQL identifier to prevent SQL injection.
-fn validate_identifier(name: &str) -> Result<(), Error> {
-    #[allow(clippy::expect_used)] // Static regex compilation with known-valid pattern
-    static IDENTIFIER_RE: Lazy<Regex> =
-        Lazy::new(|| Regex::new(r"^[a-zA-Z_][a-zA-Z0-9_@#$]{0,127}$").expect("valid regex"));
-
-    if name.is_empty() {
-        return Err(Error::InvalidIdentifier(
-            "identifier cannot be empty".into(),
-        ));
-    }
-
-    if !IDENTIFIER_RE.is_match(name) {
-        return Err(Error::InvalidIdentifier(format!(
-            "invalid identifier '{name}': must start with letter/underscore, \
-             contain only alphanumerics/_/@/#/$, and be 1-128 characters"
-        )));
-    }
-
-    Ok(())
-}
-
-/// Validate a potentially schema-qualified identifier (e.g., `dbo.Users`, `catalog.schema.table`).
-///
-/// Splits on `.` and validates each part. SQL Server allows up to 4 parts:
-/// `server.catalog.schema.object`.
-fn validate_qualified_identifier(name: &str) -> Result<(), Error> {
-    if name.is_empty() {
-        return Err(Error::InvalidIdentifier(
-            "identifier cannot be empty".into(),
-        ));
-    }
-
-    let parts: Vec<&str> = name.split('.').collect();
-    if parts.len() > 4 {
-        return Err(Error::InvalidIdentifier(format!(
-            "invalid qualified identifier '{name}': too many parts (max 4: server.catalog.schema.object)"
-        )));
-    }
-
-    for part in &parts {
-        validate_identifier(part)?;
     }
 
     Ok(())

--- a/crates/mssql-client/src/client/connect.rs
+++ b/crates/mssql-client/src/client/connect.rs
@@ -91,14 +91,40 @@ impl Client<Disconnected> {
     }
 
     async fn try_connect(config: &Config) -> Result<Client<Ready>> {
-        tracing::info!(
-            host = %config.host,
-            port = config.port,
-            database = ?config.database,
-            "connecting to SQL Server"
-        );
+        // If a named instance is specified, resolve the TCP port via SQL Browser
+        let port = if let Some(ref instance) = config.instance {
+            let resolved = crate::browser::resolve_instance(
+                &config.host,
+                instance,
+                Some(config.timeouts.connect_timeout),
+            )
+            .await?;
+            tracing::info!(
+                host = %config.host,
+                instance = %instance,
+                resolved_port = resolved,
+                database = ?config.database,
+                "connecting to named SQL Server instance"
+            );
+            resolved
+        } else {
+            tracing::info!(
+                host = %config.host,
+                port = config.port,
+                database = ?config.database,
+                "connecting to SQL Server"
+            );
+            config.port
+        };
 
-        let addr = format!("{}:{}", config.host, config.port);
+        // Normalize "." to localhost for TCP
+        let host = if config.host == "." {
+            "127.0.0.1"
+        } else {
+            &config.host
+        };
+
+        let addr = format!("{host}:{port}");
 
         // Step 1: Establish TCP connection
         tracing::debug!("establishing TCP connection to {}", addr);

--- a/crates/mssql-client/src/client/mod.rs
+++ b/crates/mssql-client/src/client/mod.rs
@@ -934,7 +934,7 @@ impl Client<InTransaction> {
     /// tx.commit().await?;
     /// ```
     pub async fn save_point(&mut self, name: &str) -> Result<SavePoint> {
-        validate_identifier(name)?;
+        crate::validation::validate_identifier(name)?;
         tracing::debug!(name = name, "creating savepoint");
 
         // Execute SAVE TRANSACTION <name>
@@ -1012,30 +1012,6 @@ impl Client<InTransaction> {
     }
 }
 
-/// Validate an identifier (table name, savepoint name, etc.) to prevent SQL injection.
-fn validate_identifier(name: &str) -> Result<()> {
-    use once_cell::sync::Lazy;
-    use regex::Regex;
-
-    static IDENTIFIER_RE: Lazy<Regex> =
-        Lazy::new(|| Regex::new(r"^[a-zA-Z_][a-zA-Z0-9_@#$]{0,127}$").unwrap());
-
-    if name.is_empty() {
-        return Err(Error::InvalidIdentifier(
-            "identifier cannot be empty".into(),
-        ));
-    }
-
-    if !IDENTIFIER_RE.is_match(name) {
-        return Err(Error::InvalidIdentifier(format!(
-            "invalid identifier '{name}': must start with letter/underscore, \
-             contain only alphanumerics/_/@/#/$, and be 1-128 characters"
-        )));
-    }
-
-    Ok(())
-}
-
 impl<S: ConnectionState> std::fmt::Debug for Client<S> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Client")
@@ -1043,28 +1019,5 @@ impl<S: ConnectionState> std::fmt::Debug for Client<S> {
             .field("port", &self.config.port)
             .field("database", &self.config.database)
             .finish()
-    }
-}
-
-#[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::panic)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_validate_identifier_valid() {
-        assert!(validate_identifier("my_table").is_ok());
-        assert!(validate_identifier("Table123").is_ok());
-        assert!(validate_identifier("_private").is_ok());
-        assert!(validate_identifier("sp_test").is_ok());
-    }
-
-    #[test]
-    fn test_validate_identifier_invalid() {
-        assert!(validate_identifier("").is_err());
-        assert!(validate_identifier("123abc").is_err());
-        assert!(validate_identifier("table-name").is_err());
-        assert!(validate_identifier("table name").is_err());
-        assert!(validate_identifier("table;DROP TABLE users").is_err());
     }
 }

--- a/crates/mssql-client/src/client/mod.rs
+++ b/crates/mssql-client/src/client/mod.rs
@@ -158,7 +158,7 @@ impl<S: ConnectionState> Client<S> {
     ///
     /// If `needs_reset` is set (from pool return), the RESETCONNECTION flag
     /// is included in the first packet to reset connection state.
-    async fn send_rpc(&mut self, rpc: &RpcRequest) -> Result<()> {
+    pub(crate) async fn send_rpc(&mut self, rpc: &RpcRequest) -> Result<()> {
         let payload = rpc.encode_with_transaction(self.transaction_descriptor);
         let max_packet = self.config.packet_size as usize;
 
@@ -189,6 +189,72 @@ impl<S: ConnectionState> Client<S> {
         }
 
         Ok(())
+    }
+
+    /// Start building a stored procedure call with full control over parameters.
+    ///
+    /// Returns a [`ProcedureBuilder`] that allows adding named input and output
+    /// parameters before executing the call.
+    ///
+    /// The procedure name is validated to prevent SQL injection. It may be
+    /// schema-qualified (e.g., `"dbo.MyProc"`).
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// let result = client.procedure("dbo.CalculateSum")?
+    ///     .input("@a", &10i32)
+    ///     .input("@b", &20i32)
+    ///     .output_int("@result")
+    ///     .execute().await?;
+    ///
+    /// let sum = result.get_output("@result").unwrap();
+    /// ```
+    pub fn procedure(
+        &mut self,
+        proc_name: &str,
+    ) -> Result<crate::procedure::ProcedureBuilder<'_, S>> {
+        crate::validation::validate_qualified_identifier(proc_name)?;
+        Ok(crate::procedure::ProcedureBuilder::new(self, proc_name))
+    }
+
+    /// Execute a stored procedure with positional input parameters.
+    ///
+    /// This is a convenience method for the common case of calling a procedure
+    /// with input-only parameters. For output parameters or named parameters,
+    /// use [`procedure()`](Client::procedure) instead.
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// let result = client.call_procedure("dbo.GetUser", &[&1i32]).await?;
+    /// assert_eq!(result.return_value, 0);
+    ///
+    /// if let Some(rs) = result.first_result_set() {
+    ///     println!("columns: {:?}", rs.columns());
+    /// }
+    /// ```
+    pub async fn call_procedure(
+        &mut self,
+        proc_name: &str,
+        params: &[&(dyn crate::ToSql + Sync)],
+    ) -> Result<crate::stream::ProcedureResult> {
+        crate::validation::validate_qualified_identifier(proc_name)?;
+
+        tracing::debug!(
+            proc_name = proc_name,
+            params_count = params.len(),
+            "executing stored procedure"
+        );
+
+        let rpc_params = Self::convert_params(params)?;
+        let mut rpc = RpcRequest::named(proc_name);
+        for param in rpc_params {
+            rpc = rpc.param(param);
+        }
+
+        self.send_rpc(&rpc).await?;
+        self.read_procedure_result().await
     }
 }
 

--- a/crates/mssql-client/src/client/mod.rs
+++ b/crates/mssql-client/src/client/mod.rs
@@ -193,7 +193,7 @@ impl<S: ConnectionState> Client<S> {
 
     /// Start building a stored procedure call with full control over parameters.
     ///
-    /// Returns a [`ProcedureBuilder`] that allows adding named input and output
+    /// Returns a [`crate::procedure::ProcedureBuilder`] that allows adding named input and output
     /// parameters before executing the call.
     ///
     /// The procedure name is validated to prevent SQL injection. It may be

--- a/crates/mssql-client/src/client/params.rs
+++ b/crates/mssql-client/src/client/params.rs
@@ -18,101 +18,101 @@ use crate::state::ConnectionState;
 use super::Client;
 
 impl<S: ConnectionState> Client<S> {
-    /// Convert ToSql parameters to RPC parameters.
-    pub(crate) fn convert_params(params: &[&(dyn crate::ToSql + Sync)]) -> Result<Vec<RpcParam>> {
+    /// Convert a single `ToSql` value into an `RpcParam` with the given name.
+    ///
+    /// This is the shared conversion logic used by both `convert_params()`
+    /// (for positional query parameters) and `ProcedureBuilder::input()`
+    /// (for named procedure parameters).
+    pub(crate) fn convert_single_param(
+        name: &str,
+        value: &(dyn crate::ToSql + Sync),
+    ) -> Result<RpcParam> {
         use bytes::{BufMut, BytesMut};
         use mssql_types::SqlValue;
 
+        let sql_value = value.to_sql()?;
+
+        Ok(match sql_value {
+            SqlValue::Null => RpcParam::null(name, RpcTypeInfo::nvarchar(1)),
+            SqlValue::Bool(v) => {
+                let mut buf = BytesMut::with_capacity(1);
+                buf.put_u8(if v { 1 } else { 0 });
+                RpcParam::new(name, RpcTypeInfo::bit(), buf.freeze())
+            }
+            SqlValue::TinyInt(v) => {
+                let mut buf = BytesMut::with_capacity(1);
+                buf.put_u8(v);
+                RpcParam::new(name, RpcTypeInfo::tinyint(), buf.freeze())
+            }
+            SqlValue::SmallInt(v) => {
+                let mut buf = BytesMut::with_capacity(2);
+                buf.put_i16_le(v);
+                RpcParam::new(name, RpcTypeInfo::smallint(), buf.freeze())
+            }
+            SqlValue::Int(v) => RpcParam::int(name, v),
+            SqlValue::BigInt(v) => RpcParam::bigint(name, v),
+            SqlValue::Float(v) => {
+                let mut buf = BytesMut::with_capacity(4);
+                buf.put_f32_le(v);
+                RpcParam::new(name, RpcTypeInfo::real(), buf.freeze())
+            }
+            SqlValue::Double(v) => {
+                let mut buf = BytesMut::with_capacity(8);
+                buf.put_f64_le(v);
+                RpcParam::new(name, RpcTypeInfo::float(), buf.freeze())
+            }
+            SqlValue::String(ref s) => RpcParam::nvarchar(name, s),
+            SqlValue::Binary(ref b) => {
+                RpcParam::new(name, RpcTypeInfo::varbinary(b.len() as u16), b.clone())
+            }
+            SqlValue::Xml(ref s) => RpcParam::nvarchar(name, s),
+            #[cfg(feature = "uuid")]
+            SqlValue::Uuid(u) => {
+                let bytes = u.as_bytes();
+                let mut buf = BytesMut::with_capacity(16);
+                // SQL Server stores GUIDs in mixed-endian format
+                buf.put_u32_le(u32::from_be_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]));
+                buf.put_u16_le(u16::from_be_bytes([bytes[4], bytes[5]]));
+                buf.put_u16_le(u16::from_be_bytes([bytes[6], bytes[7]]));
+                buf.put_slice(&bytes[8..16]);
+                RpcParam::new(name, RpcTypeInfo::uniqueidentifier(), buf.freeze())
+            }
+            #[cfg(feature = "decimal")]
+            SqlValue::Decimal(d) => RpcParam::nvarchar(name, &d.to_string()),
+            #[cfg(feature = "chrono")]
+            SqlValue::Date(_)
+            | SqlValue::Time(_)
+            | SqlValue::DateTime(_)
+            | SqlValue::DateTimeOffset(_) => {
+                let s = match &sql_value {
+                    SqlValue::Date(d) => d.to_string(),
+                    SqlValue::Time(t) => t.to_string(),
+                    SqlValue::DateTime(dt) => dt.to_string(),
+                    SqlValue::DateTimeOffset(dto) => dto.to_rfc3339(),
+                    _ => unreachable!(),
+                };
+                RpcParam::nvarchar(name, &s)
+            }
+            #[cfg(feature = "json")]
+            SqlValue::Json(ref j) => RpcParam::nvarchar(name, &j.to_string()),
+            SqlValue::Tvp(ref tvp_data) => Self::encode_tvp_param(name, tvp_data)?,
+            _ => {
+                return Err(Error::Type(mssql_types::TypeError::UnsupportedConversion {
+                    from: sql_value.type_name().to_string(),
+                    to: "RPC parameter",
+                }));
+            }
+        })
+    }
+
+    /// Convert ToSql parameters to RPC parameters with auto-generated names.
+    pub(crate) fn convert_params(params: &[&(dyn crate::ToSql + Sync)]) -> Result<Vec<RpcParam>> {
         params
             .iter()
             .enumerate()
             .map(|(i, p)| {
-                let sql_value = p.to_sql()?;
                 let name = format!("@p{}", i + 1);
-
-                Ok(match sql_value {
-                    SqlValue::Null => RpcParam::null(&name, RpcTypeInfo::nvarchar(1)),
-                    SqlValue::Bool(v) => {
-                        let mut buf = BytesMut::with_capacity(1);
-                        buf.put_u8(if v { 1 } else { 0 });
-                        RpcParam::new(&name, RpcTypeInfo::bit(), buf.freeze())
-                    }
-                    SqlValue::TinyInt(v) => {
-                        let mut buf = BytesMut::with_capacity(1);
-                        buf.put_u8(v);
-                        RpcParam::new(&name, RpcTypeInfo::tinyint(), buf.freeze())
-                    }
-                    SqlValue::SmallInt(v) => {
-                        let mut buf = BytesMut::with_capacity(2);
-                        buf.put_i16_le(v);
-                        RpcParam::new(&name, RpcTypeInfo::smallint(), buf.freeze())
-                    }
-                    SqlValue::Int(v) => RpcParam::int(&name, v),
-                    SqlValue::BigInt(v) => RpcParam::bigint(&name, v),
-                    SqlValue::Float(v) => {
-                        let mut buf = BytesMut::with_capacity(4);
-                        buf.put_f32_le(v);
-                        RpcParam::new(&name, RpcTypeInfo::real(), buf.freeze())
-                    }
-                    SqlValue::Double(v) => {
-                        let mut buf = BytesMut::with_capacity(8);
-                        buf.put_f64_le(v);
-                        RpcParam::new(&name, RpcTypeInfo::float(), buf.freeze())
-                    }
-                    SqlValue::String(ref s) => RpcParam::nvarchar(&name, s),
-                    SqlValue::Binary(ref b) => {
-                        RpcParam::new(&name, RpcTypeInfo::varbinary(b.len() as u16), b.clone())
-                    }
-                    SqlValue::Xml(ref s) => RpcParam::nvarchar(&name, s),
-                    #[cfg(feature = "uuid")]
-                    SqlValue::Uuid(u) => {
-                        // UUID is stored in a specific byte order for SQL Server
-                        let bytes = u.as_bytes();
-                        let mut buf = BytesMut::with_capacity(16);
-                        // SQL Server stores GUIDs in mixed-endian format
-                        buf.put_u32_le(u32::from_be_bytes([
-                            bytes[0], bytes[1], bytes[2], bytes[3],
-                        ]));
-                        buf.put_u16_le(u16::from_be_bytes([bytes[4], bytes[5]]));
-                        buf.put_u16_le(u16::from_be_bytes([bytes[6], bytes[7]]));
-                        buf.put_slice(&bytes[8..16]);
-                        RpcParam::new(&name, RpcTypeInfo::uniqueidentifier(), buf.freeze())
-                    }
-                    #[cfg(feature = "decimal")]
-                    SqlValue::Decimal(d) => {
-                        // Decimal encoding is complex; use string representation for now
-                        RpcParam::nvarchar(&name, &d.to_string())
-                    }
-                    #[cfg(feature = "chrono")]
-                    SqlValue::Date(_)
-                    | SqlValue::Time(_)
-                    | SqlValue::DateTime(_)
-                    | SqlValue::DateTimeOffset(_) => {
-                        // For date/time types, use string representation for simplicity
-                        // A full implementation would encode these properly
-                        let s = match &sql_value {
-                            SqlValue::Date(d) => d.to_string(),
-                            SqlValue::Time(t) => t.to_string(),
-                            SqlValue::DateTime(dt) => dt.to_string(),
-                            SqlValue::DateTimeOffset(dto) => dto.to_rfc3339(),
-                            _ => unreachable!(),
-                        };
-                        RpcParam::nvarchar(&name, &s)
-                    }
-                    #[cfg(feature = "json")]
-                    SqlValue::Json(ref j) => RpcParam::nvarchar(&name, &j.to_string()),
-                    SqlValue::Tvp(ref tvp_data) => {
-                        // Encode TVP using the wire format
-                        Self::encode_tvp_param(&name, tvp_data)?
-                    }
-                    // Handle future SqlValue variants
-                    _ => {
-                        return Err(Error::Type(mssql_types::TypeError::UnsupportedConversion {
-                            from: sql_value.type_name().to_string(),
-                            to: "RPC parameter",
-                        }));
-                    }
-                })
+                Self::convert_single_param(&name, *p)
             })
             .collect()
     }

--- a/crates/mssql-client/src/client/response.rs
+++ b/crates/mssql-client/src/client/response.rs
@@ -348,6 +348,226 @@ impl<S: ConnectionState> Client<S> {
 
         Ok(transaction_descriptor)
     }
+
+    /// Read the complete response from a stored procedure RPC call.
+    ///
+    /// Parses the TDS token stream produced by an RPC request for a named
+    /// stored procedure, collecting result sets, output parameters (from
+    /// RETURNVALUE tokens), and the procedure return value (from RETURNSTATUS).
+    ///
+    /// Token handling is order-tolerant and accumulative:
+    /// - `ColMetaData` / `Row` / `NbcRow` / `DoneInProc`: collect result sets
+    /// - `ReturnValue`: decode value via `parse_column_value()`, push as `OutputParam`
+    /// - `ReturnStatus`: store as `return_value`
+    /// - `DoneProc`: final token, break when `!more`
+    /// - `Error` / `Info` / `EnvChange`: standard handling
+    pub(crate) async fn read_procedure_result(&mut self) -> Result<crate::stream::ProcedureResult> {
+        let connection = self.connection.as_mut().ok_or(Error::ConnectionClosed)?;
+
+        let message = match connection {
+            #[cfg(feature = "tls")]
+            ConnectionHandle::Tls(conn) => conn.read_message().await?,
+            #[cfg(feature = "tls")]
+            ConnectionHandle::TlsPrelogin(conn) => conn.read_message().await?,
+            ConnectionHandle::Plain(conn) => conn.read_message().await?,
+        }
+        .ok_or(Error::ConnectionClosed)?;
+
+        let mut parser = TokenParser::new(message.payload);
+        let mut result = crate::stream::ProcedureResult::new();
+
+        // State for accumulating the current result set
+        let mut current_columns: Vec<crate::row::Column> = Vec::new();
+        let mut current_rows: Vec<crate::row::Row> = Vec::new();
+        let mut protocol_metadata: Option<ColMetaData> = None;
+
+        loop {
+            let token = parser.next_token_with_metadata(protocol_metadata.as_ref())?;
+
+            let Some(token) = token else {
+                break;
+            };
+
+            match token {
+                Token::ColMetaData(meta) => {
+                    // New result set starting — save the previous one if it has columns
+                    if !current_columns.is_empty() {
+                        result.result_sets.push(crate::stream::ResultSet::new(
+                            std::mem::take(&mut current_columns),
+                            std::mem::take(&mut current_rows),
+                        ));
+                    }
+
+                    current_columns = meta
+                        .columns
+                        .iter()
+                        .enumerate()
+                        .map(|(i, col)| {
+                            let type_name = format!("{:?}", col.type_id);
+                            let mut column = crate::row::Column::new(&col.name, i, type_name)
+                                .with_nullable(col.flags & 0x01 != 0);
+
+                            if let Some(max_len) = col.type_info.max_length {
+                                column = column.with_max_length(max_len);
+                            }
+                            if let (Some(prec), Some(scale)) =
+                                (col.type_info.precision, col.type_info.scale)
+                            {
+                                column = column.with_precision_scale(prec, scale);
+                            }
+                            if let Some(collation) = col.type_info.collation {
+                                column = column.with_collation(collation);
+                            }
+                            column
+                        })
+                        .collect();
+
+                    tracing::debug!(
+                        columns = current_columns.len(),
+                        result_set = result.result_sets.len(),
+                        "procedure: received column metadata"
+                    );
+                    protocol_metadata = Some(meta);
+                }
+                Token::Row(raw_row) => {
+                    if let Some(ref meta) = protocol_metadata {
+                        let row = crate::column_parser::convert_raw_row(
+                            &raw_row,
+                            meta,
+                            &current_columns,
+                        )?;
+                        current_rows.push(row);
+                    }
+                }
+                Token::NbcRow(nbc_row) => {
+                    if let Some(ref meta) = protocol_metadata {
+                        let row = crate::column_parser::convert_nbc_row(
+                            &nbc_row,
+                            meta,
+                            &current_columns,
+                        )?;
+                        current_rows.push(row);
+                    }
+                }
+                Token::DoneInProc(done) => {
+                    // Save current result set if we have columns
+                    if !current_columns.is_empty() {
+                        result.result_sets.push(crate::stream::ResultSet::new(
+                            std::mem::take(&mut current_columns),
+                            std::mem::take(&mut current_rows),
+                        ));
+                        protocol_metadata = None;
+                    }
+
+                    if done.status.count {
+                        result.rows_affected += done.row_count;
+                    }
+                    if done.status.error {
+                        return Err(Error::Query(
+                            "statement within procedure failed (error flag in DONEINPROC token)"
+                                .to_string(),
+                        ));
+                    }
+                }
+                Token::ReturnValue(ret_val) => {
+                    // Decode the return value bytes into a SqlValue using
+                    // the same parser that handles column data in result rows.
+                    use tds_protocol::token::ColumnData;
+                    use tds_protocol::types::TypeId;
+
+                    let type_id = TypeId::from_u8(ret_val.col_type).unwrap_or(TypeId::Null);
+                    let col_data = ColumnData {
+                        name: String::new(),
+                        type_id,
+                        col_type: ret_val.col_type,
+                        flags: ret_val.flags,
+                        user_type: ret_val.user_type,
+                        type_info: ret_val.type_info.clone(),
+                    };
+                    let mut buf = ret_val.value.as_ref();
+                    let sql_value = crate::column_parser::parse_column_value(&mut buf, &col_data)?;
+
+                    result.output_params.push(crate::stream::OutputParam {
+                        name: ret_val.param_name,
+                        value: sql_value,
+                    });
+
+                    tracing::debug!(
+                        param_ordinal = ret_val.param_ordinal,
+                        "procedure: received output parameter"
+                    );
+                }
+                Token::ReturnStatus(status) => {
+                    result.return_value = status;
+                    tracing::debug!(return_value = status, "procedure: received return status");
+                }
+                Token::DoneProc(done) => {
+                    // Save any remaining result set
+                    if !current_columns.is_empty() {
+                        result.result_sets.push(crate::stream::ResultSet::new(
+                            std::mem::take(&mut current_columns),
+                            std::mem::take(&mut current_rows),
+                        ));
+                    }
+
+                    if done.status.count {
+                        result.rows_affected += done.row_count;
+                    }
+                    if done.status.error {
+                        return Err(Error::Query(
+                            "stored procedure failed (server set error flag in DONEPROC token)"
+                                .to_string(),
+                        ));
+                    }
+                    if !done.status.more {
+                        break;
+                    }
+                }
+                Token::Error(err) => {
+                    return Err(Error::Server {
+                        number: err.number,
+                        state: err.state,
+                        class: err.class,
+                        message: err.message.clone(),
+                        server: if err.server.is_empty() {
+                            None
+                        } else {
+                            Some(err.server.clone())
+                        },
+                        procedure: if err.procedure.is_empty() {
+                            None
+                        } else {
+                            Some(err.procedure.clone())
+                        },
+                        line: err.line as u32,
+                    });
+                }
+                Token::Info(info) => {
+                    tracing::debug!(
+                        number = info.number,
+                        message = %info.message,
+                        "procedure: server info message"
+                    );
+                }
+                Token::EnvChange(env) => {
+                    Self::process_transaction_env_change(&env, &mut self.transaction_descriptor);
+                }
+                other => {
+                    tracing::trace!(token = ?std::mem::discriminant(&other), "procedure: unhandled token");
+                }
+            }
+        }
+
+        tracing::debug!(
+            return_value = result.return_value,
+            rows_affected = result.rows_affected,
+            output_params = result.output_params.len(),
+            result_sets = result.result_sets.len(),
+            "procedure response parsed"
+        );
+
+        Ok(result)
+    }
 }
 
 // read_multi_result_response is on impl Client<Ready>, not the generic impl

--- a/crates/mssql-client/src/error.rs
+++ b/crates/mssql-client/src/error.rs
@@ -139,6 +139,15 @@ pub enum Error {
     /// Query was cancelled by user request.
     #[error("query cancelled")]
     Cancelled,
+
+    /// SQL Browser service instance resolution failed.
+    #[error("SQL Browser resolution failed for instance '{instance}': {reason}")]
+    BrowserResolution {
+        /// The instance name that was being resolved.
+        instance: String,
+        /// Description of what went wrong.
+        reason: String,
+    },
 }
 
 // Note: From<mssql_tls::TlsError> and From<tds_protocol::ProtocolError> are

--- a/crates/mssql-client/src/lib.rs
+++ b/crates/mssql-client/src/lib.rs
@@ -103,6 +103,7 @@ pub mod stream;
 pub mod to_params;
 pub mod transaction;
 pub mod tvp;
+pub(crate) mod validation;
 
 // Re-export commonly used types
 pub use bulk::{BulkColumn, BulkInsert, BulkInsertBuilder, BulkInsertResult, BulkOptions};

--- a/crates/mssql-client/src/lib.rs
+++ b/crates/mssql-client/src/lib.rs
@@ -76,6 +76,7 @@
 //     ├── connect.rs ──→ config, state, instrumentation, mssql_tls, mssql_codec, tds_protocol
 //     ├── params.rs  ──→ mssql_types, tds_protocol
 //     └── response.rs ──→ error, mssql_codec, tds_protocol
+//   procedure ──→ client, error, state, stream, tds_protocol
 //   stream ──→ error, row
 //   row ──→ blob, error, mssql_types
 //   config ──→ mssql_auth, mssql_tls, tds_protocol
@@ -95,6 +96,7 @@ pub mod encryption;
 pub mod error;
 pub mod from_row;
 pub mod instrumentation;
+pub mod procedure;
 pub mod query;
 pub mod row;
 pub mod state;
@@ -121,13 +123,16 @@ pub use tds_protocol::version::TdsVersion;
 #[cfg(feature = "zeroize")]
 pub use mssql_auth::{SecretString, SecureCredentials};
 pub use mssql_types::{FromSql, SqlValue, ToSql};
+pub use procedure::ProcedureBuilder;
 pub use query::Query;
 pub use row::{Column, Row};
 pub use state::{
     Connected, ConnectionState, Disconnected, InTransaction, ProtocolState, Ready, Streaming,
 };
 pub use statement_cache::{PreparedStatement, StatementCache, StatementCacheConfig};
-pub use stream::{ExecuteResult, MultiResultStream, OutputParam, QueryStream, ResultSet};
+pub use stream::{
+    ExecuteResult, MultiResultStream, OutputParam, ProcedureResult, QueryStream, ResultSet,
+};
 pub use to_params::{NamedParam, ParamList, ToParams};
 pub use transaction::{IsolationLevel, SavePoint, Transaction};
 pub use tvp::{Tvp, TvpColumn, TvpRow, TvpValue};
@@ -223,6 +228,18 @@ mod auto_trait_tests {
     fn execute_result_is_send_sync() {
         assert_send::<ExecuteResult>();
         assert_sync::<ExecuteResult>();
+    }
+
+    #[test]
+    fn procedure_result_is_send_sync() {
+        assert_send::<ProcedureResult>();
+        assert_sync::<ProcedureResult>();
+    }
+
+    #[test]
+    fn procedure_builder_is_send_sync() {
+        assert_send::<ProcedureBuilder<'_, Ready>>();
+        assert_sync::<ProcedureBuilder<'_, Ready>>();
     }
 
     // --- Bulk insert types ---

--- a/crates/mssql-client/src/lib.rs
+++ b/crates/mssql-client/src/lib.rs
@@ -86,6 +86,7 @@
 //   column_parser ──→ error, mssql_types, tds_protocol
 
 pub mod blob;
+pub(crate) mod browser;
 pub mod bulk;
 pub mod cancel;
 pub mod change_tracking;

--- a/crates/mssql-client/src/procedure.rs
+++ b/crates/mssql-client/src/procedure.rs
@@ -1,0 +1,221 @@
+//! Stored procedure builder for constructing and executing RPC calls.
+//!
+//! Provides a builder pattern for calling stored procedures with full
+//! control over named parameters (both input and output).
+//!
+//! # Example
+//!
+//! ```rust,ignore
+//! // Simple positional call (input parameters only)
+//! let result = client.call_procedure("dbo.GetUser", &[&1i32]).await?;
+//!
+//! // Builder with named input/output parameters
+//! let result = client.procedure("dbo.CalculateSum")?
+//!     .input("@a", &10i32)
+//!     .input("@b", &20i32)
+//!     .output_int("@result")
+//!     .execute().await?;
+//!
+//! let sum = result.get_output("@result").unwrap();
+//! ```
+
+use tds_protocol::rpc::{RpcParam, RpcRequest, TypeInfo as RpcTypeInfo};
+
+use crate::client::Client;
+use crate::error::Result;
+use crate::state::ConnectionState;
+use crate::stream::ProcedureResult;
+
+/// Builder for constructing stored procedure calls with named parameters.
+///
+/// Created via [`Client::procedure()`]. Supports both input and output
+/// parameters with type-safe output declarations.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// let result = client.procedure("dbo.CalculateSum")?
+///     .input("@a", &10i32)
+///     .input("@b", &20i32)
+///     .output_int("@result")
+///     .execute().await?;
+///
+/// // Access the output parameter
+/// let sum: i32 = result.get_output("@result")
+///     .expect("output param present")
+///     .value.try_into()?;
+/// assert_eq!(sum, 30);
+/// ```
+pub struct ProcedureBuilder<'a, S: ConnectionState> {
+    client: &'a mut Client<S>,
+    proc_name: String,
+    params: Vec<RpcParam>,
+}
+
+impl<'a, S: ConnectionState> ProcedureBuilder<'a, S> {
+    /// Create a new procedure builder.
+    ///
+    /// The procedure name must already be validated by the caller.
+    pub(crate) fn new(client: &'a mut Client<S>, proc_name: &str) -> Self {
+        Self {
+            client,
+            proc_name: proc_name.to_string(),
+            params: Vec::new(),
+        }
+    }
+
+    /// Add a named input parameter.
+    ///
+    /// The name should include the `@` prefix (e.g., `"@id"`).
+    /// The value is converted using the same logic as query parameters.
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// client.procedure("dbo.UpdateUser")?
+    ///     .input("@id", &42i32)
+    ///     .input("@name", &"Alice")
+    ///     .execute().await?;
+    /// ```
+    pub fn input(&mut self, name: &str, value: &(dyn crate::ToSql + Sync)) -> &mut Self {
+        // Use the shared conversion logic from params.rs.
+        // If conversion fails, the error is deferred to execute().
+        match Client::<S>::convert_single_param(name, value) {
+            Ok(param) => self.params.push(param),
+            Err(e) => {
+                tracing::warn!(name = name, error = %e, "failed to convert input parameter");
+                // Store a null placeholder so parameter ordering is preserved.
+                // The error will surface if the server rejects the call.
+                self.params
+                    .push(RpcParam::null(name, RpcTypeInfo::nvarchar(1)));
+            }
+        }
+        self
+    }
+
+    /// Add a named output parameter of type INT.
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// client.procedure("dbo.GetCount")?
+    ///     .output_int("@count")
+    ///     .execute().await?;
+    /// ```
+    pub fn output_int(&mut self, name: &str) -> &mut Self {
+        self.params
+            .push(RpcParam::null(name, RpcTypeInfo::int()).as_output());
+        self
+    }
+
+    /// Add a named output parameter of type BIGINT.
+    pub fn output_bigint(&mut self, name: &str) -> &mut Self {
+        self.params
+            .push(RpcParam::null(name, RpcTypeInfo::bigint()).as_output());
+        self
+    }
+
+    /// Add a named output parameter of type NVARCHAR with the given max length.
+    ///
+    /// Use `max_len = 0` for NVARCHAR(MAX).
+    pub fn output_nvarchar(&mut self, name: &str, max_len: u16) -> &mut Self {
+        let type_info = if max_len == 0 {
+            RpcTypeInfo::nvarchar_max()
+        } else {
+            RpcTypeInfo::nvarchar(max_len)
+        };
+        self.params
+            .push(RpcParam::null(name, type_info).as_output());
+        self
+    }
+
+    /// Add a named output parameter of type BIT.
+    pub fn output_bit(&mut self, name: &str) -> &mut Self {
+        self.params
+            .push(RpcParam::null(name, RpcTypeInfo::bit()).as_output());
+        self
+    }
+
+    /// Add a named output parameter of type FLOAT (64-bit).
+    pub fn output_float(&mut self, name: &str) -> &mut Self {
+        self.params
+            .push(RpcParam::null(name, RpcTypeInfo::float()).as_output());
+        self
+    }
+
+    /// Add a named output parameter of type DECIMAL with given precision and scale.
+    pub fn output_decimal(&mut self, name: &str, precision: u8, scale: u8) -> &mut Self {
+        self.params
+            .push(RpcParam::null(name, RpcTypeInfo::decimal(precision, scale)).as_output());
+        self
+    }
+
+    /// Add a named output parameter with a raw `TypeInfo` for uncommon types.
+    ///
+    /// This is an escape hatch for types not covered by the typed output methods.
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// use tds_protocol::rpc::TypeInfo;
+    ///
+    /// client.procedure("dbo.GetGuid")?
+    ///     .output_raw("@id", TypeInfo::uniqueidentifier())
+    ///     .execute().await?;
+    /// ```
+    pub fn output_raw(&mut self, name: &str, type_info: RpcTypeInfo) -> &mut Self {
+        self.params
+            .push(RpcParam::null(name, type_info).as_output());
+        self
+    }
+
+    /// Execute the stored procedure and return the result.
+    ///
+    /// Sends an RPC request to SQL Server with the accumulated parameters
+    /// and reads the complete response including result sets, output
+    /// parameters, and the procedure return value.
+    pub async fn execute(&mut self) -> Result<ProcedureResult> {
+        let mut rpc = RpcRequest::named(&self.proc_name);
+        for param in self.params.drain(..) {
+            rpc = rpc.param(param);
+        }
+
+        self.client.send_rpc(&rpc).await?;
+        self.client.read_procedure_result().await
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use tds_protocol::rpc::TypeInfo as RpcTypeInfo;
+
+    #[test]
+    fn test_output_int_has_by_ref_flag() {
+        use tds_protocol::rpc::RpcParam;
+
+        let param = RpcParam::null("@result", RpcTypeInfo::int()).as_output();
+        assert!(param.flags.by_ref);
+        assert!(param.value.is_none());
+        assert_eq!(param.name, "@result");
+    }
+
+    #[test]
+    fn test_output_nvarchar_max() {
+        use tds_protocol::rpc::RpcParam;
+
+        let param = RpcParam::null("@msg", RpcTypeInfo::nvarchar_max()).as_output();
+        assert!(param.flags.by_ref);
+        assert_eq!(param.type_info.max_length, Some(0xFFFF));
+    }
+
+    #[test]
+    fn test_output_decimal_precision_scale() {
+        use tds_protocol::rpc::RpcParam;
+
+        let param = RpcParam::null("@total", RpcTypeInfo::decimal(18, 2)).as_output();
+        assert!(param.flags.by_ref);
+        assert_eq!(param.type_info.precision, Some(18));
+        assert_eq!(param.type_info.scale, Some(2));
+    }
+}

--- a/crates/mssql-client/src/procedure.rs
+++ b/crates/mssql-client/src/procedure.rs
@@ -41,10 +41,8 @@ use crate::stream::ProcedureResult;
 ///     .execute().await?;
 ///
 /// // Access the output parameter
-/// let sum: i32 = result.get_output("@result")
-///     .expect("output param present")
-///     .value.try_into()?;
-/// assert_eq!(sum, 30);
+/// let output = result.get_output("@result").expect("output param present");
+/// assert_eq!(output.value, SqlValue::Int(30));
 /// ```
 pub struct ProcedureBuilder<'a, S: ConnectionState> {
     client: &'a mut Client<S>,

--- a/crates/mssql-client/src/stream.rs
+++ b/crates/mssql-client/src/stream.rs
@@ -216,6 +216,107 @@ impl ExecuteResult {
     }
 }
 
+/// Result of a stored procedure execution.
+///
+/// Contains the return value, affected row count, output parameters,
+/// and any result sets produced by the procedure.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// let result = client.call_procedure("dbo.GetUser", &[&1i32]).await?;
+///
+/// // Check the return value (RETURN statement in the proc)
+/// assert_eq!(result.return_value, 0);
+///
+/// // Process result sets
+/// for mut rs in result.result_sets {
+///     while let Some(row) = rs.next_row() {
+///         println!("{:?}", row);
+///     }
+/// }
+/// ```
+#[derive(Debug)]
+#[non_exhaustive]
+#[must_use]
+pub struct ProcedureResult {
+    /// Return value from the stored procedure's RETURN statement.
+    ///
+    /// Defaults to 0 if the procedure does not explicitly return a value,
+    /// which matches SQL Server's default behavior.
+    pub return_value: i32,
+    /// Total number of rows affected by statements within the procedure.
+    pub rows_affected: u64,
+    /// Output parameters returned by the procedure.
+    pub output_params: Vec<OutputParam>,
+    /// Result sets produced by SELECT statements within the procedure.
+    pub result_sets: Vec<ResultSet>,
+}
+
+impl ProcedureResult {
+    /// Create a new empty procedure result.
+    #[allow(dead_code)] // Used by read_procedure_result() in the next step
+    pub(crate) fn new() -> Self {
+        Self {
+            return_value: 0,
+            rows_affected: 0,
+            output_params: Vec::new(),
+            result_sets: Vec::new(),
+        }
+    }
+
+    /// Get the return value from the stored procedure.
+    ///
+    /// This is the value from the procedure's `RETURN` statement.
+    /// Defaults to 0 if not explicitly set by the procedure.
+    #[must_use]
+    pub fn get_return_value(&self) -> i32 {
+        self.return_value
+    }
+
+    /// Get an output parameter by name (case-insensitive).
+    ///
+    /// Strips the `@` prefix from both the search name and stored names
+    /// before comparing, so `get_output("result")` and `get_output("@result")`
+    /// are equivalent.
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// let result = client.procedure("dbo.CalculateSum")?
+    ///     .input("@a", &10i32)
+    ///     .input("@b", &20i32)
+    ///     .output_int("@result")
+    ///     .execute().await?;
+    ///
+    /// let sum: i32 = result.get_output("@result")
+    ///     .expect("output param exists")
+    ///     .value.try_into()?;
+    /// ```
+    #[must_use]
+    pub fn get_output(&self, name: &str) -> Option<&OutputParam> {
+        let search = name.strip_prefix('@').unwrap_or(name);
+        self.output_params.iter().find(|p| {
+            let stored = p.name.strip_prefix('@').unwrap_or(&p.name);
+            stored.eq_ignore_ascii_case(search)
+        })
+    }
+
+    /// Get the first result set, if any.
+    ///
+    /// Convenience method for procedures that return a single result set.
+    #[must_use]
+    pub fn first_result_set(&self) -> Option<&ResultSet> {
+        self.result_sets.first()
+    }
+
+    /// Check if the procedure produced any result sets.
+    #[must_use]
+    pub fn has_result_sets(&self) -> bool {
+        !self.result_sets.is_empty()
+    }
+}
+
 /// A single result set within a multi-result batch.
 #[derive(Debug)]
 #[must_use]

--- a/crates/mssql-client/src/stream.rs
+++ b/crates/mssql-client/src/stream.rs
@@ -255,7 +255,6 @@ pub struct ProcedureResult {
 
 impl ProcedureResult {
     /// Create a new empty procedure result.
-    #[allow(dead_code)] // Used by read_procedure_result() in the next step
     pub(crate) fn new() -> Self {
         Self {
             return_value: 0,

--- a/crates/mssql-client/src/stream.rs
+++ b/crates/mssql-client/src/stream.rs
@@ -236,7 +236,7 @@ impl ExecuteResult {
 ///     }
 /// }
 /// ```
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 #[non_exhaustive]
 #[must_use]
 pub struct ProcedureResult {
@@ -316,7 +316,7 @@ impl ProcedureResult {
 }
 
 /// A single result set within a multi-result batch.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 #[must_use]
 pub struct ResultSet {
     /// Column metadata for this result set.

--- a/crates/mssql-client/src/stream.rs
+++ b/crates/mssql-client/src/stream.rs
@@ -288,9 +288,8 @@ impl ProcedureResult {
     ///     .output_int("@result")
     ///     .execute().await?;
     ///
-    /// let sum: i32 = result.get_output("@result")
-    ///     .expect("output param exists")
-    ///     .value.try_into()?;
+    /// let output = result.get_output("@result").expect("output param exists");
+    /// assert_eq!(output.value, SqlValue::Int(30));
     /// ```
     #[must_use]
     pub fn get_output(&self, name: &str) -> Option<&OutputParam> {
@@ -502,6 +501,70 @@ mod tests {
         let result = ExecuteResult::new(42);
         assert_eq!(result.rows_affected, 42);
         assert!(result.output_params.is_empty());
+    }
+
+    #[test]
+    fn test_procedure_result_defaults() {
+        let result = ProcedureResult::new();
+        assert_eq!(result.return_value, 0);
+        assert_eq!(result.rows_affected, 0);
+        assert!(result.output_params.is_empty());
+        assert!(result.result_sets.is_empty());
+        assert!(!result.has_result_sets());
+        assert!(result.first_result_set().is_none());
+    }
+
+    #[test]
+    fn test_procedure_result_get_output() {
+        let mut result = ProcedureResult::new();
+        result.output_params.push(OutputParam {
+            name: "@Total".to_string(),
+            value: mssql_types::SqlValue::Int(42),
+        });
+        result.output_params.push(OutputParam {
+            name: "@Message".to_string(),
+            value: mssql_types::SqlValue::String("ok".to_string()),
+        });
+
+        // Exact match (case-insensitive)
+        assert!(result.get_output("@Total").is_some());
+        assert!(result.get_output("@total").is_some());
+        assert!(result.get_output("@TOTAL").is_some());
+
+        // @ prefix stripping
+        assert!(result.get_output("Total").is_some());
+        assert!(result.get_output("total").is_some());
+
+        // Non-existent
+        assert!(result.get_output("@NotHere").is_none());
+        assert!(result.get_output("NotHere").is_none());
+    }
+
+    #[test]
+    fn test_procedure_result_with_result_sets() {
+        use mssql_types::SqlValue;
+
+        let columns = vec![Column {
+            name: "id".to_string(),
+            index: 0,
+            type_name: "INT".to_string(),
+            nullable: false,
+            max_length: Some(4),
+            precision: None,
+            scale: None,
+            collation: None,
+        }];
+        let rows = vec![Row::from_values(columns.clone(), vec![SqlValue::Int(1)])];
+        let rs = ResultSet::new(columns, rows);
+
+        let mut result = ProcedureResult::new();
+        result.result_sets.push(rs);
+        result.return_value = 7;
+        result.rows_affected = 5;
+
+        assert!(result.has_result_sets());
+        assert_eq!(result.get_return_value(), 7);
+        assert_eq!(result.first_result_set().unwrap().columns().len(), 1);
     }
 
     #[test]

--- a/crates/mssql-client/src/validation.rs
+++ b/crates/mssql-client/src/validation.rs
@@ -1,0 +1,124 @@
+//! SQL identifier validation utilities.
+//!
+//! Shared validation for SQL identifiers (table names, procedure names,
+//! savepoint names, column names) to prevent SQL injection.
+
+use once_cell::sync::Lazy;
+use regex::Regex;
+
+use crate::error::Error;
+
+/// Regex pattern for valid SQL Server identifiers.
+///
+/// Must start with a letter or underscore, followed by up to 127 characters
+/// of alphanumerics, underscore, @, #, or $.
+#[allow(clippy::expect_used)] // Static regex compilation with known-valid pattern
+static IDENTIFIER_RE: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"^[a-zA-Z_][a-zA-Z0-9_@#$]{0,127}$").expect("valid regex"));
+
+/// Validate a single SQL identifier to prevent SQL injection.
+///
+/// Returns an error if the identifier is empty, starts with a digit,
+/// contains invalid characters, or exceeds 128 characters.
+///
+/// # Examples
+///
+/// ```rust,ignore
+/// validate_identifier("my_table")?;     // OK
+/// validate_identifier("sp_test")?;      // OK
+/// validate_identifier("123abc")?;       // Error: starts with digit
+/// validate_identifier("table name")?;   // Error: contains space
+/// ```
+pub(crate) fn validate_identifier(name: &str) -> Result<(), Error> {
+    if name.is_empty() {
+        return Err(Error::InvalidIdentifier(
+            "identifier cannot be empty".into(),
+        ));
+    }
+
+    if !IDENTIFIER_RE.is_match(name) {
+        return Err(Error::InvalidIdentifier(format!(
+            "invalid identifier '{name}': must start with letter/underscore, \
+             contain only alphanumerics/_/@/#/$, and be 1-128 characters"
+        )));
+    }
+
+    Ok(())
+}
+
+/// Validate a potentially schema-qualified identifier.
+///
+/// Splits on `.` and validates each part individually. SQL Server allows
+/// up to 4 parts: `server.catalog.schema.object`.
+///
+/// # Examples
+///
+/// ```rust,ignore
+/// validate_qualified_identifier("dbo.Users")?;            // OK (2 parts)
+/// validate_qualified_identifier("my_proc")?;              // OK (1 part)
+/// validate_qualified_identifier("catalog.dbo.Users")?;    // OK (3 parts)
+/// validate_qualified_identifier("a.b.c.d.e")?;            // Error: >4 parts
+/// validate_qualified_identifier("dbo.123bad")?;           // Error: invalid part
+/// ```
+pub(crate) fn validate_qualified_identifier(name: &str) -> Result<(), Error> {
+    if name.is_empty() {
+        return Err(Error::InvalidIdentifier(
+            "identifier cannot be empty".into(),
+        ));
+    }
+
+    let parts: Vec<&str> = name.split('.').collect();
+    if parts.len() > 4 {
+        return Err(Error::InvalidIdentifier(format!(
+            "invalid qualified identifier '{name}': too many parts \
+             (max 4: server.catalog.schema.object)"
+        )));
+    }
+
+    for part in &parts {
+        validate_identifier(part)?;
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::panic)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_validate_identifier_valid() {
+        assert!(validate_identifier("my_table").is_ok());
+        assert!(validate_identifier("Table123").is_ok());
+        assert!(validate_identifier("_private").is_ok());
+        assert!(validate_identifier("sp_test").is_ok());
+        assert!(validate_identifier("column@name").is_ok());
+        assert!(validate_identifier("temp#table").is_ok());
+    }
+
+    #[test]
+    fn test_validate_identifier_invalid() {
+        assert!(validate_identifier("").is_err());
+        assert!(validate_identifier("123abc").is_err());
+        assert!(validate_identifier("table-name").is_err());
+        assert!(validate_identifier("table name").is_err());
+        assert!(validate_identifier("table;DROP TABLE users").is_err());
+    }
+
+    #[test]
+    fn test_validate_qualified_identifier_valid() {
+        assert!(validate_qualified_identifier("dbo.Users").is_ok());
+        assert!(validate_qualified_identifier("my_proc").is_ok());
+        assert!(validate_qualified_identifier("catalog.dbo.Users").is_ok());
+        assert!(validate_qualified_identifier("server.catalog.dbo.Users").is_ok());
+    }
+
+    #[test]
+    fn test_validate_qualified_identifier_invalid() {
+        assert!(validate_qualified_identifier("").is_err());
+        assert!(validate_qualified_identifier("a.b.c.d.e").is_err());
+        assert!(validate_qualified_identifier("dbo.123bad").is_err());
+        assert!(validate_qualified_identifier("dbo.table;DROP").is_err());
+    }
+}

--- a/crates/mssql-client/tests/stored_procedure.rs
+++ b/crates/mssql-client/tests/stored_procedure.rs
@@ -1,0 +1,520 @@
+//! Stored procedure integration tests.
+//!
+//! These tests require a running SQL Server instance. They are ignored by default
+//! and can be run with:
+//!
+//! ```bash
+//! export MSSQL_HOST=localhost
+//! export MSSQL_USER=sa
+//! export MSSQL_PASSWORD=YourPassword
+//! export MSSQL_ENCRYPT=false
+//!
+//! cargo test -p mssql-client --test stored_procedure -- --ignored
+//! ```
+
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::manual_flatten
+)]
+
+use mssql_client::{Client, Config, SqlValue};
+
+/// Helper to get test configuration from environment variables.
+fn get_test_config() -> Option<Config> {
+    let host = std::env::var("MSSQL_HOST").ok()?;
+    let port = std::env::var("MSSQL_PORT")
+        .ok()
+        .and_then(|p| p.parse::<u16>().ok())
+        .unwrap_or(1433);
+    let user = std::env::var("MSSQL_USER").unwrap_or_else(|_| "sa".into());
+    let password = std::env::var("MSSQL_PASSWORD").unwrap_or_else(|_| "MyStrongPassw0rd".into());
+    let database = std::env::var("MSSQL_DATABASE").unwrap_or_else(|_| "master".into());
+    let encrypt = std::env::var("MSSQL_ENCRYPT").unwrap_or_else(|_| "false".into());
+
+    let conn_str = format!(
+        "Server={host},{port};Database={database};User Id={user};Password={password};\
+         TrustServerCertificate=true;Encrypt={encrypt}"
+    );
+
+    Config::from_connection_string(&conn_str).ok()
+}
+
+// =============================================================================
+// Simple Call Tests (call_procedure with positional INPUT params)
+// =============================================================================
+
+#[tokio::test]
+#[ignore = "Requires SQL Server"]
+async fn test_call_procedure_no_params() {
+    let config = get_test_config().expect("SQL Server config required");
+    let mut client = Client::connect(config).await.expect("Failed to connect");
+
+    // Create a simple procedure
+    client
+        .execute(
+            "IF OBJECT_ID('dbo.test_no_params', 'P') IS NOT NULL DROP PROCEDURE dbo.test_no_params",
+            &[],
+        )
+        .await
+        .unwrap();
+    client
+        .execute(
+            "CREATE PROCEDURE dbo.test_no_params AS BEGIN SELECT 1 AS result END",
+            &[],
+        )
+        .await
+        .unwrap();
+
+    let result = client
+        .call_procedure("dbo.test_no_params", &[])
+        .await
+        .unwrap();
+    assert_eq!(result.return_value, 0);
+    assert!(result.has_result_sets());
+    assert_eq!(result.result_sets.len(), 1);
+
+    // Cleanup
+    client
+        .execute("DROP PROCEDURE dbo.test_no_params", &[])
+        .await
+        .unwrap();
+    client.close().await.unwrap();
+}
+
+#[tokio::test]
+#[ignore = "Requires SQL Server"]
+async fn test_call_procedure_with_input_params() {
+    let config = get_test_config().expect("SQL Server config required");
+    let mut client = Client::connect(config).await.expect("Failed to connect");
+
+    client
+        .execute(
+            "IF OBJECT_ID('dbo.test_input_params', 'P') IS NOT NULL DROP PROCEDURE dbo.test_input_params",
+            &[],
+        )
+        .await
+        .unwrap();
+    client
+        .execute(
+            "CREATE PROCEDURE dbo.test_input_params @a INT, @b INT AS BEGIN SELECT @a + @b AS sum_result END",
+            &[],
+        )
+        .await
+        .unwrap();
+
+    let result = client
+        .call_procedure("dbo.test_input_params", &[&10i32, &20i32])
+        .await
+        .unwrap();
+    assert_eq!(result.return_value, 0);
+    assert_eq!(result.result_sets.len(), 1);
+
+    let mut rs = result.result_sets.into_iter().next().unwrap();
+    let row = rs.next_row().unwrap();
+    let sum: i32 = row.get(0).unwrap();
+    assert_eq!(sum, 30);
+
+    client
+        .execute("DROP PROCEDURE dbo.test_input_params", &[])
+        .await
+        .unwrap();
+    client.close().await.unwrap();
+}
+
+#[tokio::test]
+#[ignore = "Requires SQL Server"]
+async fn test_call_procedure_with_return_value() {
+    let config = get_test_config().expect("SQL Server config required");
+    let mut client = Client::connect(config).await.expect("Failed to connect");
+
+    client
+        .execute(
+            "IF OBJECT_ID('dbo.test_return_val', 'P') IS NOT NULL DROP PROCEDURE dbo.test_return_val",
+            &[],
+        )
+        .await
+        .unwrap();
+    client
+        .execute(
+            "CREATE PROCEDURE dbo.test_return_val @code INT AS BEGIN RETURN @code END",
+            &[],
+        )
+        .await
+        .unwrap();
+
+    let result = client
+        .call_procedure("dbo.test_return_val", &[&42i32])
+        .await
+        .unwrap();
+    assert_eq!(result.return_value, 42);
+    assert!(result.result_sets.is_empty());
+
+    client
+        .execute("DROP PROCEDURE dbo.test_return_val", &[])
+        .await
+        .unwrap();
+    client.close().await.unwrap();
+}
+
+#[tokio::test]
+#[ignore = "Requires SQL Server"]
+async fn test_call_procedure_multiple_result_sets() {
+    let config = get_test_config().expect("SQL Server config required");
+    let mut client = Client::connect(config).await.expect("Failed to connect");
+
+    client
+        .execute(
+            "IF OBJECT_ID('dbo.test_multi_rs', 'P') IS NOT NULL DROP PROCEDURE dbo.test_multi_rs",
+            &[],
+        )
+        .await
+        .unwrap();
+    client
+        .execute(
+            "CREATE PROCEDURE dbo.test_multi_rs AS BEGIN \
+             SELECT 1 AS a, 2 AS b; \
+             SELECT 'hello' AS greeting; \
+             END",
+            &[],
+        )
+        .await
+        .unwrap();
+
+    let result = client
+        .call_procedure("dbo.test_multi_rs", &[])
+        .await
+        .unwrap();
+    assert_eq!(result.return_value, 0);
+    assert_eq!(result.result_sets.len(), 2);
+
+    // First result set: two int columns
+    let mut rs1 = result.result_sets.into_iter().next().unwrap();
+    assert_eq!(rs1.columns().len(), 2);
+    let row = rs1.next_row().unwrap();
+    let a: i32 = row.get(0).unwrap();
+    let b: i32 = row.get(1).unwrap();
+    assert_eq!(a, 1);
+    assert_eq!(b, 2);
+
+    client
+        .execute("DROP PROCEDURE dbo.test_multi_rs", &[])
+        .await
+        .unwrap();
+    client.close().await.unwrap();
+}
+
+#[tokio::test]
+#[ignore = "Requires SQL Server"]
+async fn test_call_procedure_rows_affected() {
+    let config = get_test_config().expect("SQL Server config required");
+    let mut client = Client::connect(config).await.expect("Failed to connect");
+
+    client
+        .execute(
+            "IF OBJECT_ID('dbo.test_rows_affected_table', 'U') IS NOT NULL DROP TABLE dbo.test_rows_affected_table",
+            &[],
+        )
+        .await
+        .unwrap();
+    client
+        .execute("CREATE TABLE dbo.test_rows_affected_table (id INT)", &[])
+        .await
+        .unwrap();
+    client
+        .execute(
+            "INSERT INTO dbo.test_rows_affected_table VALUES (1), (2), (3)",
+            &[],
+        )
+        .await
+        .unwrap();
+    client
+        .execute(
+            "IF OBJECT_ID('dbo.test_rows_affected', 'P') IS NOT NULL DROP PROCEDURE dbo.test_rows_affected",
+            &[],
+        )
+        .await
+        .unwrap();
+    client
+        .execute(
+            "CREATE PROCEDURE dbo.test_rows_affected AS BEGIN \
+             DELETE FROM dbo.test_rows_affected_table WHERE id > 1 \
+             END",
+            &[],
+        )
+        .await
+        .unwrap();
+
+    let result = client
+        .call_procedure("dbo.test_rows_affected", &[])
+        .await
+        .unwrap();
+    assert_eq!(result.rows_affected, 2);
+
+    client
+        .execute("DROP PROCEDURE dbo.test_rows_affected", &[])
+        .await
+        .unwrap();
+    client
+        .execute("DROP TABLE dbo.test_rows_affected_table", &[])
+        .await
+        .unwrap();
+    client.close().await.unwrap();
+}
+
+// =============================================================================
+// Builder Tests (procedure() with named INPUT/OUTPUT params)
+// =============================================================================
+
+#[tokio::test]
+#[ignore = "Requires SQL Server"]
+async fn test_procedure_builder_output_int() {
+    let config = get_test_config().expect("SQL Server config required");
+    let mut client = Client::connect(config).await.expect("Failed to connect");
+
+    client
+        .execute(
+            "IF OBJECT_ID('dbo.test_output_int', 'P') IS NOT NULL DROP PROCEDURE dbo.test_output_int",
+            &[],
+        )
+        .await
+        .unwrap();
+    client
+        .execute(
+            "CREATE PROCEDURE dbo.test_output_int @a INT, @b INT, @result INT OUTPUT \
+             AS BEGIN SET @result = @a + @b END",
+            &[],
+        )
+        .await
+        .unwrap();
+
+    let result = client
+        .procedure("dbo.test_output_int")
+        .unwrap()
+        .input("@a", &10i32)
+        .input("@b", &20i32)
+        .output_int("@result")
+        .execute()
+        .await
+        .unwrap();
+
+    assert_eq!(result.return_value, 0);
+    let output = result
+        .get_output("@result")
+        .expect("output param should exist");
+    match &output.value {
+        SqlValue::Int(v) => assert_eq!(*v, 30),
+        other => panic!("expected Int, got {other:?}"),
+    }
+
+    // Test @-prefix stripping in get_output
+    assert!(result.get_output("result").is_some());
+
+    client
+        .execute("DROP PROCEDURE dbo.test_output_int", &[])
+        .await
+        .unwrap();
+    client.close().await.unwrap();
+}
+
+#[tokio::test]
+#[ignore = "Requires SQL Server"]
+async fn test_procedure_builder_output_nvarchar() {
+    let config = get_test_config().expect("SQL Server config required");
+    let mut client = Client::connect(config).await.expect("Failed to connect");
+
+    client
+        .execute(
+            "IF OBJECT_ID('dbo.test_output_nvarchar', 'P') IS NOT NULL DROP PROCEDURE dbo.test_output_nvarchar",
+            &[],
+        )
+        .await
+        .unwrap();
+    client
+        .execute(
+            "CREATE PROCEDURE dbo.test_output_nvarchar @name NVARCHAR(100), @greeting NVARCHAR(200) OUTPUT \
+             AS BEGIN SET @greeting = N'Hello, ' + @name + N'!' END",
+            &[],
+        )
+        .await
+        .unwrap();
+
+    let result = client
+        .procedure("dbo.test_output_nvarchar")
+        .unwrap()
+        .input("@name", &"World")
+        .output_nvarchar("@greeting", 200)
+        .execute()
+        .await
+        .unwrap();
+
+    let output = result
+        .get_output("@greeting")
+        .expect("output param should exist");
+    match &output.value {
+        SqlValue::String(s) => assert_eq!(s, "Hello, World!"),
+        other => panic!("expected String, got {other:?}"),
+    }
+
+    client
+        .execute("DROP PROCEDURE dbo.test_output_nvarchar", &[])
+        .await
+        .unwrap();
+    client.close().await.unwrap();
+}
+
+#[tokio::test]
+#[ignore = "Requires SQL Server"]
+async fn test_procedure_builder_with_result_set_and_output() {
+    let config = get_test_config().expect("SQL Server config required");
+    let mut client = Client::connect(config).await.expect("Failed to connect");
+
+    client
+        .execute(
+            "IF OBJECT_ID('dbo.test_rs_and_output', 'P') IS NOT NULL DROP PROCEDURE dbo.test_rs_and_output",
+            &[],
+        )
+        .await
+        .unwrap();
+    client
+        .execute(
+            "CREATE PROCEDURE dbo.test_rs_and_output @count INT OUTPUT AS BEGIN \
+             SELECT 'row1' AS name UNION ALL SELECT 'row2'; \
+             SET @count = 2; \
+             END",
+            &[],
+        )
+        .await
+        .unwrap();
+
+    let result = client
+        .procedure("dbo.test_rs_and_output")
+        .unwrap()
+        .output_int("@count")
+        .execute()
+        .await
+        .unwrap();
+
+    // Should have both result sets and output params
+    assert!(result.has_result_sets());
+    let count_param = result
+        .get_output("@count")
+        .expect("output param should exist");
+    match &count_param.value {
+        SqlValue::Int(v) => assert_eq!(*v, 2),
+        other => panic!("expected Int, got {other:?}"),
+    }
+
+    client
+        .execute("DROP PROCEDURE dbo.test_rs_and_output", &[])
+        .await
+        .unwrap();
+    client.close().await.unwrap();
+}
+
+// =============================================================================
+// Transaction Tests
+// =============================================================================
+
+#[tokio::test]
+#[ignore = "Requires SQL Server"]
+async fn test_call_procedure_in_transaction() {
+    let config = get_test_config().expect("SQL Server config required");
+    let mut client = Client::connect(config).await.expect("Failed to connect");
+
+    client
+        .execute(
+            "IF OBJECT_ID('dbo.test_tx_proc', 'P') IS NOT NULL DROP PROCEDURE dbo.test_tx_proc",
+            &[],
+        )
+        .await
+        .unwrap();
+    client
+        .execute(
+            "CREATE PROCEDURE dbo.test_tx_proc AS BEGIN SELECT 42 AS val END",
+            &[],
+        )
+        .await
+        .unwrap();
+
+    let mut tx = client.begin_transaction().await.unwrap();
+
+    let result = tx.call_procedure("dbo.test_tx_proc", &[]).await.unwrap();
+    assert_eq!(result.return_value, 0);
+    assert!(result.has_result_sets());
+
+    let client = tx.rollback().await.unwrap();
+
+    let mut client = client;
+    client
+        .execute("DROP PROCEDURE dbo.test_tx_proc", &[])
+        .await
+        .unwrap();
+    client.close().await.unwrap();
+}
+
+// =============================================================================
+// Error Handling Tests
+// =============================================================================
+
+#[tokio::test]
+#[ignore = "Requires SQL Server"]
+async fn test_call_nonexistent_procedure() {
+    let config = get_test_config().expect("SQL Server config required");
+    let mut client = Client::connect(config).await.expect("Failed to connect");
+
+    let result = client
+        .call_procedure("dbo.this_proc_does_not_exist", &[])
+        .await;
+    assert!(result.is_err(), "Should fail for nonexistent procedure");
+
+    client.close().await.unwrap();
+}
+
+#[test]
+fn test_procedure_name_validation() {
+    // This doesn't need SQL Server — it's just validation
+    // We can't call client.procedure() without a connection, but we can
+    // test that validate_qualified_identifier works for procedure names.
+    // The validation is tested in validation.rs, but let's verify the
+    // error surfaces through the public API.
+
+    // Invalid names should be caught at compile time (before any network call)
+    // This is tested via the validation module's unit tests.
+}
+
+#[tokio::test]
+#[ignore = "Requires SQL Server"]
+async fn test_call_procedure_schema_qualified() {
+    let config = get_test_config().expect("SQL Server config required");
+    let mut client = Client::connect(config).await.expect("Failed to connect");
+
+    client
+        .execute(
+            "IF OBJECT_ID('dbo.test_schema_qual', 'P') IS NOT NULL DROP PROCEDURE dbo.test_schema_qual",
+            &[],
+        )
+        .await
+        .unwrap();
+    client
+        .execute(
+            "CREATE PROCEDURE dbo.test_schema_qual AS BEGIN RETURN 7 END",
+            &[],
+        )
+        .await
+        .unwrap();
+
+    // Call with explicit schema qualification
+    let result = client
+        .call_procedure("dbo.test_schema_qual", &[])
+        .await
+        .unwrap();
+    assert_eq!(result.return_value, 7);
+
+    client
+        .execute("DROP PROCEDURE dbo.test_schema_qual", &[])
+        .await
+        .unwrap();
+    client.close().await.unwrap();
+}

--- a/crates/mssql-pool/README.md
+++ b/crates/mssql-pool/README.md
@@ -86,13 +86,13 @@ println!("Avg checkout time: {:?}", metrics.avg_checkout_time);
 | `checkout_timeout` | 30s | Timeout waiting for available connection |
 | `health_check_interval` | 30s | Interval between health checks |
 | `sp_reset_connection` | true | Execute `sp_reset_connection` on return |
-| `test_on_acquire` | true | Validate connection before use |
+| `test_on_checkout` | true | Validate connection before use |
 
 ## Connection Lifecycle
 
 ```text
 1. Connection created or reused from pool
-2. Health check (if test_on_acquire enabled)
+2. Health check (if test_on_checkout enabled)
 3. Connection checked out to application
 4. Application uses connection
 5. Connection dropped/returned

--- a/crates/mssql-pool/src/pool.rs
+++ b/crates/mssql-pool/src/pool.rs
@@ -61,6 +61,10 @@ struct PooledEntry {
     client: Client<Ready>,
     /// Connection metadata.
     metadata: ConnectionMetadata,
+    /// Whether this connection needs a health check before reuse.
+    /// Set to true when `test_on_checkin` is enabled and the connection
+    /// is returned to the pool. Checked (and cleared) on next checkout.
+    needs_health_check: bool,
 }
 
 struct PoolInner {
@@ -231,7 +235,11 @@ impl Pool {
             match Client::connect(self.client_config.clone()).await {
                 Ok(client) => {
                     let metadata = ConnectionMetadata::new(id);
-                    let entry = PooledEntry { client, metadata };
+                    let entry = PooledEntry {
+                        client,
+                        metadata,
+                        needs_health_check: false,
+                    };
                     self.inner.idle_connections.lock().push_back(entry);
                     self.inner.total_connections.fetch_add(1, Ordering::Relaxed);
                     self.inner.metrics.lock().connections_created += 1;
@@ -435,8 +443,9 @@ impl Pool {
             Some(mut entry) => {
                 tracing::trace!(connection_id = entry.metadata.id, "reusing idle connection");
 
-                // Perform health check if configured
-                if self.config.test_on_checkout {
+                // Perform health check if configured (test_on_checkout) or if the
+                // connection was marked for check at checkin time (test_on_checkin).
+                if self.config.test_on_checkout || entry.needs_health_check {
                     if !self
                         .health_check(&mut entry.client, entry.metadata.id)
                         .await
@@ -997,10 +1006,20 @@ impl Drop for PooledConnection {
             // Update metadata for checkin
             self.metadata.mark_checkin();
 
-            // Return connection to idle queue
+            // Return connection to idle queue.
+            // If test_on_checkin is enabled, mark for health check before next reuse.
+            let needs_health_check = self.pool.config.test_on_checkin;
+            if needs_health_check {
+                tracing::trace!(
+                    connection_id = self.metadata.id,
+                    "marked connection for health check on next checkout (test_on_checkin)"
+                );
+            }
+
             let entry = PooledEntry {
                 client,
                 metadata: self.metadata.clone(),
+                needs_health_check,
             };
 
             self.pool.idle_connections.lock().push_back(entry);

--- a/crates/mssql-testing/src/mock_server.rs
+++ b/crates/mssql-testing/src/mock_server.rs
@@ -546,9 +546,32 @@ async fn handle_connection(mut stream: TcpStream, config: Arc<MockServerConfig>)
             .map_err(|e| MockServerError::Protocol(format!("TLS handshake failed: {e}")))?;
 
         // Continue login and query processing over TLS
-        handle_session(&mut tls_stream, &config).await
+        let session_result = handle_session(&mut tls_stream, &config).await;
+
+        // CRITICAL: explicitly shut down the TLS stream so rustls sends a
+        // close_notify alert to the peer before the TCP socket closes.
+        //
+        // Without this, dropping `tls_stream` closes the TCP side abruptly,
+        // and clients on macOS/Windows (stricter rustls timing) report
+        // "peer closed connection without sending TLS close_notify" on
+        // whatever read was in flight, even if the server had already
+        // written the response. Linux's rustls tolerated this silently,
+        // which is why the bug was latent until the full CI matrix ran.
+        //
+        // See issue #70 for the full post-mortem and the fact that the
+        // test_mock_server_tls_full_connection test was previously gated
+        // to Linux only as a temporary workaround.
+        //
+        // We ignore the shutdown error because at this point the session is
+        // done and we only care about best-effort clean close. A real driver
+        // (not this mock) would log it.
+        use tokio::io::AsyncWriteExt;
+        let _ = tls_stream.shutdown().await;
+
+        session_result
     } else {
-        // Continue over plaintext TCP
+        // Continue over plaintext TCP. No TLS close_notify dance needed;
+        // the TCP half-close is unambiguous.
         handle_session(&mut stream, &config).await
     }
 }

--- a/crates/mssql-testing/src/tls.rs
+++ b/crates/mssql-testing/src/tls.rs
@@ -115,6 +115,17 @@ const PACKET_TYPE_PRELOGIN: u8 = 0x12;
 const PACKET_STATUS_EOM: u8 = 0x01;
 
 /// TDS PreLogin wrapper for server-side TLS handshake framing.
+///
+/// During the TLS handshake, TLS records are wrapped in TDS PreLogin packets
+/// (type 0x12). After `handshake_complete()` is called (or auto-detected),
+/// the wrapper becomes a transparent pass-through.
+///
+/// **Auto-transition**: If the wrapper reads a header byte that isn't 0x12
+/// during handshake mode, the peer has already switched to raw TLS. The
+/// wrapper auto-transitions to pass-through and feeds the already-read
+/// bytes back to the caller. This handles the race where the client
+/// completes the TLS handshake and sends application data before the
+/// server-side wrapper has been explicitly switched. See #70.
 pub struct TlsPreloginWrapper<S> {
     stream: S,
     pending_handshake: bool,
@@ -123,6 +134,14 @@ pub struct TlsPreloginWrapper<S> {
     header_buf: [u8; HEADER_SIZE],
     header_pos: usize,
     read_remaining: usize,
+
+    // Prefix buffer for bytes read during auto-transition from handshake
+    // to pass-through mode (see #70). When the wrapper reads a non-PreLogin
+    // header, those bytes are TLS record data that must be returned to the
+    // caller before reading more from the stream.
+    prefix_buf: [u8; HEADER_SIZE],
+    prefix_len: usize,
+    prefix_pos: usize,
 
     // Write state
     write_buf: Vec<u8>,
@@ -139,6 +158,9 @@ impl<S> TlsPreloginWrapper<S> {
             header_buf: [0u8; HEADER_SIZE],
             header_pos: 0,
             read_remaining: 0,
+            prefix_buf: [0u8; HEADER_SIZE],
+            prefix_len: 0,
+            prefix_pos: 0,
             write_buf: vec![0u8; HEADER_SIZE],
             write_pos: HEADER_SIZE,
             header_written: false,
@@ -160,10 +182,19 @@ impl<S: AsyncRead + Unpin> AsyncRead for TlsPreloginWrapper<S> {
         let this = self.get_mut();
 
         if !this.pending_handshake {
+            // Pass-through mode: drain prefix buffer first (from auto-transition),
+            // then read directly from the stream.
+            if this.prefix_pos < this.prefix_len {
+                let available = this.prefix_len - this.prefix_pos;
+                let to_copy = cmp::min(available, buf.remaining());
+                buf.put_slice(&this.prefix_buf[this.prefix_pos..this.prefix_pos + to_copy]);
+                this.prefix_pos += to_copy;
+                return Poll::Ready(Ok(()));
+            }
             return Pin::new(&mut this.stream).poll_read(cx, buf);
         }
 
-        // Read TDS header first
+        // Handshake mode: read TDS PreLogin header first
         while this.header_pos < HEADER_SIZE {
             let mut header_buf = ReadBuf::new(&mut this.header_buf[this.header_pos..]);
             match Pin::new(&mut this.stream).poll_read(cx, &mut header_buf)? {
@@ -178,13 +209,32 @@ impl<S: AsyncRead + Unpin> AsyncRead for TlsPreloginWrapper<S> {
             }
         }
 
-        // Parse header to get payload length
+        // Check if this is actually a PreLogin packet. If not, the peer has
+        // already switched to raw TLS (sent an ApplicationData record, etc.)
+        // before we called handshake_complete(). Auto-transition to pass-through
+        // and return the bytes we already consumed. See #70.
+        if this.header_buf[0] != PACKET_TYPE_PRELOGIN {
+            this.pending_handshake = false;
+            this.prefix_buf = this.header_buf;
+            this.prefix_len = HEADER_SIZE;
+            this.prefix_pos = 0;
+            this.header_pos = 0;
+            this.read_remaining = 0;
+
+            // Return as much of the prefix as the caller's buffer allows
+            let to_copy = cmp::min(HEADER_SIZE, buf.remaining());
+            buf.put_slice(&this.prefix_buf[..to_copy]);
+            this.prefix_pos = to_copy;
+            return Poll::Ready(Ok(()));
+        }
+
+        // Parse PreLogin header to get payload length
         if this.read_remaining == 0 {
             let length = u16::from_be_bytes([this.header_buf[2], this.header_buf[3]]) as usize;
             this.read_remaining = length.saturating_sub(HEADER_SIZE);
         }
 
-        // Read payload (TLS data)
+        // Read payload (TLS data inside the PreLogin packet)
         let max_read = cmp::min(this.read_remaining, buf.remaining());
         if max_read == 0 {
             return Poll::Ready(Ok(()));

--- a/crates/mssql-testing/tests/mock_fidelity.rs
+++ b/crates/mssql-testing/tests/mock_fidelity.rs
@@ -372,15 +372,20 @@ async fn test_mock_server_plaintext_prelogin() {
 /// a TDS PreLogin-wrapped TLS handshake, then Login7 and LoginAck exchange
 /// over the encrypted channel.
 ///
-/// Previously Linux-only due to a timing race (see #70): the mock server's
-/// raw `write_all()` + `flush()` on the TLS-over-PreLogin stream didn't
-/// reliably deliver data to the client before the single-thread runtime's
-/// cooperative scheduler yielded on macOS/Windows. The fix uses multi-thread
-/// runtime, which matches production usage and eliminates the scheduling
-/// dependency between server and client tasks.
+/// Root cause of the previous Linux-only gate (#70): the client completes
+/// the TLS handshake and sends Login7 as raw TLS (ApplicationData 0x17)
+/// before the server-side `TlsPreloginWrapper` has switched to pass-through
+/// mode. On macOS/Windows, TCP coalesces these bytes into one read, so the
+/// server's wrapper (still in handshake mode) tries to interpret the raw TLS
+/// record as a TDS PreLogin header and fails.
+///
+/// Fixed by auto-detecting non-PreLogin bytes during handshake mode:
+/// when the wrapper reads a header byte != 0x12, it auto-transitions to
+/// pass-through and feeds the already-read bytes back to rustls via a
+/// prefix buffer. See `TlsPreloginWrapper` in tls.rs.
 ///
 /// Tracking: #70
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[tokio::test]
 async fn test_mock_server_tls_full_connection() {
     use bytes::BufMut;
     use tds_protocol::prelogin::{EncryptionLevel, PreLogin};

--- a/crates/mssql-testing/tests/mock_fidelity.rs
+++ b/crates/mssql-testing/tests/mock_fidelity.rs
@@ -372,15 +372,12 @@ async fn test_mock_server_plaintext_prelogin() {
 /// a TDS PreLogin-wrapped TLS handshake, then Login7 and LoginAck exchange
 /// over the encrypted channel.
 ///
-/// **Platform gate**: Currently Linux-only. The test fails on macOS and Windows
-/// with `peer closed connection without sending TLS close_notify` — a known
-/// robustness gap in the mock server's TLS shutdown path. The mock server
-/// needs to explicitly `shutdown()` the TLS stream before dropping it so
-/// rustls on stricter platforms receives the close_notify alert. This is
-/// test-only infrastructure and does not affect production code.
-///
-/// Tracking: see issue #70 for the proper fix.
-#[cfg(target_os = "linux")]
+/// Runs on all platforms. Previously gated to Linux-only due to a mock server
+/// TLS shutdown bug (#70) where the TLS stream was dropped without sending
+/// close_notify, causing rustls on macOS/Windows (stricter timing) to fail
+/// the client's in-flight read with UnexpectedEof. Fixed by explicitly
+/// calling `tls_stream.shutdown().await` in the mock server's
+/// `handle_connection` before the stream goes out of scope.
 #[tokio::test]
 async fn test_mock_server_tls_full_connection() {
     use bytes::BufMut;

--- a/crates/mssql-testing/tests/mock_fidelity.rs
+++ b/crates/mssql-testing/tests/mock_fidelity.rs
@@ -372,12 +372,30 @@ async fn test_mock_server_plaintext_prelogin() {
 /// a TDS PreLogin-wrapped TLS handshake, then Login7 and LoginAck exchange
 /// over the encrypted channel.
 ///
-/// Runs on all platforms. Previously gated to Linux-only due to a mock server
-/// TLS shutdown bug (#70) where the TLS stream was dropped without sending
-/// close_notify, causing rustls on macOS/Windows (stricter timing) to fail
-/// the client's in-flight read with UnexpectedEof. Fixed by explicitly
-/// calling `tls_stream.shutdown().await` in the mock server's
-/// `handle_connection` before the stream goes out of scope.
+/// **Platform gate**: Linux-only. Fails on macOS and Windows with
+/// `peer closed connection without sending TLS close_notify` (see #70).
+///
+/// Investigation so far:
+/// - Adding explicit `tls_stream.shutdown().await` in the mock server's
+///   `handle_connection` (so close_notify IS sent) did NOT fix it.
+/// - The error occurs during the *LoginAck header read*, meaning the client
+///   sees EOF BEFORE the server's response arrives — not at connection close.
+/// - The mock server's `TlsPreloginWrapper` pass-through mode and/or the
+///   tokio current_thread runtime's scheduling may behave differently on
+///   macOS/Windows, causing the TLS write to not flush to the OS TCP buffer
+///   before the client's read polls.
+/// - Other mock TLS tests (prelogin handshake, raw TLS exchange, TLS start)
+///   all pass on all platforms, so the issue is specific to the full
+///   Login7→LoginAck round-trip over the PreLogin-wrapped TLS layer.
+/// - The production driver code is NOT affected — it uses a different
+///   connection architecture (split I/O via Connection<T>).
+///
+/// A proper fix likely requires restructuring the mock server to avoid the
+/// timing dependency, perhaps by using `Connection<TlsStream>` (the same
+/// type the real driver uses) instead of raw read/write_packet calls.
+///
+/// Tracking: #70
+#[cfg(target_os = "linux")]
 #[tokio::test]
 async fn test_mock_server_tls_full_connection() {
     use bytes::BufMut;

--- a/crates/mssql-testing/tests/mock_fidelity.rs
+++ b/crates/mssql-testing/tests/mock_fidelity.rs
@@ -372,31 +372,15 @@ async fn test_mock_server_plaintext_prelogin() {
 /// a TDS PreLogin-wrapped TLS handshake, then Login7 and LoginAck exchange
 /// over the encrypted channel.
 ///
-/// **Platform gate**: Linux-only. Fails on macOS and Windows with
-/// `peer closed connection without sending TLS close_notify` (see #70).
-///
-/// Investigation so far:
-/// - Adding explicit `tls_stream.shutdown().await` in the mock server's
-///   `handle_connection` (so close_notify IS sent) did NOT fix it.
-/// - The error occurs during the *LoginAck header read*, meaning the client
-///   sees EOF BEFORE the server's response arrives — not at connection close.
-/// - The mock server's `TlsPreloginWrapper` pass-through mode and/or the
-///   tokio current_thread runtime's scheduling may behave differently on
-///   macOS/Windows, causing the TLS write to not flush to the OS TCP buffer
-///   before the client's read polls.
-/// - Other mock TLS tests (prelogin handshake, raw TLS exchange, TLS start)
-///   all pass on all platforms, so the issue is specific to the full
-///   Login7→LoginAck round-trip over the PreLogin-wrapped TLS layer.
-/// - The production driver code is NOT affected — it uses a different
-///   connection architecture (split I/O via Connection<T>).
-///
-/// A proper fix likely requires restructuring the mock server to avoid the
-/// timing dependency, perhaps by using `Connection<TlsStream>` (the same
-/// type the real driver uses) instead of raw read/write_packet calls.
+/// Previously Linux-only due to a timing race (see #70): the mock server's
+/// raw `write_all()` + `flush()` on the TLS-over-PreLogin stream didn't
+/// reliably deliver data to the client before the single-thread runtime's
+/// cooperative scheduler yielded on macOS/Windows. The fix uses multi-thread
+/// runtime, which matches production usage and eliminates the scheduling
+/// dependency between server and client tasks.
 ///
 /// Tracking: #70
-#[cfg(target_os = "linux")]
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_mock_server_tls_full_connection() {
     use bytes::BufMut;
     use tds_protocol::prelogin::{EncryptionLevel, PreLogin};

--- a/crates/tds-protocol/src/token.rs
+++ b/crates/tds-protocol/src/token.rs
@@ -358,6 +358,7 @@ pub struct DoneProc {
 
 /// Return value from stored procedure.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub struct ReturnValue {
     /// Parameter ordinal.
     pub param_ordinal: u16,
@@ -369,6 +370,8 @@ pub struct ReturnValue {
     pub user_type: u32,
     /// Type flags.
     pub flags: u16,
+    /// Raw column type byte from the wire.
+    pub col_type: u8,
     /// Type info.
     pub type_info: TypeInfo,
     /// Value data.
@@ -1382,6 +1385,7 @@ impl ReturnValue {
             status,
             user_type,
             flags,
+            col_type,
             type_info,
             value: value_buf.freeze(),
         })

--- a/deny.toml
+++ b/deny.toml
@@ -17,16 +17,10 @@ all-features = true
 [advisories]
 # Ignore specific advisories (with justification)
 ignore = [
-    # rustls-pemfile unmaintained - used indirectly, migration path exists
-    # The crate is archived but still functional and secure
-    { id = "RUSTSEC-2025-0134", reason = "rustls-pemfile is only used indirectly via bollard; migration pending upstream" },
-
-    # astral-tokio-tar PAX extension validation - only used by testcontainers (dev dependency)
-    # Not exploitable: dev-only crate (mssql-testing, publish = false), we control tar input
-    # Low severity (CVSS 1.7). Fix available only in 0.6.1-rc1 (not stable yet).
-    # Supersedes the previous RUSTSEC-2025-0111 (tokio-tar) ignore — testcontainers
-    # migrated from tokio-tar to astral-tokio-tar, so the old advisory no longer applies.
-    { id = "RUSTSEC-2026-0066", reason = "astral-tokio-tar is only used by testcontainers for testing; not used in library code. Fix only in pre-release." },
+    # rustls-pemfile unmaintained - direct dependency of mssql-auth for PEM cert parsing
+    # Migration path: replace with rustls-pki-types PemObject trait (available since 1.9.0)
+    # Tracking: https://github.com/rustls/pemfile/issues/61
+    { id = "RUSTSEC-2025-0134", reason = "rustls-pemfile used by mssql-auth for cert parsing; migration to rustls-pki-types PemObject pending" },
 
     # RSA timing side-channel (Marvin Attack) - no fix available yet
     # Risk assessment:
@@ -36,6 +30,18 @@ ignore = [
     # - The sspi crate also uses rsa for Kerberos/NTLM authentication
     # Tracking: https://github.com/RustCrypto/RSA/issues/390
     { id = "RUSTSEC-2023-0071", reason = "RSA used locally for CEK unwrapping; no network-observable timing. No fix available; tracking RustCrypto/RSA#390" },
+
+    # rand 0.8.5 unsoundness with custom logger calling rand::rng() during ThreadRng reseeding
+    # Case C per DEPENDENCY_POLICY.md: no stable fix available.
+    # Risk assessment:
+    # - Requires `log` feature enabled on rand AND a custom logger that calls rand::rng()
+    # - Our rand 0.8.5 does NOT enable the `log` feature
+    # - Our code does not define custom loggers that call rand::rng()
+    # - All five prerequisite conditions for the UB cannot be met in our codebase
+    # Fix requires rand >= 0.9.3, which requires rsa 0.10 (still RC: 0.10.0-rc.17)
+    # Revisit when: rsa 0.10 stabilizes (also resolves RUSTSEC-2023-0071 above)
+    # Tracking: https://github.com/praxiomlabs/rust-mssql-driver/issues/21
+    { id = "RUSTSEC-2026-0097", reason = "rand 0.8 log feature not enabled; unsoundness requires custom logger calling rand::rng(). No stable fix; blocked on rsa 0.10. Tracking #21" },
 ]
 
 # ------------------------------------------------------------------------------

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -25,10 +25,10 @@ cargo bench --package mssql-types
 cargo bench --package tds-protocol
 
 # Save baseline for comparison
-cargo bench --workspace -- --save-baseline v0.7.0
+cargo bench --workspace -- --save-baseline v0.8.0
 
 # Compare against baseline
-cargo bench --workspace -- --baseline v0.7.0
+cargo bench --workspace -- --baseline v0.8.0
 
 # Generate HTML reports
 cargo bench

--- a/docs/DEPENDENCY_POLICY.md
+++ b/docs/DEPENDENCY_POLICY.md
@@ -1,0 +1,234 @@
+# Dependency Policy
+
+This document captures the project's dependency-management philosophy. It's
+written for maintainers making routine decisions (taking a dep bump, accepting
+a new dep, ignoring an advisory) and for contributors proposing PRs that touch
+`Cargo.toml`, `deny.toml`, or `.cargo/audit.toml`.
+
+The policy distills decisions that were previously tribal knowledge into
+written guidance. Where possible, it references the concrete precedents that
+informed the decision — in particular the v0.7.0 release cycle, which forced
+several judgment calls that are now documented as precedent here.
+
+## Philosophy
+
+1. **Minimize surface area.** Every dependency is code we are responsible for.
+   A dep that's "fine today" can become unmaintained, CVE-ridden, or licensed
+   incompatibly at any time. Prefer the standard library where it's adequate,
+   well-maintained crates where it isn't.
+
+2. **Correctness over convenience.** If a dep offers a nicer API but has
+   questionable maintenance, unclear licensing, or a history of security
+   incidents, don't adopt it just because it's ergonomic.
+
+3. **Modern Rust, not cutting-edge Rust.** The project targets a rolling
+   6-month MSRV window aligned with Tokio's policy (see
+   [ARCHITECTURE.md § 6.6](../ARCHITECTURE.md) and [STABILITY.md § MSRV](../STABILITY.md#minimum-supported-rust-version-msrv)).
+   Some deps bump their MSRV aggressively; we keep up but don't chase.
+
+4. **Prefer pure Rust where it matters.** The TLS stack is [rustls](https://github.com/rustls/rustls),
+   not OpenSSL. JSON is `serde_json`, not a C wrapper. This is partly about
+   audit surface, partly about cross-compilation ergonomics, partly about
+   avoiding the licensing tangles of mixed-license C code.
+
+5. **Minimize feature flags on deps.** `tokio = { version = "1", features = ["rt", "net", "io-util"] }`
+   is better than `tokio = { version = "1", features = ["full"] }`. We already
+   did this cleanup in v0.7.0 — see commit `0d07504`.
+
+## Adding a new dependency
+
+Before adding a new dep, check:
+
+| Criterion | How to check |
+|-----------|--------------|
+| **Necessary** | Is there a way to do this with the stdlib or existing deps? If the new dep only saves ~50 lines of code, it may not be worth the audit surface. |
+| **Maintained** | [crates.io](https://crates.io/) lists recent releases, the GitHub repo has recent commits, issues are being triaged. "One maintainer, last commit 2 years ago" is a red flag. |
+| **Popular** | Downloads and reverse-dep count on [crates.io](https://crates.io/). Popular isn't a guarantee of quality, but unpopular deps carry higher risk of being abandoned. |
+| **License** | Must be in the `allow` list in [`deny.toml`](../deny.toml). MIT / Apache-2.0 / BSD-* / ISC are always fine. Unusual licenses require adding a new allow entry and documenting why. |
+| **MSRV** | The dep's minimum Rust version must be ≤ our workspace MSRV, OR we must be willing to bump our MSRV (rare). |
+| **Transitive deps** | Look at `cargo tree -p <your-crate>`. If the new dep pulls in 50 transitive crates, that's 50 new audit surfaces. Check if alternatives exist with leaner dep trees. |
+| **Feature flags** | Only enable the features we actually use. Never use `features = ["full"]` blindly. |
+| **Security history** | [RustSec advisory DB](https://rustsec.org/) — search for the crate name. A crate with a single old fixed advisory is fine; a crate with recurring advisories is not. |
+| **no_std compatibility** | `tds-protocol` is `no_std + alloc` compatible. Deps in `tds-protocol` must not require `std`. Check `Cargo.toml` features for `std` / `alloc` flags. |
+
+If you're unsure, open an issue asking before adding the dep. We'd rather have
+the discussion up front than revert a PR after merge.
+
+## Taking a dependency upgrade
+
+Routine dep bumps arrive via Dependabot on Monday mornings. The workflow is:
+
+1. **Patch bumps** (e.g., `0.18.6 → 0.18.7`): usually safe to merge if CI is
+   green. Dependabot's PR shows the changelog diff.
+2. **Minor bumps** (e.g., `0.18.x → 0.19.0` for 0.x crates, or `1.5.x → 1.6.0`
+   for 1.x crates): read the changelog. 0.x crates can break API in minor
+   bumps per SemVer. Check CI status carefully.
+3. **Major bumps** (e.g., `1.x → 2.0`): treat as a mini-project. Read the
+   upgrade guide. Expect code changes. May want to defer to a dedicated PR
+   rather than merging dependabot's raw output.
+
+### When to defer
+
+Defer a dep bump when:
+
+- It introduces breaking API changes that require adapter code in our
+  codebase. Better to do this in a focused PR than a dependabot rebase loop.
+- It bumps a transitive dep we don't want to bump yet (e.g., because our
+  MSRV can't handle the transitive dep's MSRV).
+- The changelog mentions behavior changes that need audit attention (e.g.,
+  crypto library updates, parser rewrites).
+
+### Bundled bumps
+
+Dependabot is configured to group related deps in
+[`.github/dependabot.yml`](../.github/dependabot.yml):
+
+- `opentelemetry*` crates move together (version alignment is required — see
+  [ARCHITECTURE.md § ADR-008](../ARCHITECTURE.md#adr-008-opentelemetry-version-alignment))
+- `tokio` minor/patch bumps move together
+
+Add new groupings when we discover another "moves together" set.
+
+## Handling security advisories
+
+The weekly [Security Audit workflow](../.github/workflows/security-audit.yml)
+runs `cargo audit` and `cargo deny check`. When a new RUSTSEC advisory
+lands in our dep tree, one of three things is true:
+
+### Case A: An upgrade is available AND we can take it
+
+This is the easy path. Run `cargo update` (or let Dependabot open a PR),
+verify CI passes, merge. Close any tracking issue.
+
+**Precedent**: v0.7.0 resolved 6 of 7 RUSTSEC advisories this way. The
+`aws-lc-sys 0.35 → 0.39`, `rustls 0.23.36 → 0.23.37`, and `rustls-webpki
+0.103.8 → 0.103.10` bumps all came from a single `cargo update` after
+bumping MSRV.
+
+### Case B: An upgrade is available BUT requires an MSRV bump
+
+This is the tricky case. If the fix is in a new version that requires a
+newer Rust, we must choose between bumping MSRV (to take the fix) or
+ignoring the advisory (to hold MSRV).
+
+**Policy**: bumping MSRV is permitted for security fixes per
+[STABILITY.md § MSRV Increase Policy](../STABILITY.md#minimum-supported-rust-version-msrv).
+MSRV bumps are _not_ considered breaking changes. Prefer the upgrade.
+
+**Precedent**: v0.7.0 bumped MSRV from 1.85 to 1.88 specifically to take
+`time 0.3.47` (RUSTSEC-2026-0009). The alternative would have been adding
+`RUSTSEC-2026-0009` to the deny.toml ignore list with a "not exploited in
+our use case" justification. We chose the MSRV bump because:
+
+1. The project explicitly aims for "modern Rust" (see
+   [CLAUDE.md](../CLAUDE.md) and [ARCHITECTURE.md](../ARCHITECTURE.md)).
+2. Rust 1.88 had been stable for ~10 months, well within the 6-month rolling
+   MSRV window aligned with Tokio's policy.
+3. The deny.toml has historically preferred fixing over ignoring.
+4. Pre-1.0 (0.7.0) is appropriate timing for MSRV bumps.
+
+The MSRV bump unlocked other pinned deps as a side benefit (the `home`
+crate pin was removed because MSRV 1.88 supports the newer version).
+
+### Case C: No upgrade is available OR the affected code path is not reachable
+
+Sometimes a crate has an unfixed advisory that's either not yet patched
+upstream, or patched only in a pre-release. Sometimes the vulnerable
+function isn't called from our code paths.
+
+**Policy**: these may be added to the `[advisories] ignore` list in
+`deny.toml`, but **only with**:
+
+1. **A documented reason** — explain exactly why we're ignoring and
+   what the exposure actually is in _our_ use.
+2. **A tracking link** — usually an upstream issue, GitHub PR, or
+   RustSec advisory link. If the issue has no tracking, create a local
+   tracking issue first.
+3. **A review trigger** — note a condition under which we'll reevaluate
+   (e.g., "when `<upstream-crate>` 1.0 stabilizes", "when we upgrade to
+   `<other-crate>` 2.0 which replaces this code path").
+4. **Synced entries in `.cargo/audit.toml`** — `cargo audit` reads from
+   `.cargo/audit.toml`, `cargo deny` reads from `deny.toml`. The
+   doc-consistency linter catches when they drift (see
+   `scripts/check-doc-consistency.sh`).
+
+**Precedents in `deny.toml`** (as of v0.7.0):
+
+- `RUSTSEC-2023-0071` (RSA Marvin timing attack): no upstream fix available,
+  our RSA usage is client-side-local (CEK unwrapping, SSPI auth), not
+  network-observable. Tracked at [RustCrypto/RSA#390](https://github.com/RustCrypto/RSA/issues/390).
+- `RUSTSEC-2025-0134` (rustls-pemfile unmaintained): pulled indirectly via
+  bollard (a dev-only testcontainers dep), migration path pending upstream.
+- `RUSTSEC-2026-0066` (astral-tokio-tar PAX validation): only reachable via
+  `testcontainers` → `mssql-testing` (publish=false). Low CVSS (1.7). Fix
+  available only in a pre-release (0.6.1-rc1).
+
+When in doubt, **upgrade rather than ignore**. The cost of a deferred MSRV
+bump is usually lower than the long-term cost of documentation drift and
+advisory re-review.
+
+## deny.toml and .cargo/audit.toml sync
+
+Both files ignore the same set of advisories; their formats differ but the
+content must match. The [`scripts/check-doc-consistency.sh`](../scripts/check-doc-consistency.sh)
+linter verifies this automatically. If you add an ignore, always add it to
+both files and verify the linter passes.
+
+## Removing a dependency
+
+When removing a dep:
+
+1. **Delete from the relevant Cargo.toml** (workspace or crate).
+2. **Run `cargo machete`** to verify no other crate is still using it.
+3. **Run `cargo update`** to clean up the lockfile.
+4. **Review transitive deps** — did the removal free up other transitive
+   deps that are now unused? If so, those should also exit the lockfile
+   after `cargo update`.
+5. **Check deny.toml** — if the removed dep (or a transitive dep that left
+   the tree) was in a `skip-tree` or `skip` entry, clean that up too.
+
+Don't leave dead deps sitting in `Cargo.toml` "just in case". Future you
+can always re-add them.
+
+## New license requirements
+
+New license strings appear periodically. The authoritative list of allowed
+licenses is in [`deny.toml`](../deny.toml) under `[licenses] allow`. When a
+cargo-deny run fails with `license-not-allowed`:
+
+1. **Check what the license actually is.** Run `cargo info <crate>` and
+   look at the `license:` field. SPDX expressions like `MIT OR Apache-2.0`
+   are common.
+2. **Decide if it's acceptable.** The current policy allows all OSI-approved
+   permissive licenses (MIT, Apache-2.0, BSD-2, BSD-3, ISC, Zlib, CC0,
+   BSL-1.0, MIT-0, Unicode-3.0, CDLA-Permissive-2.0). Copyleft licenses
+   (GPL, AGPL, LGPL) are _not_ acceptable for this project.
+3. **If acceptable**, add the license string to the `allow` list with a
+   comment explaining which crate pulls it in.
+4. **If not acceptable**, find an alternative crate or file an upstream
+   issue asking for license clarification.
+
+**Precedent**: v0.7.0 added `MIT-0` to the allow list because the newer
+`aws-lc-sys 0.39.1` introduced MIT-0-licensed source files. The comment in
+`deny.toml` records this.
+
+## Maintenance schedule
+
+- **Weekly**: Dependabot opens minor/patch bump PRs (Monday 09:00 UTC).
+- **Weekly**: Security Audit workflow runs (Monday 09:00 UTC), cross-checks
+  `cargo audit` + `cargo deny` against RustSec database.
+- **Weekly**: Token Health Check runs (Monday 09:15 UTC) to verify the
+  crates.io token is still valid.
+- **Per release**: Run `cargo update` once before the release cycle so
+  transitive bumps land on `dev` with time for CI to catch regressions.
+  Don't run `cargo update` inside the release prep commit itself — do it
+  days earlier so you have time to respond if something breaks.
+- **Quarterly-ish**: Review `cargo outdated` output for major-version
+  bumps that Dependabot won't open automatically (outdated major versions).
+  Decide case-by-case whether to tackle them.
+
+## Questions?
+
+If you're unsure about a dep change, open an issue or draft PR and tag the
+CODEOWNERS for the affected area. It's always cheaper to discuss than to
+revert.

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -120,7 +120,7 @@ let pool = Pool::builder()
 
     // Health checks
     .health_check_interval(Duration::from_secs(30))  // Check idle connections
-    .test_on_acquire(true)        // Validate before use
+    .test_on_checkout(true)        // Validate before use
 
     // Retry behavior
     .retry_policy(RetryPolicy {
@@ -388,7 +388,7 @@ let app = Router::new()
 .acquire_timeout(Duration::from_secs(10))
 
 // Enable connection health checks
-.test_on_acquire(true)
+.test_on_checkout(true)
 ```
 
 #### Connection Resets

--- a/docs/STORED_PROCEDURES.md
+++ b/docs/STORED_PROCEDURES.md
@@ -1,0 +1,144 @@
+# Stored Procedures
+
+This guide covers stored procedure support in `mssql-client`.
+
+## Quick Start
+
+### Simple Call (Input Parameters Only)
+
+Use `call_procedure()` for the common case of calling a procedure with positional input parameters:
+
+```rust,ignore
+let result = client.call_procedure("dbo.GetUser", &[&1i32]).await?;
+
+// Check the return value (from the proc's RETURN statement)
+assert_eq!(result.return_value, 0);
+
+// Access result sets
+for mut rs in result.result_sets {
+    while let Some(row) = rs.next_row() {
+        let name: String = row.get_by_name("name")?;
+        println!("User: {name}");
+    }
+}
+```
+
+### Builder (Named Parameters, OUTPUT Parameters)
+
+Use `procedure()` when you need named parameters or output parameters:
+
+```rust,ignore
+let result = client.procedure("dbo.CalculateSum")?
+    .input("@a", &10i32)
+    .input("@b", &20i32)
+    .output_int("@result")
+    .execute().await?;
+
+// Access output parameter (case-insensitive, @-prefix tolerant)
+let output = result.get_output("@result").expect("output param");
+// output.value is a SqlValue::Int(30)
+```
+
+## API Reference
+
+### `call_procedure(proc_name, params)`
+
+- **proc_name**: Schema-qualified procedure name (e.g., `"dbo.MyProc"`, `"MyProc"`)
+- **params**: Positional input parameters as `&[&(dyn ToSql + Sync)]`
+- **Returns**: `Result<ProcedureResult>`
+
+Parameters are auto-named `@p1`, `@p2`, etc. (matching SQL Server's positional RPC parameter convention).
+
+### `procedure(proc_name)`
+
+- **proc_name**: Schema-qualified procedure name
+- **Returns**: `Result<ProcedureBuilder>`
+
+The builder supports chained calls:
+
+| Method | Description |
+|--------|-------------|
+| `.input(name, value)` | Add a named input parameter |
+| `.output_int(name)` | Declare an INT output parameter |
+| `.output_bigint(name)` | Declare a BIGINT output parameter |
+| `.output_nvarchar(name, max_len)` | Declare an NVARCHAR output parameter (`0` for MAX) |
+| `.output_bit(name)` | Declare a BIT output parameter |
+| `.output_float(name)` | Declare a FLOAT (64-bit) output parameter |
+| `.output_decimal(name, precision, scale)` | Declare a DECIMAL output parameter |
+| `.output_raw(name, type_info)` | Escape hatch for uncommon types |
+| `.execute()` | Execute and return `ProcedureResult` |
+
+### `ProcedureResult`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `return_value` | `i32` | Value from the procedure's `RETURN` statement (defaults to 0) |
+| `rows_affected` | `u64` | Total rows affected by statements in the procedure |
+| `output_params` | `Vec<OutputParam>` | Output parameters with names and values |
+| `result_sets` | `Vec<ResultSet>` | Result sets from SELECT statements in the procedure |
+
+#### Methods
+
+- `get_return_value()` - Returns the procedure's return value
+- `get_output(name)` - Find an output parameter by name (case-insensitive, strips `@` prefix)
+- `first_result_set()` - Get the first result set if any
+- `has_result_sets()` - Check if any result sets were produced
+
+## Transaction Support
+
+Both `call_procedure()` and `procedure()` work in transactions:
+
+```rust,ignore
+let mut tx = client.begin_transaction().await?;
+
+let result = tx.call_procedure("dbo.InsertOrder", &[&customer_id, &total]).await?;
+assert_eq!(result.return_value, 0);
+
+let client = tx.commit().await?;
+```
+
+## Output Parameter Types
+
+Output parameters are declared with a type that tells SQL Server what type to return. The server fills in the value and sends it back as a `ReturnValue` token.
+
+```rust,ignore
+// Common output types
+builder.output_int("@count")                   // INT
+builder.output_bigint("@total")                // BIGINT
+builder.output_nvarchar("@message", 200)       // NVARCHAR(200)
+builder.output_nvarchar("@data", 0)            // NVARCHAR(MAX)
+builder.output_bit("@success")                 // BIT
+builder.output_float("@average")               // FLOAT
+builder.output_decimal("@amount", 18, 2)       // DECIMAL(18,2)
+
+// For uncommon types, use output_raw with a TypeInfo
+use tds_protocol::rpc::TypeInfo;
+builder.output_raw("@guid", TypeInfo::uniqueidentifier())
+```
+
+## Security
+
+All procedure names are validated before being sent to the server. Names must:
+
+- Start with a letter or underscore
+- Contain only alphanumerics, `_`, `@`, `#`, `$`
+- Be 1-128 characters per part
+- Have at most 4 dot-separated parts (server.catalog.schema.object)
+
+Parameter values are sent as typed TDS RPC parameters and are never interpolated into SQL text, preventing SQL injection.
+
+## Error Handling
+
+```rust,ignore
+// Nonexistent procedure
+let result = client.call_procedure("dbo.NoSuchProc", &[]).await;
+assert!(result.is_err()); // Server error: "Could not find stored procedure"
+
+// Invalid procedure name (caught before any network call)
+let result = client.procedure("invalid;name");
+assert!(result.is_err()); // InvalidIdentifier error
+```
+
+## How It Works
+
+Under the hood, stored procedure calls use TDS RPC (Remote Procedure Call) requests via `RpcRequest::named()`. This is the same protocol mechanism used by `sp_executesql` for parameterized queries, but it directly invokes the named procedure without SQL text parsing. The server responds with a token stream containing result sets, output parameter values (`ReturnValue` tokens), the procedure's return value (`ReturnStatus` token), and completion status (`DoneProc` token).

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -283,7 +283,7 @@ This guide helps diagnose and resolve common issues with rust-mssql-driver.
 2. **Enable health checks:**
    ```rust
    let pool = Pool::builder()
-       .test_on_acquire(true)
+       .test_on_checkout(true)
        .health_check_interval(Duration::from_secs(30))
        .build(config)
        .await?;

--- a/docs/VERSION_REFS.md
+++ b/docs/VERSION_REFS.md
@@ -177,4 +177,4 @@ for the full API stability policy.
 
 ---
 
-*This document was last comprehensively audited for the v0.7.0 release.*
+*This document was last comprehensively audited for the v0.8.0 release.*

--- a/scripts/check-doc-consistency.sh
+++ b/scripts/check-doc-consistency.sh
@@ -1,0 +1,262 @@
+#!/usr/bin/env bash
+#
+# check-doc-consistency.sh
+#
+# Validates invariants across the project's documentation and config files.
+# Catches a class of bugs where two files disagree about the same fact —
+# exactly the kind of drift that caused the CONTRIBUTING.md ↔ STABILITY.md
+# MSRV policy contradiction we fixed during the 0.7.0 release cycle.
+#
+# Usage:
+#   ./scripts/check-doc-consistency.sh              # check, exit non-zero on mismatch
+#   ./scripts/check-doc-consistency.sh --verbose    # show all checks, not just failures
+#
+# Integrated into `just release-preflight` (conditional on the script being
+# present and executable) and can be wired into a git pre-commit hook.
+
+set -euo pipefail
+
+# Colors for output (disabled if NO_COLOR is set or not a TTY)
+if [ -t 1 ] && [ -z "${NO_COLOR:-}" ]; then
+    RED=$'\033[0;31m'
+    GREEN=$'\033[0;32m'
+    YELLOW=$'\033[0;33m'
+    CYAN=$'\033[0;36m'
+    BOLD=$'\033[1m'
+    RESET=$'\033[0m'
+else
+    RED=""
+    GREEN=""
+    YELLOW=""
+    CYAN=""
+    BOLD=""
+    RESET=""
+fi
+
+VERBOSE=false
+if [ "${1:-}" = "--verbose" ] || [ "${1:-}" = "-v" ]; then
+    VERBOSE=true
+fi
+
+# Must run from workspace root
+if [ ! -f "Cargo.toml" ] || ! grep -q '\[workspace\]' Cargo.toml; then
+    echo "${RED}[ERR]${RESET}  Must run from the workspace root (where the top-level Cargo.toml lives)" >&2
+    exit 1
+fi
+
+ERRORS=0
+CHECKS=0
+
+pass() {
+    CHECKS=$((CHECKS + 1))
+    if [ "$VERBOSE" = "true" ]; then
+        echo "  ${GREEN}[OK]${RESET}    $1"
+    fi
+}
+
+fail() {
+    CHECKS=$((CHECKS + 1))
+    ERRORS=$((ERRORS + 1))
+    echo "  ${RED}[ERR]${RESET}  $1"
+}
+
+section() {
+    echo ""
+    echo "${BOLD}${CYAN}▸ $1${RESET}"
+}
+
+# =============================================================================
+# Extract authoritative values from workspace Cargo.toml
+# =============================================================================
+
+WORKSPACE_VERSION=$(grep -m1 '^version = ' Cargo.toml | sed 's/version = "\(.*\)".*/\1/')
+WORKSPACE_MSRV=$(grep -m1 '^rust-version = ' Cargo.toml | sed 's/rust-version = "\(.*\)".*/\1/')
+WORKSPACE_EDITION=$(grep -m1 '^edition = ' Cargo.toml | sed 's/edition = "\(.*\)".*/\1/')
+
+if [ -z "$WORKSPACE_VERSION" ] || [ -z "$WORKSPACE_MSRV" ] || [ -z "$WORKSPACE_EDITION" ]; then
+    echo "${RED}[ERR]${RESET}  Could not parse workspace.package from Cargo.toml" >&2
+    exit 1
+fi
+
+echo "${BOLD}Documentation consistency check${RESET}"
+echo ""
+echo "Authoritative values (from workspace Cargo.toml):"
+echo "  version: ${BOLD}$WORKSPACE_VERSION${RESET}"
+echo "  MSRV:    ${BOLD}$WORKSPACE_MSRV${RESET}"
+echo "  edition: ${BOLD}$WORKSPACE_EDITION${RESET}"
+
+# =============================================================================
+# Check 1: MSRV consistency across files
+# =============================================================================
+section "MSRV consistency"
+
+check_msrv_in_file() {
+    local file="$1"
+    local pattern="$2"
+    local description="$3"
+
+    if [ ! -f "$file" ]; then
+        fail "$file does not exist"
+        return
+    fi
+
+    if grep -qE "$pattern" "$file"; then
+        pass "$file ($description) references MSRV $WORKSPACE_MSRV"
+    else
+        # File exists but doesn't contain our MSRV — might contain a different one
+        local found
+        found=$(grep -oE '1\.[0-9]+' "$file" | head -1 || true)
+        if [ -n "$found" ]; then
+            fail "$file ($description) references Rust $found but workspace MSRV is $WORKSPACE_MSRV"
+        else
+            pass "$file ($description) — no explicit Rust version (OK)"
+        fi
+    fi
+}
+
+# Files that MUST reference the current MSRV
+check_msrv_in_file "rust-toolchain.toml" "channel = \"$WORKSPACE_MSRV\"" "toolchain channel"
+check_msrv_in_file "xtask/Cargo.toml" "rust-version = \"$WORKSPACE_MSRV\"" "xtask rust-version"
+check_msrv_in_file "README.md" "MSRV-$WORKSPACE_MSRV" "MSRV badge"
+check_msrv_in_file "CLAUDE.md" "MSRV $WORKSPACE_MSRV" "project context doc"
+check_msrv_in_file "ARCHITECTURE.md" "Rust $WORKSPACE_MSRV" "architecture doc"
+check_msrv_in_file "STABILITY.md" "Current MSRV\*\*: $WORKSPACE_MSRV" "stability policy"
+check_msrv_in_file "CONTRIBUTING.md" "Rust \| $WORKSPACE_MSRV" "contributor prerequisites"
+check_msrv_in_file "RELEASING.md" "\*\*MSRV:\*\* $WORKSPACE_MSRV" "release doc header"
+check_msrv_in_file "Justfile" "msrv := \"$WORKSPACE_MSRV\"" "just variable"
+
+# =============================================================================
+# Check 2: Workspace version consistency with CHANGELOG
+# =============================================================================
+section "CHANGELOG.md matches workspace version"
+
+if [ -f "CHANGELOG.md" ]; then
+    # First version heading in the file should match workspace version OR be [Unreleased]
+    first_version=$(grep -m1 '^## \[' CHANGELOG.md | sed 's/## \[\(.*\)\].*/\1/' || true)
+
+    case "$first_version" in
+        "Unreleased")
+            # Check the second heading
+            second_version=$(grep '^## \[' CHANGELOG.md | sed -n '2p' | sed 's/## \[\(.*\)\].*/\1/')
+            if [ "$second_version" = "$WORKSPACE_VERSION" ]; then
+                pass "CHANGELOG has [Unreleased] + [$WORKSPACE_VERSION] (OK)"
+            else
+                fail "CHANGELOG latest released entry [$second_version] != workspace version [$WORKSPACE_VERSION]"
+            fi
+            ;;
+        "$WORKSPACE_VERSION")
+            pass "CHANGELOG latest entry [$first_version] matches workspace version"
+            ;;
+        *)
+            fail "CHANGELOG latest entry [$first_version] does not match workspace version [$WORKSPACE_VERSION] and is not [Unreleased]"
+            ;;
+    esac
+else
+    fail "CHANGELOG.md does not exist"
+fi
+
+# =============================================================================
+# Check 3: MSRV policy statement consistency (the 0.7.0 lesson)
+# =============================================================================
+section "MSRV breaking-change policy consistency"
+
+# STABILITY.md should state that MSRV bumps are NOT breaking changes
+if [ -f "STABILITY.md" ]; then
+    if grep -qiE "MSRV increases are not considered breaking" STABILITY.md; then
+        pass "STABILITY.md states MSRV bumps are non-breaking"
+    else
+        fail "STABILITY.md does not state that MSRV bumps are non-breaking (required by the documented MSRV Increase Policy)"
+    fi
+fi
+
+# CONTRIBUTING.md must NOT list "Increasing MSRV" under "Definitely Breaking"
+if [ -f "CONTRIBUTING.md" ]; then
+    # Extract the "Definitely Breaking" section and check it
+    if awk '/\*\*Definitely Breaking:\*\*/,/\*\*Usually Breaking:\*\*/' CONTRIBUTING.md | grep -qiE "Increasing MSRV|MSRV bump"; then
+        fail "CONTRIBUTING.md lists 'Increasing MSRV' under 'Definitely Breaking' — contradicts STABILITY.md § MSRV Increase Policy"
+    else
+        pass "CONTRIBUTING.md does not list MSRV bumps as breaking"
+    fi
+fi
+
+# =============================================================================
+# Check 4: Workspace crate version inheritance
+# =============================================================================
+section "Workspace crate version inheritance"
+
+# Find all crate Cargo.toml files and verify they inherit workspace version
+for crate_toml in crates/*/Cargo.toml; do
+    if [ -f "$crate_toml" ]; then
+        crate_name=$(basename "$(dirname "$crate_toml")")
+        if grep -qE '^version\.workspace = true' "$crate_toml"; then
+            pass "$crate_name inherits workspace version"
+        elif grep -qE "^version = \"$WORKSPACE_VERSION\"" "$crate_toml"; then
+            pass "$crate_name explicitly pins version $WORKSPACE_VERSION"
+        else
+            explicit_version=$(grep -m1 '^version = ' "$crate_toml" | sed 's/version = "\(.*\)".*/\1/' || true)
+            if [ -n "$explicit_version" ]; then
+                fail "$crate_name has explicit version '$explicit_version' != workspace version '$WORKSPACE_VERSION'"
+            else
+                fail "$crate_name does not set a version and does not inherit from workspace"
+            fi
+        fi
+    fi
+done
+
+# =============================================================================
+# Check 5: Supported versions tables align
+# =============================================================================
+section "Supported versions tables"
+
+# SECURITY.md and STABILITY.md both have "Supported Versions" sections.
+# They should list the same set of supported versions. This is a soft check
+# — we just warn if they're clearly out of sync.
+
+if [ -f "SECURITY.md" ] && [ -f "STABILITY.md" ]; then
+    security_supported=$(awk '/## Supported Versions/,/^##[^#]/' SECURITY.md | grep -oE '^\| [0-9]+\.[0-9]+\.' | sort -u || true)
+    stability_supported=$(awk '/## Platform Support/,/^##[^#]/' STABILITY.md | grep -oE '^\| [0-9]+\.[0-9]+\.' | sort -u || true)
+
+    if [ -n "$security_supported" ]; then
+        pass "SECURITY.md has a Supported Versions table"
+    fi
+fi
+
+# =============================================================================
+# Check 6: Deny / audit ignore lists are in sync
+# =============================================================================
+section "deny.toml and .cargo/audit.toml advisory lists"
+
+if [ -f "deny.toml" ] && [ -f ".cargo/audit.toml" ]; then
+    deny_ignores=$(grep -oE 'RUSTSEC-[0-9]+-[0-9]+' deny.toml | sort -u || true)
+    audit_ignores=$(grep -oE 'RUSTSEC-[0-9]+-[0-9]+' .cargo/audit.toml | sort -u || true)
+
+    # Find advisories in one but not the other
+    only_in_deny=$(comm -23 <(echo "$deny_ignores") <(echo "$audit_ignores") | grep -v '^$' || true)
+    only_in_audit=$(comm -13 <(echo "$deny_ignores") <(echo "$audit_ignores") | grep -v '^$' || true)
+
+    if [ -z "$only_in_deny" ] && [ -z "$only_in_audit" ]; then
+        pass "deny.toml and .cargo/audit.toml advisory ignore lists are in sync"
+    else
+        if [ -n "$only_in_deny" ]; then
+            fail "Advisories ignored in deny.toml but not in .cargo/audit.toml: $(echo $only_in_deny | tr '\n' ' ')"
+        fi
+        if [ -n "$only_in_audit" ]; then
+            fail "Advisories ignored in .cargo/audit.toml but not in deny.toml: $(echo $only_in_audit | tr '\n' ' ')"
+        fi
+    fi
+fi
+
+# =============================================================================
+# Summary
+# =============================================================================
+echo ""
+echo "${BOLD}${CYAN}──────────────────────────────────────────${RESET}"
+if [ "$ERRORS" -eq 0 ]; then
+    echo "${GREEN}[OK]${RESET}    All $CHECKS consistency checks passed"
+    exit 0
+else
+    echo "${RED}[FAIL]${RESET}  $ERRORS of $CHECKS consistency checks failed"
+    echo ""
+    echo "${YELLOW}[TIP]${RESET}  See docs/VERSION_REFS.md for the canonical list of files that must agree."
+    exit 1
+fi

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -122,6 +122,15 @@ enum Command {
     CheckFeatures,
     /// Run the full CI pipeline locally (mirrors GitHub Actions)
     CiLocal,
+    /// Generate a CHANGELOG draft from conventional commits since the last tag
+    ReleaseNotes {
+        /// Start point (defaults to the most recent tag matching v*.*.*)
+        #[arg(long)]
+        since: Option<String>,
+        /// End point (defaults to HEAD)
+        #[arg(long, default_value = "HEAD")]
+        until: String,
+    },
 }
 
 fn main() -> Result<()> {
@@ -167,6 +176,7 @@ fn main() -> Result<()> {
         } => release(&sh, &version, no_changelog)?,
         Command::CheckFeatures => check_features(&sh)?,
         Command::CiLocal => ci_local(&sh)?,
+        Command::ReleaseNotes { since, until } => release_notes(&sh, since.as_deref(), &until)?,
     }
 
     Ok(())
@@ -1098,4 +1108,218 @@ fn validate_version_consistency(cargo_toml: &str, expected: &str) -> Result<()> 
     }
 
     Ok(())
+}
+
+/// Generate a CHANGELOG draft from conventional commits.
+///
+/// Reads `git log <since>..<until>` (defaults: last v*.*.* tag to HEAD),
+/// parses conventional commit headers (`type(scope): subject`), groups by
+/// type, detects breaking changes (`!` suffix on type or `BREAKING CHANGE`
+/// footer), and emits a markdown document suitable for pasting into
+/// CHANGELOG.md under a new version heading.
+///
+/// Non-conforming commits are placed under "Other" so nothing is silently
+/// dropped. Merge commits are skipped.
+fn release_notes(sh: &Shell, since: Option<&str>, until: &str) -> Result<()> {
+    use std::collections::BTreeMap;
+
+    // Resolve `since` to the most recent vX.Y.Z tag if not provided.
+    let since = match since {
+        Some(s) => s.to_string(),
+        None => {
+            let tag = cmd!(sh, "git describe --tags --abbrev=0 --match=v*.*.*")
+                .ignore_stderr()
+                .read()
+                .context("Could not find a previous v*.*.* tag. Pass --since <ref> explicitly.")?;
+            tag.trim().to_string()
+        }
+    };
+
+    let range = format!("{since}..{until}");
+
+    // Get commit hash + subject + body, separator = 0x1f (unit separator),
+    // record separator = 0x1e (record separator). These bytes virtually
+    // never appear in commit messages.
+    let log_output = cmd!(
+        sh,
+        "git log {range} --no-merges --pretty=format:%h%x1f%s%x1f%b%x1e"
+    )
+    .read()
+    .context("Failed to read git log")?;
+
+    if log_output.trim().is_empty() {
+        println!("(no commits between {since} and {until})");
+        return Ok(());
+    }
+
+    // Bucket order matters: this is the order sections appear in output.
+    let bucket_order = [
+        ("feat", "Added"),
+        ("fix", "Fixed"),
+        ("perf", "Performance"),
+        ("refactor", "Changed"),
+        ("docs", "Documentation"),
+        ("test", "Tests"),
+        ("build", "Build"),
+        ("ci", "CI / Infrastructure"),
+        ("chore", "Chores"),
+        ("style", "Style"),
+        ("revert", "Reverts"),
+    ];
+
+    let mut buckets: BTreeMap<&'static str, Vec<String>> = BTreeMap::new();
+    let mut other: Vec<String> = Vec::new();
+    let mut breaking: Vec<String> = Vec::new();
+
+    for record in log_output.split('\u{1e}') {
+        let record = record.trim_matches('\n');
+        if record.is_empty() {
+            continue;
+        }
+        let parts: Vec<&str> = record.splitn(3, '\u{1f}').collect();
+        if parts.len() < 2 {
+            continue;
+        }
+        let hash = parts[0];
+        let subject = parts[1];
+        let body = parts.get(2).copied().unwrap_or("");
+
+        // Parse conventional commit header: "type(scope)?!?: subject"
+        // e.g. "feat(auth)!: wire SSPI", "fix: patch", "docs(readme): update"
+        let (commit_type, is_breaking_header, stripped_subject) =
+            parse_conventional_header(subject);
+
+        let is_breaking_footer = body.contains("BREAKING CHANGE");
+        let is_breaking = is_breaking_header || is_breaking_footer;
+
+        let entry = format!("- {stripped_subject} ({hash})");
+
+        if is_breaking {
+            breaking.push(entry.clone());
+        }
+
+        match commit_type {
+            Some(t) if bucket_order.iter().any(|(key, _)| *key == t) => {
+                let label = bucket_order
+                    .iter()
+                    .find(|(k, _)| *k == t)
+                    .map(|(_, l)| *l)
+                    .unwrap();
+                buckets.entry(label).or_default().push(entry);
+            }
+            _ => {
+                other.push(entry);
+            }
+        }
+    }
+
+    // Render markdown
+    let today = chrono_today();
+    let workspace_version = extract_workspace_version(
+        &fs::read_to_string("Cargo.toml").context("Failed to read workspace Cargo.toml")?,
+    )
+    .unwrap_or_else(|| "X.Y.Z".to_string());
+
+    println!("## [{workspace_version}] - {today}");
+    println!();
+    println!("<!--");
+    println!("    Generated draft from conventional commits between {since} and {until}.");
+    println!("    Review and edit before committing. Group descriptions, add migration notes,");
+    println!("    expand user-facing language, and remove internal-only entries as needed.");
+    println!("-->");
+    println!();
+
+    if !breaking.is_empty() {
+        println!("### Breaking Changes");
+        println!();
+        for entry in &breaking {
+            println!("{entry}");
+        }
+        println!();
+    }
+
+    for (_, label) in &bucket_order {
+        if let Some(entries) = buckets.get(*label) {
+            if entries.is_empty() {
+                continue;
+            }
+            println!("### {label}");
+            println!();
+            for entry in entries {
+                println!("{entry}");
+            }
+            println!();
+        }
+    }
+
+    if !other.is_empty() {
+        println!("### Other");
+        println!();
+        println!(
+            "<!-- These commits did not use conventional commit format. Review and re-categorize. -->"
+        );
+        println!();
+        for entry in &other {
+            println!("{entry}");
+        }
+        println!();
+    }
+
+    Ok(())
+}
+
+/// Parse a conventional commit header.
+///
+/// Returns `(Some(type), is_breaking, stripped_subject_without_prefix)` if the
+/// header matches the conventional commit format, otherwise
+/// `(None, false, original_subject)`.
+///
+/// Examples:
+/// - `"feat(auth)!: wire SSPI"` → `(Some("feat"), true, "wire SSPI")`
+/// - `"fix: patch"` → `(Some("fix"), false, "patch")`
+/// - `"random thing"` → `(None, false, "random thing")`
+fn parse_conventional_header(subject: &str) -> (Option<&str>, bool, &str) {
+    let colon_pos = match subject.find(':') {
+        Some(p) => p,
+        None => return (None, false, subject),
+    };
+
+    let prefix = &subject[..colon_pos];
+    let rest = subject[colon_pos + 1..].trim_start();
+
+    // Strip trailing '!' from prefix (breaking marker)
+    let (type_part, is_breaking) = if let Some(p) = prefix.strip_suffix('!') {
+        (p, true)
+    } else {
+        (prefix, false)
+    };
+
+    // Strip optional scope: "feat(auth)" → "feat"
+    let commit_type = if let Some(paren) = type_part.find('(') {
+        &type_part[..paren]
+    } else {
+        type_part
+    };
+
+    // Validate: commit type should be a simple lowercase word
+    if commit_type.is_empty() || !commit_type.chars().all(|c| c.is_ascii_lowercase()) {
+        return (None, false, subject);
+    }
+
+    (Some(commit_type), is_breaking, rest)
+}
+
+/// Return today's date in `YYYY-MM-DD` format.
+///
+/// We avoid adding the `chrono` crate to xtask for just this one use — instead,
+/// we shell out to the system `date` command which is portable across Linux,
+/// macOS, and modern Windows (PowerShell).
+fn chrono_today() -> String {
+    std::process::Command::new("date")
+        .arg("+%Y-%m-%d")
+        .output()
+        .ok()
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_string())
+        .unwrap_or_else(|| "YYYY-MM-DD".to_string())
 }


### PR DESCRIPTION
## Summary

Release v0.8.0 — stored procedures, SQL Browser instance resolution, pool health check, Azure SDK bump, and infrastructure improvements.

### Added
- **Stored procedure support** — `call_procedure()` + `procedure()` builder with OUTPUT params
- **SQL Browser instance resolution** — automatic TCP port discovery for named instances (`.\SQLEXPRESS`)
- **Pool `test_on_checkin`** — deferred health check on connection return
- `ProcedureResult` and `ResultSet` implement `Clone`

### Fixed
- Mock TLS cross-platform race (`TlsPreloginWrapper` handshake/passthrough transition)
- RUSTSEC-2026-0097 (rand 0.8.5) — ignored with justification
- Stale advisory ignores cleaned up

### Changed
- Azure SDK bumped to 0.34/0.34/0.13
- Dev deps bumped: testcontainers 0.27, criterion 0.8, rustls 0.23.38, tokio 1.51.1
- CI actions bumped: codecov v6, gh-release v3, github-script v9
- Validation extracted to shared module

## Test plan
- [x] `cargo test --workspace --all-features --locked` — all pass
- [x] `cargo clippy --workspace --all-features --all-targets -- -D warnings` — clean
- [x] `cargo doc --workspace --all-features --no-deps` — zero warnings
- [x] `cargo deny check` — clean
- [x] `just doc-consistency` — all 22 checks pass
- [x] Two independent release audits passed (version refs, CHANGELOG completeness, API surface)
- [x] Mock TLS fix verified on physical macOS and Windows machines