### PR TITLE
ci: only save rust-cache from main to stop cache thrashing

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -39,6 +39,9 @@ jobs:
         with:
           # Cache the benchmark target directory
           cache-targets: true
+          # Only write caches from main so PR runs don't push total Actions cache
+          # usage over the 10 GB limit and evict main's caches (cache thrashing).
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Install Kerberos headers
         run: sudo apt-get update && sudo apt-get install -y libkrb5-dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,8 @@ jobs:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: taiki-e/install-action@nextest
       - uses: ./.github/actions/setup-linux-deps
       - name: Run tests
@@ -60,6 +62,11 @@ jobs:
         with:
           components: clippy, rustfmt
       - uses: Swatinem/rust-cache@v2
+        with:
+          # Only write caches from main. PRs restore main's cache but never save
+          # their own ~4 GB of per-PR entries, which were pushing total usage over
+          # the 10 GB Actions limit and LRU-evicting main's caches (cache thrashing).
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: ./.github/actions/setup-linux-deps
       - name: Check formatting
         run: cargo fmt --all -- --check
@@ -85,6 +92,11 @@ jobs:
         with:
           toolchain: ${{ steps.msrv.outputs.version }}
       - uses: Swatinem/rust-cache@v2
+        with:
+          # Only write caches from main. PRs restore main's cache but never save
+          # their own ~4 GB of per-PR entries, which were pushing total usage over
+          # the 10 GB Actions limit and LRU-evicting main's caches (cache thrashing).
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: ./.github/actions/setup-linux-deps
       - name: Check MSRV
         run: cargo check --all-features
@@ -96,6 +108,11 @@ jobs:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+        with:
+          # Only write caches from main. PRs restore main's cache but never save
+          # their own ~4 GB of per-PR entries, which were pushing total usage over
+          # the 10 GB Actions limit and LRU-evicting main's caches (cache thrashing).
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: ./.github/actions/setup-linux-deps
       - name: Build documentation
         run: cargo doc --all-features --no-deps
@@ -109,6 +126,11 @@ jobs:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+        with:
+          # Only write caches from main. PRs restore main's cache but never save
+          # their own ~4 GB of per-PR entries, which were pushing total usage over
+          # the 10 GB Actions limit and LRU-evicting main's caches (cache thrashing).
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: ./.github/actions/setup-linux-deps
       - name: Build examples
         run: cargo build --examples --all-features
@@ -166,6 +188,8 @@ jobs:
         with:
           components: llvm-tools-preview
       - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: taiki-e/install-action@cargo-llvm-cov
       - uses: ./.github/actions/setup-linux-deps
       - name: Generate coverage report
@@ -198,6 +222,8 @@ jobs:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: taiki-e/install-action@nextest
       - uses: ./.github/actions/setup-linux-deps
       - name: Wait for SQL Server
@@ -226,6 +252,11 @@ jobs:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+        with:
+          # Only write caches from main. PRs restore main's cache but never save
+          # their own ~4 GB of per-PR entries, which were pushing total usage over
+          # the 10 GB Actions limit and LRU-evicting main's caches (cache thrashing).
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: ./.github/actions/setup-linux-deps
       - name: Install cargo-hack
         run: cargo install cargo-hack --locked
@@ -253,6 +284,11 @@ jobs:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+        with:
+          # Only write caches from main. PRs restore main's cache but never save
+          # their own ~4 GB of per-PR entries, which were pushing total usage over
+          # the 10 GB Actions limit and LRU-evicting main's caches (cache thrashing).
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: ./.github/actions/setup-linux-deps
       - name: Dry-run package all publishable crates
         run: |


### PR DESCRIPTION
## What

Add `save-if: \${{ github.ref == 'refs/heads/main' }}` to every `Swatinem/rust-cache@v2` step in `ci.yml` (9 steps) and `benchmarks.yml` (1 step). PRs now restore main's caches but never write their own.

## Why (measured)

Actions cache usage is over the 10 GB limit, so GitHub LRU-evicts entries faster than they are reused:

| | caches | size |
|---|---|---|
| `refs/heads/main` | 12 | **5821 MB** |
| `refs/pull/*` (per-PR) | 9 | **4021 MB** |
| **total** | 21 | **9842 MB** (limit 10240 MB) |

The per-PR entries are pure overflow — they evict main's caches, which is why some PR jobs log `No cache found` and cold-compile (e.g. the benchmark job's 111 s cold build) while others hit. With `save-if: main`, steady-state usage drops to ~5.8 GB and all per-job caches stay resident, so PR jobs restore them instead of rebuilding.

## Evidence this is needed, not the dominant cost

Re-verified the prior audit: ci.yml caches are mostly *working* (a PR test job restored its cache and recompiled only the 13 first-party crates, not the dep graph). Thrashing is **intermittent**, caused by the over-budget state — this PR removes that pressure. The dominant PR time-to-green cost is the separate `benchmarks.yml` workflow (~13 min), addressed in a follow-up PR.

## Risk

Low. PRs still *restore* main's caches (read), they just don't *write*. No validation removed.