### PR TITLE
docs: dedup version strings via versionless cargo add

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,10 +244,9 @@ for result in rows {
 
 Enable optional features:
 
-```toml
-[dependencies]
-mssql-client = { version = "0.11", features = ["otel"] }
-mssql-auth = { version = "0.11", features = ["sspi-auth"] }
+```bash
+cargo add mssql-client --features otel
+cargo add mssql-auth --features sspi-auth
 ```
 
 ## SQL Server Compatibility

--- a/crates/mssql-auth/README.md
+++ b/crates/mssql-auth/README.md
@@ -59,8 +59,8 @@ let azure_auth = AzureAdAuth::with_token("eyJ0eXAi...");
 
 Enable the `zeroize` feature for secure credential handling:
 
-```toml
-mssql-auth = { version = "0.11", features = ["zeroize"] }
+```bash
+cargo add mssql-auth --features zeroize
 ```
 
 This automatically zeroes sensitive data from memory when credentials are dropped.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -261,10 +261,8 @@ async fn query_with_fallback(
 
 ### OpenTelemetry Integration
 
-```toml
-# Cargo.toml
-[dependencies]
-mssql-client = { version = "0.11", features = ["otel"] }
+```bash
+cargo add mssql-client --features otel
 ```
 
 ```text

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -54,8 +54,8 @@ client.query(
 
 **Disable if:** You don't use date/time types or prefer manual parsing.
 
-```toml
-mssql-client = { version = "0.11", default-features = false, features = ["uuid", "decimal", "json"] }
+```bash
+cargo add mssql-client --no-default-features --features uuid,decimal,json
 ```
 
 ### uuid
@@ -139,8 +139,8 @@ client.execute(
 
 Enables OpenTelemetry instrumentation for distributed tracing:
 
-```toml
-mssql-client = { version = "0.11", features = ["otel"] }
+```bash
+cargo add mssql-client --features otel
 ```
 
 When enabled, the driver automatically creates spans for:
@@ -159,8 +159,8 @@ See [OPENTELEMETRY.md](OPENTELEMETRY.md) for detailed setup instructions.
 
 Enables secure credential wiping using the `zeroize` crate:
 
-```toml
-mssql-client = { version = "0.11", features = ["zeroize"] }
+```bash
+cargo add mssql-client --features zeroize
 ```
 
 When enabled:
@@ -176,8 +176,8 @@ When enabled:
 
 Enables async read/write access to SQL Server FILESTREAM BLOBs (Windows only):
 
-```toml
-mssql-client = { version = "0.11", features = ["sspi-auth", "filestream"] }
+```bash
+cargo add mssql-client --features sspi-auth,filestream
 ```
 
 When enabled:
@@ -215,8 +215,8 @@ The authentication crate (`mssql-auth`) provides these features:
 
 Enables Azure authentication methods:
 
-```toml
-mssql-auth = { version = "0.11", features = ["azure-identity"] }
+```bash
+cargo add mssql-auth --features azure-identity
 ```
 
 Provides:
@@ -229,8 +229,8 @@ Provides:
 
 Enables Kerberos/GSSAPI authentication on Linux and macOS:
 
-```toml
-mssql-auth = { version = "0.11", features = ["integrated-auth"] }
+```bash
+cargo add mssql-auth --features integrated-auth
 ```
 
 **Prerequisites:**
@@ -243,8 +243,8 @@ mssql-auth = { version = "0.11", features = ["integrated-auth"] }
 
 Enables Windows SSPI authentication via the cross-platform sspi-rs crate:
 
-```toml
-mssql-auth = { version = "0.11", features = ["sspi-auth"] }
+```bash
+cargo add mssql-auth --features sspi-auth
 ```
 
 Works on Windows natively and on other platforms when appropriate credentials are available.
@@ -255,8 +255,8 @@ Works on Windows natively and on other platforms when appropriate credentials ar
 
 Enables client certificate authentication for Azure AD Service Principal:
 
-```toml
-mssql-auth = { version = "0.11", features = ["cert-auth"] }
+```bash
+cargo add mssql-auth --features cert-auth
 ```
 
 Requires X.509 certificate and private key for authentication.
@@ -267,8 +267,8 @@ Requires X.509 certificate and private key for authentication.
 
 Enables Always Encrypted transparent column decryption:
 
-```toml
-mssql-auth = { version = "0.11", features = ["always-encrypted"] }
+```bash
+cargo add mssql-auth --features always-encrypted
 ```
 
 When `Column Encryption Setting=Enabled` is in the connection string, encrypted
@@ -308,54 +308,48 @@ Provides full standard library support including I/O and error handling.
 
 Enables compilation without the standard library, using only the `alloc` crate. Useful for embedded or constrained environments.
 
-```toml
-[dependencies]
-tds-protocol = { version = "0.11", default-features = false, features = ["alloc"] }
+```bash
+cargo add tds-protocol --no-default-features --features alloc
 ```
 
 ## Common Configurations
 
 ### Minimal (Smallest Binary)
 
-```toml
-[dependencies]
-mssql-client = { version = "0.11", default-features = false }
+```bash
+cargo add mssql-client --no-default-features
 ```
 
 Only basic types supported. No date/time, UUID, decimal, or JSON.
 
 ### Web Application (Typical)
 
-```toml
-[dependencies]
-mssql-client = { version = "0.11" }
+```bash
+cargo add mssql-client
 ```
 
 All default features enabled for broad type support.
 
 ### Production with Observability
 
-```toml
-[dependencies]
-mssql-client = { version = "0.11", features = ["otel"] }
+```bash
+cargo add mssql-client --features otel
 ```
 
 Default features plus OpenTelemetry tracing.
 
 ### High-Security Environment
 
-```toml
-[dependencies]
-mssql-client = { version = "0.11", features = ["zeroize", "otel"] }
+```bash
+cargo add mssql-client --features zeroize,otel
 ```
 
 All defaults plus secure credential handling and audit tracing.
 
 ### Numeric-Only Application
 
-```toml
-[dependencies]
-mssql-client = { version = "0.11", default-features = false, features = ["decimal"] }
+```bash
+cargo add mssql-client --no-default-features --features decimal
 ```
 
 Only decimal support, no date/time or JSON.

--- a/docs/FILESTREAM.md
+++ b/docs/FILESTREAM.md
@@ -12,9 +12,8 @@ SQL Server FILESTREAM stores `VARBINARY(MAX)` data directly on the NTFS filesyst
 
 ## Quick Start
 
-```toml
-[dependencies]
-mssql-client = { version = "0.11", features = ["sspi-auth", "filestream"] }
+```bash
+cargo add mssql-client --features sspi-auth,filestream
 ```
 
 ```rust

--- a/docs/MIGRATION_FROM_TIBERIUS.md
+++ b/docs/MIGRATION_FROM_TIBERIUS.md
@@ -459,9 +459,8 @@ tiberius = { version = "0.12", features = ["chrono", "rust_decimal"] }
 
 ### rust-mssql-driver
 
-```toml
-[dependencies]
-mssql-client = { version = "0.11", features = ["chrono", "decimal", "uuid"] }
+```bash
+cargo add mssql-client --features chrono,decimal,uuid
 ```
 
 Available features:

--- a/docs/OPENTELEMETRY.md
+++ b/docs/OPENTELEMETRY.md
@@ -6,9 +6,8 @@ rust-mssql-driver provides optional OpenTelemetry instrumentation for distribute
 
 Add the `otel` feature to your dependency:
 
-```toml
-[dependencies]
-mssql-client = { version = "0.11", features = ["otel"] }
+```bash
+cargo add mssql-client --features otel
 ```
 
 ## Automatic Instrumentation

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -202,9 +202,8 @@ fn setup_logging() {
 
 Enable the `otel` feature for distributed tracing:
 
-```toml
-[dependencies]
-mssql-client = { version = "0.11", features = ["otel"] }
+```bash
+cargo add mssql-client --features otel
 ```
 
 ```text


### PR DESCRIPTION
Follow-up to #118. Removes the version-string duplication at its source instead of just guarding it.

## Why

The version was hardcoded in 24 dependency snippets across README and docs. Pre-1.0, each is minor-pinned (`mssql-client = "0.11"` means `>=0.11.0, <0.12.0`), so every minor release stales all of them — that's the drift #118's linter catches but doesn't eliminate. (Post-1.0 this mostly evaporates: `= "1"` covers all 1.x. Pre-1.0 the minor is load-bearing and can't be dropped.)

## What

- Convert the 23 feature/configuration illustrations to `cargo add … --features …` (versionless, modern idiom). The version was incidental to what those snippets teach.
- Keep exactly one versioned TOML line — the canonical install in `README.md` (shown with the tokio pairing) — as the single guarded spot.

**Drift surface: 24 → 1.** The doc-consistency snippet check now guards that one line; a future minor bump can't re-stale the docs.

## Verification

doc-consistency (24 checks), all code-fence balance, and `cargo test -p doc-tests` (75) pass. Only `toml`→`bash` fences changed — no Rust doctest blocks were touched. Spot-checked rendering across all 8 files.