### PR TITLE
deps: bump OpenTelemetry stack (opentelemetry 0.32, tracing-opentelemetry 0.33)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2810,9 +2810,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
+checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -2824,15 +2824,16 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.31.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14ae4f5991976fd48df6d843de219ca6d31b01daaab2dad5af2badeded372bd"
+checksum = "9b59f80e1ac4d5ff7a2db8fb6c80badb7f0f3f858211fba08dd9aaec750894f9"
 dependencies = [
  "futures-channel",
  "futures-executor",
  "futures-util",
  "opentelemetry",
  "percent-encoding",
+ "portable-atomic",
  "rand 0.9.2",
  "thiserror 2.0.18",
 ]
@@ -4960,9 +4961,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.32.1"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac28f2d093c6c477eaa76b23525478f38de514fa9aeb1285738d4b97a9552fc"
+checksum = "adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26"
 dependencies = [
  "js-sys",
  "opentelemetry",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,11 +79,11 @@ regex = "1.11"
 lru = "0.18"
 
 # Observability (used with `otel` feature in individual crates)
-# All otel crates aligned at 0.31; tracing-opentelemetry 0.32 uses otel 0.31
-opentelemetry = "0.31"
-opentelemetry_sdk = "0.31"
-opentelemetry-otlp = "0.31"
-tracing-opentelemetry = "0.32"
+# All otel crates aligned at 0.32; tracing-opentelemetry 0.33 uses otel 0.32
+opentelemetry = "0.32"
+opentelemetry_sdk = "0.32"
+opentelemetry-otlp = "0.32"
+tracing-opentelemetry = "0.33"
 
 # Testing
 criterion = { version = "0.8", features = ["async_tokio"] }


### PR DESCRIPTION
Supersedes #109. Dependabot only proposed `tracing-opentelemetry` 0.33, but per the `Cargo.toml` alignment note that pulls `opentelemetry` 0.32, so all four otel crates move together to stay aligned (now at 0.32).

## Verified
- `cargo check --all-features`: clean.
- `cargo clippy --all-features --all-targets -- -D warnings`: clean.
- `cargo test -p mssql-client --features otel`: all pass, 0 failures.

The `mssql-client` instrumentation module compiles **unchanged** against the new versions — no code changes were needed, just the version bumps and the alignment comment.