### PR TITLE
ci: fix publish dry-run to work on release PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -290,14 +290,19 @@ jobs:
           # the 10 GB Actions limit and LRU-evicting main's caches (cache thrashing).
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: ./.github/actions/setup-linux-deps
-      - name: Dry-run package all publishable crates
-        run: |
-          set -euo pipefail
-          for crate in tds-protocol mssql-types mssql-tls mssql-codec mssql-auth mssql-derive mssql-client mssql-driver-pool; do
-            echo "::group::$crate"
-            cargo publish -p "$crate" --dry-run --no-verify
-            echo "::endgroup::"
-          done
+      # Registry-independent invariant guarding the v0.11.0 incident directly:
+      # no published crate may carry a versioned first-party dev/build-dependency.
+      # Holds identically on release PRs, where the per-crate dry-run below cannot.
+      - name: Check publish invariants
+        run: bash scripts/check-publish-invariants.sh
+      # Workspace-aware dry-run: resolves sibling crates from the local workspace
+      # instead of crates.io, so it validates packaging + ordered dependency
+      # resolution even on release PRs whose versions are bumped ahead of the
+      # index. The old per-crate `cargo publish -p ... --dry-run` loop could not:
+      # downstream crates failed to resolve the just-bumped, not-yet-published
+      # first-party versions (the cause of the v0.11.1 Release PR CI failure).
+      - name: Workspace publish dry-run
+        run: cargo publish --workspace --dry-run --no-verify --exclude mssql-testing
 
   hygiene:
     name: Hygiene (typos, unused deps)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -302,6 +302,11 @@ jobs:
       # downstream crates failed to resolve the just-bumped, not-yet-published
       # first-party versions (the cause of the v0.11.1 Release PR CI failure).
       - name: Workspace publish dry-run
+        # rust-toolchain.toml pins 1.88, but `cargo publish --workspace` is stable
+        # only on cargo >= 1.90. Override to the installed stable for this step
+        # (this is packaging validation, not an MSRV check — the msrv job covers 1.88).
+        env:
+          RUSTUP_TOOLCHAIN: stable
         run: cargo publish --workspace --dry-run --no-verify --exclude mssql-testing
 
   hygiene:

--- a/scripts/check-publish-invariants.sh
+++ b/scripts/check-publish-invariants.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+#
+# Guards the v0.11.0 partial-publish incident class: a *versioned* first-party
+# dev- or build-dependency.
+#
+# cargo strips path-only dev/build-dependencies when packaging a crate, but keeps
+# versioned ones. So a published crate that dev-depends on a first-party crate
+# *with a version* demands that exact version on the crates.io index at publish
+# time. release-plz publishes crate-by-crate in runtime-dependency order and
+# ignores dev-deps for ordering, so that demand cannot be satisfied — the release
+# breaks mid-publish (exactly what happened to mssql-client -> mssql-derive in
+# v0.11.0). First-party dev/build-dependencies must therefore be path-only.
+#
+# Unlike `cargo publish --dry-run`, this invariant is registry-independent: it
+# holds identically on release PRs, where the workspace version is bumped ahead
+# of the crates.io index.
+set -euo pipefail
+
+violations=$(cargo metadata --no-deps --format-version 1 | jq -r '
+  .packages as $p
+  | ($p | map(.name)) as $members
+  | $p[]
+  | select(.publish != [])            # skip publish = false (never reaches the registry)
+  | .name as $pkg
+  | .dependencies[]
+  | select(.kind == "dev" or .kind == "build")
+  | select([.name] | inside($members))
+  | select(.req != "*")
+  | "  - \($pkg): \(.kind)-dependency on first-party `\(.name)` carries version `\(.req)` (must be path-only)"
+')
+
+if [ -n "$violations" ]; then
+  echo "error: versioned first-party dev/build-dependency found (v0.11.0 publish-incident class):"
+  echo "$violations"
+  echo
+  echo "Fix: declare these as path-only in [workspace.dependencies] (drop the version field)."
+  exit 1
+fi
+
+echo "OK: no versioned first-party dev/build-dependencies in publishable crates."


### PR DESCRIPTION
## Problem

The `Publish Dry-Run (packaging)` job — a **required, strict** status check — cannot pass on a release-plz Release PR. It runs `cargo publish -p <crate> --dry-run` per crate, which resolves each crate's first-party dependencies against **crates.io**. On a Release PR the workspace version is bumped ahead of the index, so downstream crates fail:

```
error: failed to prepare local package for uploading
Caused by:
  failed to select a version for the requirement `tds-protocol = "^0.11.1"`
  candidate versions found which didn't match: 0.11.0, ...
```

This is a [known cargo limitation](https://github.com/crate-ci/cargo-release/issues/691), not a repo bug — the real ordered publish succeeds because release-plz publishes `tds-protocol` before `mssql-codec`. But the required check blocks the v0.11.1 Release PR (#119) from merging.

The job was added in the post-v0.11.0 hardening and falsification-tested only against the *0.11.0 tree* (versions already on crates.io), so this failure mode was never exercised.

## Fix

Replace the per-crate loop with two complementary checks:

1. **`scripts/check-publish-invariants.sh`** — a registry-independent invariant that guards the actual v0.11.0 incident **directly**: no publishable crate may carry a *versioned* first-party `dev`/`build` dependency. cargo keeps versioned dev-deps when packaging (path-only ones are stripped), so such a dep demands that version on the index at publish time — the `mssql-client → mssql-derive@0.11.0` cycle that broke v0.11.0. Because it reads `cargo metadata`, not the registry, it holds **identically on Release PRs**.
2. **`cargo publish --workspace --dry-run`** — resolves sibling crates from the local workspace instead of crates.io, validating packaging + ordered dependency resolution even when versions are bumped ahead of the index. `--workspace`/`--exclude` are stable on CI's `@stable` (1.92).

## Falsification test (run locally against a bumped, unpublished 0.12.0 tree)

| Test | Result |
|------|--------|
| Old per-crate loop on 0.12.0 bump | **FAIL at `mssql-codec`** — reproduces #119 |
| `cargo publish --workspace --dry-run` on 0.12.0 bump | **PASS** — siblings resolve locally |
| Invariant lint, clean tree | **OK** |
| Invariant lint, v0.11.0 bug reintroduced (`mssql-derive` versioned) | **FAIL**, pinpoints `mssql-client → mssql-derive` |

The test also surfaced (and I fixed) a false-positive: the lint must exempt `publish = false` crates (`mssql-testing`), whose dev-deps never reach the registry.

## Scope note

Kept `--no-verify` to preserve the job's original scope (packaging + dependency resolution, the incident class) rather than expanding it to standalone build-verification of each packaged crate. Happy to enable full verification as a follow-up if wanted.

## Effect on #119

Once merged to `main`, the v0.11.1 Release PR's `Publish Dry-Run (packaging)` check will pass, unblocking the release when you're ready.