### PR TITLE
ci: bump codecov/codecov-action from v6 to v7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,7 +171,7 @@ jobs:
       - name: Generate coverage report
         run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@v7
         with:
           files: lcov.info
           fail_ci_if_error: false


### PR DESCRIPTION
Supersedes #106. Inputs unchanged; validated by CI's own Code Coverage job, and `fail_ci_if_error: false` means a Codecov-side problem cannot fail the build.