### PR TITLE
deps: bump libgssapi 0.9 -> 0.11 (with API adaptation)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2301,13 +2301,12 @@ checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
 name = "libgssapi"
-version = "0.9.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "834339e86b2561169d45d3b01741967fee3e5716c7d0b6e33cd4e3b34c9558cd"
+checksum = "e440a6151f5ef06571612e4121709aed90cfc0c40f8161f9090c71656758086d"
 dependencies = [
  "bitflags 2.11.0",
  "bytes",
- "lazy_static",
  "libgssapi-sys",
 ]
 

--- a/crates/mssql-auth/Cargo.toml
+++ b/crates/mssql-auth/Cargo.toml
@@ -48,7 +48,7 @@ azure_core = { workspace = true, optional = true }
 time = { version = "0.3", optional = true }
 
 # Optional: Integrated authentication (Kerberos/SPNEGO)
-libgssapi = { version = "0.9", optional = true }
+libgssapi = { version = "0.11", optional = true }
 
 # Optional: Windows SSPI authentication
 sspi = { version = "0.18", optional = true }

--- a/crates/mssql-auth/src/integrated_auth.rs
+++ b/crates/mssql-auth/src/integrated_auth.rs
@@ -118,7 +118,7 @@ impl IntegratedAuth {
 
     /// Create a GSSAPI Name from the stored SPN.
     fn create_service_name(&self) -> Result<Name, AuthError> {
-        Name::new(self.spn.as_bytes(), Some(&GSS_NT_HOSTBASED_SERVICE))
+        Name::new(self.spn.as_bytes(), Some(GSS_NT_HOSTBASED_SERVICE))
             .map_err(|e| AuthError::Sspi(format!("Failed to create service name: {e}")))
     }
 
@@ -135,17 +135,16 @@ impl IntegratedAuth {
         let service_name = self.create_service_name()?;
 
         // Acquire default credentials from the Kerberos ticket cache
-        let mut mechs =
-            OidSet::new().map_err(|e| AuthError::Sspi(format!("Failed to create OID set: {e}")))?;
+        let mut mechs = OidSet::new();
 
         // Add SPNEGO mechanism for negotiation
         mechs
-            .add(&GSS_MECH_SPNEGO)
+            .add(GSS_MECH_SPNEGO)
             .map_err(|e| AuthError::Sspi(format!("Failed to add SPNEGO mechanism: {e}")))?;
 
         // Also add Kerberos as fallback
         mechs
-            .add(&GSS_MECH_KRB5)
+            .add(GSS_MECH_KRB5)
             .map_err(|e| AuthError::Sspi(format!("Failed to add Kerberos mechanism: {e}")))?;
 
         let cred = Cred::acquire(None, None, CredUsage::Initiate, Some(&mechs))
@@ -156,7 +155,7 @@ impl IntegratedAuth {
             Some(cred),
             service_name,
             CtxFlags::GSS_C_MUTUAL_FLAG | CtxFlags::GSS_C_REPLAY_FLAG,
-            Some(&GSS_MECH_SPNEGO),
+            Some(GSS_MECH_SPNEGO),
         );
 
         // Get initial token


### PR DESCRIPTION
Supersedes #110, which was build-breaking as a raw bump.

## API changes adapted (libgssapi 0.11)

- `OidSet::new()` is now infallible (removed `.map_err(...)?`).
- `Name::new`, `OidSet::add`, and `ClientCtx::new` take `Oid` by value, not `&Oid` (removed the borrows).

All in `crates/mssql-auth/src/integrated_auth.rs` (the Kerberos/SPNEGO initiator).

## Verified

- `cargo build/clippy -p mssql-auth --features integrated-auth`: clean.
- `cargo test -p mssql-auth --features integrated-auth`: 45 pass.
- `cargo check --all-features` (whole workspace): clean.

## NOT verified (needs your help)

The live Kerberos handshake (`initialize` / `step` against a real KDC) is not exercised by CI. **Please validate this against a working Kerberos environment before relying on it.** The change is a mechanical API adaptation, but I can't confirm runtime behavior from here.