### PR TITLE
docs: compile-check the mssql-client doc examples (no_run, not ignore)

### DIFF
--- a/crates/mssql-client/src/blob.rs
+++ b/crates/mssql-client/src/blob.rs
@@ -12,7 +12,7 @@
 //!
 //! ## Usage
 //!
-//! ```rust,ignore
+//! ```text
 //! use mssql_client::blob::BlobReader;
 //! use tokio::io::AsyncReadExt;
 //!
@@ -77,7 +77,7 @@ use tokio::io::{AsyncRead, ReadBuf};
 ///
 /// # Example
 ///
-/// ```rust,ignore
+/// ```text
 /// use mssql_client::blob::BlobReader;
 /// use tokio::io::AsyncReadExt;
 ///

--- a/crates/mssql-client/src/browser.rs
+++ b/crates/mssql-client/src/browser.rs
@@ -15,7 +15,7 @@
 //!
 //! # Example
 //!
-//! ```rust,ignore
+//! ```text
 //! use mssql_client::browser::resolve_instance;
 //! use std::time::Duration;
 //!
@@ -66,7 +66,7 @@ const MAX_RESPONSE_SIZE: usize = 1024 + 3; // 3 bytes for header (type + length)
 ///
 /// # Example
 ///
-/// ```rust,ignore
+/// ```text
 /// let port = resolve_instance("localhost", "SQLEXPRESS", Duration::from_secs(2)).await?;
 /// ```
 pub(crate) async fn resolve_instance(

--- a/crates/mssql-client/src/bulk.rs
+++ b/crates/mssql-client/src/bulk.rs
@@ -13,7 +13,7 @@
 //!
 //! ## Usage
 //!
-//! ```rust,ignore
+//! ```text
 //! use mssql_client::{BulkInsertBuilder, BulkColumn, BulkOptions};
 //!
 //! let builder = BulkInsertBuilder::new("dbo.Users")
@@ -1331,7 +1331,9 @@ impl BulkInsert {
 ///
 /// # Example
 ///
-/// ```rust,ignore
+/// ```rust,no_run
+/// # use mssql_client::{BulkInsertBuilder, BulkColumn, SqlValue};
+/// # async fn ex(client: &mut mssql_client::Client<mssql_client::Ready>) -> Result<(), mssql_client::Error> {
 /// let builder = BulkInsertBuilder::new("dbo.Users")
 ///     .with_typed_columns(vec![
 ///         BulkColumn::new("id", "INT", 0)?,
@@ -1339,9 +1341,12 @@ impl BulkInsert {
 ///     ]);
 ///
 /// let mut writer = client.bulk_insert(&builder).await?;
-/// writer.send_row(&[&1i32, &"Alice"])?;
-/// writer.send_row(&[&2i32, &"Bob"])?;
+/// writer.send_row_values(&[SqlValue::Int(1), SqlValue::String("Alice".into())])?;
+/// writer.send_row_values(&[SqlValue::Int(2), SqlValue::String("Bob".into())])?;
 /// let result = writer.finish().await?;
+/// # let _ = result;
+/// # Ok(())
+/// # }
 /// ```
 pub struct BulkWriter<'a, S: crate::state::ConnectionState> {
     client: &'a mut crate::client::Client<S>,

--- a/crates/mssql-client/src/cancel.rs
+++ b/crates/mssql-client/src/cancel.rs
@@ -13,8 +13,8 @@
 //!
 //! ## Example
 //!
-//! ```rust,ignore
-//! use mssql_client::Client;
+//! ```rust,no_run
+//! # async fn ex(client: &mut mssql_client::Client<mssql_client::Ready>) -> Result<(), mssql_client::Error> {
 //! use std::time::Duration;
 //!
 //! // Get a cancel handle before starting the query
@@ -30,6 +30,9 @@
 //!
 //! // This query will be cancelled if it runs longer than 5 seconds
 //! let result = client.query("SELECT * FROM very_large_table", &[]).await;
+//! # let _ = result;
+//! # Ok(())
+//! # }
 //! ```
 //!
 //! ## Important Notes
@@ -154,11 +157,14 @@ impl CancelHandle {
     ///
     /// # Example
     ///
-    /// ```rust,ignore
+    /// ```rust,no_run
+    /// # async fn ex(client: &mut mssql_client::Client<mssql_client::Ready>) -> Result<(), mssql_client::Error> {
     /// let cancel_handle = client.cancel_handle();
     ///
     /// // From another task:
     /// cancel_handle.cancel().await?;
+    /// # Ok(())
+    /// # }
     /// ```
     pub async fn cancel(&self) -> Result<()> {
         let inner = self.inner.lock().await;

--- a/crates/mssql-client/src/change_tracking.rs
+++ b/crates/mssql-client/src/change_tracking.rs
@@ -12,7 +12,7 @@
 //!
 //! ## Usage
 //!
-//! ```rust,ignore
+//! ```text
 //! use mssql_client::change_tracking::{ChangeOperation, ChangeTrackingQuery};
 //!
 //! // Get current version for baseline

--- a/crates/mssql-client/src/client.rs
+++ b/crates/mssql-client/src/client.rs
@@ -231,7 +231,8 @@ impl<S: ConnectionState> Client<S> {
     ///
     /// # Example
     ///
-    /// ```rust,ignore
+    /// ```rust,no_run
+    /// # async fn ex(client: &mut mssql_client::Client<mssql_client::Ready>) -> Result<(), mssql_client::Error> {
     /// let result = client.procedure("dbo.CalculateSum")?
     ///     .input("@a", &10i32)
     ///     .input("@b", &20i32)
@@ -239,6 +240,9 @@ impl<S: ConnectionState> Client<S> {
     ///     .execute().await?;
     ///
     /// let sum = result.get_output("@result").unwrap();
+    /// # let _ = sum;
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn procedure(
         &mut self,
@@ -256,13 +260,16 @@ impl<S: ConnectionState> Client<S> {
     ///
     /// # Example
     ///
-    /// ```rust,ignore
+    /// ```rust,no_run
+    /// # async fn ex(client: &mut mssql_client::Client<mssql_client::Ready>) -> Result<(), mssql_client::Error> {
     /// let result = client.call_procedure("dbo.GetUser", &[&1i32]).await?;
     /// assert_eq!(result.return_value, 0);
     ///
     /// if let Some(rs) = result.first_result_set() {
     ///     println!("columns: {:?}", rs.columns());
     /// }
+    /// # Ok(())
+    /// # }
     /// ```
     pub async fn call_procedure(
         &mut self,
@@ -297,8 +304,9 @@ impl<S: ConnectionState> Client<S> {
     ///
     /// # Example
     ///
-    /// ```rust,ignore
-    /// use mssql_client::{BulkInsertBuilder, BulkColumn};
+    /// ```rust,no_run
+    /// # async fn ex(client: &mut mssql_client::Client<mssql_client::Ready>) -> Result<(), mssql_client::Error> {
+    /// use mssql_client::{BulkInsertBuilder, BulkColumn, SqlValue};
     ///
     /// let builder = BulkInsertBuilder::new("dbo.Users")
     ///     .with_typed_columns(vec![
@@ -307,10 +315,12 @@ impl<S: ConnectionState> Client<S> {
     ///     ]);
     ///
     /// let mut writer = client.bulk_insert(&builder).await?;
-    /// writer.send_row(&[&1i32, &"Alice"])?;
-    /// writer.send_row(&[&2i32, &"Bob"])?;
+    /// writer.send_row_values(&[SqlValue::Int(1), SqlValue::String("Alice".into())])?;
+    /// writer.send_row_values(&[SqlValue::Int(2), SqlValue::String("Bob".into())])?;
     /// let result = writer.finish().await?;
     /// println!("Inserted {} rows", result.rows_affected);
+    /// # Ok(())
+    /// # }
     /// ```
     pub async fn bulk_insert(
         &mut self,
@@ -496,11 +506,12 @@ impl<S: ConnectionState> Client<S> {
     ///
     /// # Example
     ///
-    /// ```rust,ignore
+    /// ```rust,no_run
+    /// # async fn ex(client: &mut mssql_client::Client<mssql_client::Ready>) -> Result<(), mssql_client::Error> {
     /// use mssql_client::{NamedParam, ToParams};
     ///
     /// // With derive macro:
-    /// #[derive(ToParams)]
+    /// #[derive(mssql_derive::ToParams)]
     /// struct UserQuery { name: String }
     ///
     /// let q = UserQuery { name: "Alice".into() };
@@ -515,6 +526,9 @@ impl<S: ConnectionState> Client<S> {
     ///     "SELECT * FROM users WHERE name = @name",
     ///     &params,
     /// ).await?;
+    /// # let _ = rows;
+    /// # Ok(())
+    /// # }
     /// ```
     pub async fn query_named<'a>(
         &'a mut self,
@@ -564,7 +578,8 @@ impl<S: ConnectionState> Client<S> {
     ///
     /// # Example
     ///
-    /// ```rust,ignore
+    /// ```rust,no_run
+    /// # async fn ex(client: &mut mssql_client::Client<mssql_client::Ready>) -> Result<(), mssql_client::Error> {
     /// use mssql_client::NamedParam;
     ///
     /// let params = vec![
@@ -575,6 +590,9 @@ impl<S: ConnectionState> Client<S> {
     ///     "INSERT INTO users (name, email) VALUES (@name, @email)",
     ///     &params,
     /// ).await?;
+    /// # let _ = rows_affected;
+    /// # Ok(())
+    /// # }
     /// ```
     pub async fn execute_named(
         &mut self,
@@ -641,12 +659,13 @@ impl Client<Ready> {
     ///
     /// # Example
     ///
-    /// ```rust,ignore
-    /// use futures::StreamExt;
-    ///
-    /// // Streaming (memory-efficient)
-    /// let mut stream = client.query("SELECT * FROM users WHERE id = @p1", &[&1]).await?;
-    /// while let Some(row) = stream.next().await {
+    /// ```rust,no_run
+    /// # use mssql_client::Row;
+    /// # fn process(_: &Row) {}
+    /// # async fn ex(client: &mut mssql_client::Client<mssql_client::Ready>) -> Result<(), mssql_client::Error> {
+    /// // Streaming (synchronous iteration over the result set)
+    /// let stream = client.query("SELECT * FROM users WHERE id = @p1", &[&1]).await?;
+    /// for row in stream {
     ///     let row = row?;
     ///     process(&row);
     /// }
@@ -657,6 +676,9 @@ impl Client<Ready> {
     ///     .await?
     ///     .collect_all()
     ///     .await?;
+    /// # let _ = rows;
+    /// # Ok(())
+    /// # }
     /// ```
     pub async fn query<'a>(
         &'a mut self,
@@ -731,7 +753,8 @@ impl Client<Ready> {
     ///
     /// # Example
     ///
-    /// ```rust,ignore
+    /// ```rust,no_run
+    /// # async fn ex(client: &mut mssql_client::Client<mssql_client::Ready>) -> Result<(), mssql_client::Error> {
     /// use std::time::Duration;
     ///
     /// // Execute with a 5-second timeout
@@ -742,6 +765,9 @@ impl Client<Ready> {
     ///         Duration::from_secs(5),
     ///     )
     ///     .await?;
+    /// # let _ = rows;
+    /// # Ok(())
+    /// # }
     /// ```
     pub async fn query_with_timeout<'a>(
         &'a mut self,
@@ -761,7 +787,8 @@ impl Client<Ready> {
     ///
     /// # Example
     ///
-    /// ```rust,ignore
+    /// ```rust,no_run
+    /// # async fn ex(client: &mut mssql_client::Client<mssql_client::Ready>) -> Result<(), mssql_client::Error> {
     /// // Execute a batch with multiple SELECT statements
     /// let mut results = client.query_multiple(
     ///     "SELECT 1 AS a; SELECT 2 AS b, 3 AS c;",
@@ -779,6 +806,8 @@ impl Client<Ready> {
     ///         println!("Result 2: {:?}", row);
     ///     }
     /// }
+    /// # Ok(())
+    /// # }
     /// ```
     pub async fn query_multiple<'a>(
         &'a mut self,
@@ -870,7 +899,8 @@ impl Client<Ready> {
     ///
     /// # Example
     ///
-    /// ```rust,ignore
+    /// ```rust,no_run
+    /// # async fn ex(client: &mut mssql_client::Client<mssql_client::Ready>) -> Result<(), mssql_client::Error> {
     /// use std::time::Duration;
     ///
     /// // Execute with a 10-second timeout
@@ -881,6 +911,9 @@ impl Client<Ready> {
     ///         Duration::from_secs(10),
     ///     )
     ///     .await?;
+    /// # let _ = rows_affected;
+    /// # Ok(())
+    /// # }
     /// ```
     pub async fn execute_with_timeout(
         &mut self,
@@ -951,12 +984,15 @@ impl Client<Ready> {
     ///
     /// # Example
     ///
-    /// ```rust,ignore
+    /// ```rust,no_run
+    /// # async fn ex(client: mssql_client::Client<mssql_client::Ready>) -> Result<(), mssql_client::Error> {
     /// use mssql_client::IsolationLevel;
     ///
     /// let tx = client.begin_transaction_with_isolation(IsolationLevel::Serializable).await?;
     /// // All operations in this transaction use SERIALIZABLE isolation
     /// tx.commit().await?;
+    /// # Ok(())
+    /// # }
     /// ```
     pub async fn begin_transaction_with_isolation(
         mut self,
@@ -1063,12 +1099,15 @@ impl Client<Ready> {
     ///
     /// # Example
     ///
-    /// ```rust,ignore
+    /// ```rust,no_run
+    /// # async fn ex(client: &mut mssql_client::Client<mssql_client::Ready>) -> Result<(), mssql_client::Error> {
     /// client.execute("BEGIN TRANSACTION", &[]).await?;
     /// assert!(client.is_in_transaction());
     ///
     /// client.execute("COMMIT", &[]).await?;
     /// assert!(!client.is_in_transaction());
+    /// # Ok(())
+    /// # }
     /// ```
     #[must_use]
     pub fn is_in_transaction(&self) -> bool {
@@ -1107,7 +1146,8 @@ impl Client<Ready> {
     ///
     /// # Example
     ///
-    /// ```rust,ignore
+    /// ```rust,no_run
+    /// # async fn ex(client: &mut mssql_client::Client<mssql_client::Ready>) -> Result<(), mssql_client::Error> {
     /// use std::time::Duration;
     ///
     /// let cancel_handle = client.cancel_handle();
@@ -1120,6 +1160,9 @@ impl Client<Ready> {
     ///
     /// // This query will be cancelled if it runs longer than 10 seconds
     /// let result = client.query("SELECT * FROM very_large_table", &[]).await;
+    /// # let _ = (handle, result);
+    /// # Ok(())
+    /// # }
     /// ```
     #[must_use]
     pub fn cancel_handle(&self) -> crate::cancel::CancelHandle {
@@ -1166,12 +1209,16 @@ impl Client<Ready> {
 /// Always ensure `commit()` or `rollback()` is called. Use helper patterns
 /// for error paths:
 ///
-/// ```rust,ignore
+/// ```rust,no_run
+/// # async fn do_work(_: &mssql_client::Client<mssql_client::InTransaction>) -> Result<(), mssql_client::Error> { Ok(()) }
+/// # async fn ex(client: mssql_client::Client<mssql_client::Ready>) -> Result<(), mssql_client::Error> {
 /// let tx = client.begin_transaction().await?;
 /// match do_work(&tx).await {
 ///     Ok(_) => { tx.commit().await?; }
 ///     Err(e) => { tx.rollback().await?; return Err(e); }
 /// }
+/// # Ok(())
+/// # }
 /// ```
 impl Client<InTransaction> {
     /// Execute a query within the transaction and return a streaming result set.
@@ -1339,7 +1386,7 @@ impl Client<InTransaction> {
     ///
     /// # Example
     ///
-    /// ```rust,ignore
+    /// ```text
     /// use mssql_client::FileStreamAccess;
     /// use tokio::io::AsyncReadExt;
     ///
@@ -1490,14 +1537,17 @@ impl Client<InTransaction> {
     ///
     /// # Example
     ///
-    /// ```rust,ignore
-    /// let tx = client.begin_transaction().await?;
-    /// tx.execute("INSERT INTO orders ...").await?;
+    /// ```rust,no_run
+    /// # async fn ex(client: mssql_client::Client<mssql_client::Ready>) -> Result<(), mssql_client::Error> {
+    /// let mut tx = client.begin_transaction().await?;
+    /// tx.execute("INSERT INTO orders ...", &[]).await?;
     /// let sp = tx.save_point("before_items").await?;
-    /// tx.execute("INSERT INTO items ...").await?;
+    /// tx.execute("INSERT INTO items ...", &[]).await?;
     /// // Oops, rollback just the items
     /// tx.rollback_to(&sp).await?;
     /// tx.commit().await?;
+    /// # Ok(())
+    /// # }
     /// ```
     pub async fn save_point(&mut self, name: &str) -> Result<SavePoint> {
         crate::validation::validate_identifier(name)?;
@@ -1520,11 +1570,14 @@ impl Client<InTransaction> {
     ///
     /// # Example
     ///
-    /// ```rust,ignore
+    /// ```rust,no_run
+    /// # async fn ex(mut tx: mssql_client::Client<mssql_client::InTransaction>) -> Result<(), mssql_client::Error> {
     /// let sp = tx.save_point("checkpoint").await?;
     /// // ... do some work ...
     /// tx.rollback_to(&sp).await?;  // Undo changes since checkpoint
     /// // Transaction is still active, savepoint is still valid
+    /// # Ok(())
+    /// # }
     /// ```
     pub async fn rollback_to(&mut self, savepoint: &SavePoint) -> Result<()> {
         tracing::debug!(name = savepoint.name(), "rolling back to savepoint");

--- a/crates/mssql-client/src/client/connect.rs
+++ b/crates/mssql-client/src/client/connect.rs
@@ -35,8 +35,13 @@ impl Client<Disconnected> {
     ///
     /// # Example
     ///
-    /// ```rust,ignore
+    /// ```rust,no_run
+    /// # use mssql_client::Client;
+    /// # async fn ex(config: mssql_client::Config) -> Result<(), mssql_client::Error> {
     /// let client = Client::connect(config).await?;
+    /// # let _ = client;
+    /// # Ok(())
+    /// # }
     /// ```
     pub async fn connect(config: Config) -> Result<Client<Ready>> {
         let retry = config.retry.clone();

--- a/crates/mssql-client/src/config.rs
+++ b/crates/mssql-client/src/config.rs
@@ -800,7 +800,10 @@ impl Config {
     ///
     /// # Example
     ///
-    /// ```rust,ignore
+    /// ```rust,no_run
+    /// # fn ex() -> Result<(), mssql_client::Error> {
+    /// use mssql_client::Config;
+    ///
     /// // Connection string (Tiberius-compatible)
     /// let config = Config::from_connection_string(
     ///     "Server=legacy-server;User Id=sa;Password=secret;Encrypt=no_tls"
@@ -810,6 +813,9 @@ impl Config {
     /// let config = Config::new()
     ///     .host("legacy-server")
     ///     .no_tls(true);
+    /// # let _ = config;
+    /// # Ok(())
+    /// # }
     /// ```
     #[must_use]
     pub fn no_tls(mut self, enabled: bool) -> Self {
@@ -827,14 +833,19 @@ impl Config {
     ///
     /// # Example
     ///
-    /// ```rust,ignore
+    /// ```rust,no_run
+    /// # #[cfg(feature = "always-encrypted")]
+    /// # fn ex() {
     /// use mssql_client::{Config, EncryptionConfig};
     /// use mssql_auth::InMemoryKeyStore;
     ///
+    /// let key_store = InMemoryKeyStore::new();
     /// let config = Config::new()
     ///     .with_column_encryption(
     ///         EncryptionConfig::new().with_provider(key_store)
     ///     );
+    /// # let _ = config;
+    /// # }
     /// ```
     #[cfg(feature = "always-encrypted")]
     #[must_use]

--- a/crates/mssql-client/src/filestream.rs
+++ b/crates/mssql-client/src/filestream.rs
@@ -15,7 +15,7 @@
 //!
 //! ## Usage
 //!
-//! ```rust,ignore
+//! ```text
 //! use mssql_client::{Client, Config, FileStream, FileStreamAccess};
 //!
 //! // Connect and begin a transaction (FILESTREAM requires a transaction)
@@ -171,7 +171,7 @@ pub mod open_options {
 ///
 /// # Example
 ///
-/// ```rust,ignore
+/// ```text
 /// use tokio::io::AsyncReadExt;
 /// use mssql_client::FileStreamAccess;
 ///

--- a/crates/mssql-client/src/from_row.rs
+++ b/crates/mssql-client/src/from_row.rs
@@ -8,7 +8,7 @@
 //! The recommended way to implement `FromRow` is via the derive macro from
 //! `mssql-derive`:
 //!
-//! ```rust,ignore
+//! ```rust,no_run
 //! use mssql_derive::FromRow;
 //!
 //! #[derive(FromRow)]
@@ -74,10 +74,11 @@ pub trait RowIteratorExt: Iterator<Item = Result<Row, Error>> + Sized {
     ///
     /// # Example
     ///
-    /// ```rust,ignore
+    /// ```rust,no_run
+    /// # async fn ex(client: &mut mssql_client::Client<mssql_client::Ready>) -> Result<(), mssql_client::Error> {
     /// use mssql_client::{FromRow, RowIteratorExt};
     ///
-    /// #[derive(FromRow)]
+    /// #[derive(mssql_derive::FromRow)]
     /// struct User { id: i32, name: String }
     ///
     /// let users: Vec<User> = client
@@ -85,6 +86,9 @@ pub trait RowIteratorExt: Iterator<Item = Result<Row, Error>> + Sized {
     ///     .await?
     ///     .map_rows::<User>()
     ///     .collect::<Result<Vec<_>, _>>()?;
+    /// # let _ = users;
+    /// # Ok(())
+    /// # }
     /// ```
     fn map_rows<T: FromRow>(self) -> MapRows<Self, T>;
 }

--- a/crates/mssql-client/src/procedure.rs
+++ b/crates/mssql-client/src/procedure.rs
@@ -5,7 +5,8 @@
 //!
 //! # Example
 //!
-//! ```rust,ignore
+//! ```rust,no_run
+//! # async fn ex(client: &mut mssql_client::Client<mssql_client::Ready>) -> Result<(), mssql_client::Error> {
 //! // Simple positional call (input parameters only)
 //! let result = client.call_procedure("dbo.GetUser", &[&1i32]).await?;
 //!
@@ -17,6 +18,9 @@
 //!     .execute().await?;
 //!
 //! let sum = result.get_output("@result").unwrap();
+//! # let _ = sum;
+//! # Ok(())
+//! # }
 //! ```
 //!
 //! ## How it works
@@ -57,7 +61,9 @@ use crate::stream::ProcedureResult;
 ///
 /// # Example
 ///
-/// ```rust,ignore
+/// ```rust,no_run
+/// # use mssql_client::SqlValue;
+/// # async fn ex(client: &mut mssql_client::Client<mssql_client::Ready>) -> Result<(), mssql_client::Error> {
 /// let result = client.procedure("dbo.CalculateSum")?
 ///     .input("@a", &10i32)
 ///     .input("@b", &20i32)
@@ -67,6 +73,8 @@ use crate::stream::ProcedureResult;
 /// // Access the output parameter
 /// let output = result.get_output("@result").expect("output param present");
 /// assert_eq!(output.value, SqlValue::Int(30));
+/// # Ok(())
+/// # }
 /// ```
 pub struct ProcedureBuilder<'a, S: ConnectionState> {
     client: &'a mut Client<S>,
@@ -93,11 +101,14 @@ impl<'a, S: ConnectionState> ProcedureBuilder<'a, S> {
     ///
     /// # Example
     ///
-    /// ```rust,ignore
+    /// ```rust,no_run
+    /// # async fn ex(client: &mut mssql_client::Client<mssql_client::Ready>) -> Result<(), mssql_client::Error> {
     /// client.procedure("dbo.UpdateUser")?
     ///     .input("@id", &42i32)
     ///     .input("@name", &"Alice")
     ///     .execute().await?;
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn input(&mut self, name: &str, value: &(dyn crate::ToSql + Sync)) -> &mut Self {
         // Use the shared conversion logic from params.rs.
@@ -124,10 +135,13 @@ impl<'a, S: ConnectionState> ProcedureBuilder<'a, S> {
     ///
     /// # Example
     ///
-    /// ```rust,ignore
+    /// ```rust,no_run
+    /// # async fn ex(client: &mut mssql_client::Client<mssql_client::Ready>) -> Result<(), mssql_client::Error> {
     /// client.procedure("dbo.GetCount")?
     ///     .output_int("@count")
     ///     .execute().await?;
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn output_int(&mut self, name: &str) -> &mut Self {
         self.params
@@ -183,12 +197,15 @@ impl<'a, S: ConnectionState> ProcedureBuilder<'a, S> {
     ///
     /// # Example
     ///
-    /// ```rust,ignore
+    /// ```rust,no_run
+    /// # async fn ex(client: &mut mssql_client::Client<mssql_client::Ready>) -> Result<(), mssql_client::Error> {
     /// use tds_protocol::rpc::TypeInfo;
     ///
     /// client.procedure("dbo.GetGuid")?
     ///     .output_raw("@id", TypeInfo::uniqueidentifier())
     ///     .execute().await?;
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn output_raw(&mut self, name: &str, type_info: RpcTypeInfo) -> &mut Self {
         self.params

--- a/crates/mssql-client/src/row.rs
+++ b/crates/mssql-client/src/row.rs
@@ -470,7 +470,7 @@ impl Row {
     ///
     /// # Example
     ///
-    /// ```rust,ignore
+    /// ```text
     /// use tokio::io::AsyncWriteExt;
     ///
     /// // Stream a large VARBINARY(MAX) column to a file
@@ -508,7 +508,7 @@ impl Row {
     ///
     /// # Example
     ///
-    /// ```rust,ignore
+    /// ```text
     /// let mut reader = row.get_stream_by_name("document_content")?;
     /// // Process the blob stream...
     /// ```

--- a/crates/mssql-client/src/stream.rs
+++ b/crates/mssql-client/src/stream.rs
@@ -62,15 +62,17 @@ pub(crate) enum PendingRow {
 ///
 /// # Example
 ///
-/// ```rust,ignore
-/// use futures::StreamExt;
-///
-/// let mut stream = client.query("SELECT * FROM large_table", &[]).await?;
-///
-/// while let Some(row) = stream.next().await {
+/// ```rust,no_run
+/// # use mssql_client::Row;
+/// # fn process_row(_: &Row) {}
+/// # async fn ex(client: &mut mssql_client::Client<mssql_client::Ready>) -> Result<(), mssql_client::Error> {
+/// let stream = client.query("SELECT * FROM large_table", &[]).await?;
+/// for row in stream {
 ///     let row = row?;
 ///     process_row(&row);
 /// }
+/// # Ok(())
+/// # }
 /// ```
 #[must_use = "streams must be consumed; dropping a stream discards remaining rows"]
 pub struct QueryStream<'a> {
@@ -337,7 +339,8 @@ impl ExecuteResult {
 ///
 /// # Example
 ///
-/// ```rust,ignore
+/// ```rust,no_run
+/// # async fn ex(client: &mut mssql_client::Client<mssql_client::Ready>) -> Result<(), mssql_client::Error> {
 /// let result = client.call_procedure("dbo.GetUser", &[&1i32]).await?;
 ///
 /// // Check the return value (RETURN statement in the proc)
@@ -350,6 +353,8 @@ impl ExecuteResult {
 ///         println!("{:?}", row);
 ///     }
 /// }
+/// # Ok(())
+/// # }
 /// ```
 #[derive(Debug, Clone)]
 #[non_exhaustive]
@@ -396,7 +401,9 @@ impl ProcedureResult {
     ///
     /// # Example
     ///
-    /// ```rust,ignore
+    /// ```rust,no_run
+    /// # use mssql_client::SqlValue;
+    /// # async fn ex(client: &mut mssql_client::Client<mssql_client::Ready>) -> Result<(), mssql_client::Error> {
     /// let result = client.procedure("dbo.CalculateSum")?
     ///     .input("@a", &10i32)
     ///     .input("@b", &20i32)
@@ -405,6 +412,8 @@ impl ProcedureResult {
     ///
     /// let output = result.get_output("@result").expect("output param exists");
     /// assert_eq!(output.value, SqlValue::Int(30));
+    /// # Ok(())
+    /// # }
     /// ```
     #[must_use]
     pub fn get_output(&self, name: &str) -> Option<&OutputParam> {
@@ -597,7 +606,8 @@ impl ResultSet {
 ///
 /// # Example
 ///
-/// ```rust,ignore
+/// ```rust,no_run
+/// # async fn ex(client: &mut mssql_client::Client<mssql_client::Ready>) -> Result<(), mssql_client::Error> {
 /// // Execute a batch with multiple SELECT statements
 /// let mut results = client.query_multiple("SELECT 1 AS a; SELECT 2 AS b, 3 AS c;", &[]).await?;
 ///
@@ -612,6 +622,8 @@ impl ResultSet {
 ///         println!("Result 2: {:?}", row);
 ///     }
 /// }
+/// # Ok(())
+/// # }
 /// ```
 #[must_use = "streams must be consumed; dropping a stream discards remaining results"]
 pub struct MultiResultStream<'a> {

--- a/crates/mssql-client/src/to_params.rs
+++ b/crates/mssql-client/src/to_params.rs
@@ -8,10 +8,11 @@
 //! The recommended way to implement `ToParams` is via the derive macro from
 //! `mssql-derive`:
 //!
-//! ```rust,ignore
-//! use mssql_derive::ToParams;
+//! ```rust,no_run
+//! # async fn ex(client: &mut mssql_client::Client<mssql_client::Ready>) -> Result<(), mssql_client::Error> {
+//! use mssql_client::ToParams;
 //!
-//! #[derive(ToParams)]
+//! #[derive(mssql_derive::ToParams)]
 //! struct NewUser {
 //!     name: String,
 //!     #[mssql(rename = "email_address")]
@@ -28,6 +29,8 @@
 //!     "INSERT INTO users (name, email_address) VALUES (@name, @email_address)",
 //!     &user.to_params()?,
 //! ).await?;
+//! # Ok(())
+//! # }
 //! ```
 //!
 //! ## Supported Attributes

--- a/crates/mssql-client/src/transaction.rs
+++ b/crates/mssql-client/src/transaction.rs
@@ -74,7 +74,8 @@ impl IsolationLevel {
 ///
 /// # Example
 ///
-/// ```rust,ignore
+/// ```rust,no_run
+/// # async fn ex(client: mssql_client::Client<mssql_client::Ready>) -> Result<(), mssql_client::Error> {
 /// let mut tx = client.begin_transaction().await?;
 ///
 /// tx.execute("INSERT INTO orders (customer_id) VALUES (@p1)", &[&42]).await?;
@@ -87,6 +88,8 @@ impl IsolationLevel {
 ///
 /// // Continue with different items...
 /// tx.commit().await?;
+/// # Ok(())
+/// # }
 /// ```
 #[derive(Debug, Clone)]
 #[must_use = "a savepoint should be used to rollback or it has no effect"]

--- a/crates/mssql-client/src/tvp.rs
+++ b/crates/mssql-client/src/tvp.rs
@@ -18,10 +18,11 @@
 //!
 //! Then use the `#[derive(Tvp)]` macro:
 //!
-//! ```rust,ignore
-//! use mssql_derive::Tvp;
+//! ```rust,no_run
+//! # async fn ex(client: &mut mssql_client::Client<mssql_client::Ready>) -> Result<(), mssql_client::Error> {
+//! use mssql_client::TvpValue;
 //!
-//! #[derive(Tvp)]
+//! #[derive(mssql_derive::Tvp)]
 //! #[mssql(type_name = "dbo.UserIdList")]
 //! struct UserIdList {
 //!     user_id: i32,
@@ -39,6 +40,8 @@
 //!     "EXEC GetUserDetails @UserIds = @user_ids",
 //!     &[&TvpValue::new(&user_ids)?],
 //! ).await?;
+//! # Ok(())
+//! # }
 //! ```
 //!
 //! ## Supported Attributes
@@ -105,7 +108,7 @@ impl TvpRow {
 ///
 /// # Example
 ///
-/// ```rust,ignore
+/// ```rust,no_run
 /// use mssql_client::{Tvp, TvpColumn, TvpRow};
 /// use mssql_types::{SqlValue, TypeError, ToSql};
 ///

--- a/crates/mssql-client/src/validation.rs
+++ b/crates/mssql-client/src/validation.rs
@@ -23,7 +23,7 @@ static IDENTIFIER_RE: Lazy<Regex> =
 ///
 /// # Examples
 ///
-/// ```rust,ignore
+/// ```text
 /// validate_identifier("my_table")?;     // OK
 /// validate_identifier("sp_test")?;      // OK
 /// validate_identifier("123abc")?;       // Error: starts with digit
@@ -53,7 +53,7 @@ pub(crate) fn validate_identifier(name: &str) -> Result<(), Error> {
 ///
 /// # Examples
 ///
-/// ```rust,ignore
+/// ```text
 /// validate_qualified_identifier("dbo.Users")?;            // OK (2 parts)
 /// validate_qualified_identifier("my_proc")?;              // OK (1 part)
 /// validate_qualified_identifier("catalog.dbo.Users")?;    // OK (3 parts)


### PR DESCRIPTION
## What

Converts every `rust,ignore` doc example in the `mssql-client` crate (≈50) to a compiled `no_run` example, or to `text` where the snippet is a genuine illustrative fragment. This closes the silent-drift hole: `rust,ignore` renders as Rust but is never compiled, so it can reference APIs that no longer exist.

## Real bugs this surfaced (none caught by humans or CI before)

- **Bulk insert never compiled.** `send_row(&[&1i32, &"Alice"])` builds a heterogeneous array; `send_row<T: ToSql>(&[T])` requires a uniform type. Fixed to `send_row_values(&[SqlValue::Int(1), SqlValue::String("Alice".into())])`, the form the integration tests use.
- **Save-point example missing an argument:** `tx.execute("...")` lacked the params slice.
- **Streaming example imported a non-dependency** (`futures::StreamExt`); `QueryStream` is iterated with `for row in stream`.
- **Derive macros did not resolve** (`#[derive(ToParams/FromRow/Tvp)]`) — only the traits are re-exported, so they are path-qualified to `mssql_derive::`.

## What became `text` (genuine fragments, per the repo's doc-tests convention)

FILESTREAM (Windows-only `cfg`), `browser`/`validation` (`pub(crate)`, not doctest-callable), and a few sketches with undefined bindings (`change_tracking`, `blob`, `row`, the bulk module walkthrough).

## Verification (run locally)

- `cargo test --doc -p mssql-client --all-features`: 63 pass, 0 ignored.
- `cargo test --doc -p mssql-client` (default features): 62 pass (cfg-gated examples elide).
- `RUSTDOCFLAGS=-D warnings cargo doc --no-deps -p mssql-client --all-features`: clean.
- Zero `rust,ignore` remain in `crates/mssql-client/src`.

## Scope

Only the `mssql-client` crate. The ~21 `rust,ignore` examples in the `mssql-auth` crates (Azure Key Vault, SSPI, Windows cert store) are left as-is — they need credentials or a specific platform to compile, so `ignore` is correct there. A follow-up could tackle those.