### PR TITLE
ci: reduced criterion sampling for benchmarks on PRs

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -44,6 +44,13 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y libkrb5-dev
 
       - name: Run benchmarks
+        env:
+          # The criterion run phase dominates this job (~600s of ~780s: 56 benches
+          # at criterion's default ~3s warm-up + ~5s measurement each). On PRs we
+          # only need a regression *signal* against the main baseline, so use
+          # reduced sampling (~2.5s/bench). Pushes to main keep full-fidelity
+          # timing because that run stores the baseline the comparison uses.
+          CRITERION_ARGS: ${{ github.event_name == 'pull_request' && '--warm-up-time 1 --measurement-time 1 --sample-size 10' || '' }}
         run: |
           # Run only criterion benchmark targets with bencher output format
           # Using explicit --bench flags avoids running lib tests which don't understand criterion flags
@@ -52,7 +59,7 @@ jobs:
             -p tds-protocol --bench protocol \
             -p mssql-types --bench types \
             -p mssql-client --bench client \
-            -- --output-format bencher 2>&1 | tee benchmark-output.txt
+            -- --output-format bencher $CRITERION_ARGS 2>&1 | tee benchmark-output.txt
 
       # Clean up any changes to Cargo.lock before switching branches
       # The benchmark action needs a clean working directory to switch to gh-pages


### PR DESCRIPTION
## What

On `pull_request` events, run the criterion benches with `--warm-up-time 1 --measurement-time 1 --sample-size 10`. Pushes to `main` keep full-fidelity default timing.

## Why (measured)

PR time-to-green is gated by `benchmarks.yml` (~13 min), **not** `ci.yml` (~5 min). Breakdown of one real bench job (782 s total):

| phase | time |
|---|---|
| cold compile (bench profile) | 111 s |
| **criterion run (56 benches × ~10.8 s)** | **606 s** |

The run phase is 77% of the job and no caching touches it — it's criterion's default ~3 s warm-up + ~5 s measurement per bench. Reduced sampling brings each bench to ~2.5 s, cutting the run phase ~70% (→ ~180 s) for an expected job time of **~300 s**.

## Regression detection is preserved, not dropped

- `main` pushes still run **full-fidelity** benches and store the baseline (`github-action-benchmark` only stores from `main`).
- The PR comparison step is already `continue-on-error: true` with a 120% alert threshold — it posts a comment, it doesn't block. Reduced sampling widens the confidence interval but the point estimate (ns/iter) that the threshold compares is unchanged for stable benches.
- This is exactly the "reduced-sample check on PRs, full benches on main" split.

## Note

Independent of #131 (cache thrashing). This branch is off `main`, so its bench job is cold — the measured win is the **run-phase** reduction; #131 additionally removes the cold compile by keeping the bench cache resident.