### PR TITLE
ci: trim debuginfo to line-tables-only in CI builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,12 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: -D warnings
+  # Trim debuginfo in CI builds: ~10% faster compile and ~39% smaller target dir,
+  # which shrinks rust-cache entries and compounds the save-if cache fix. line-tables
+  # keeps file/line backtraces. Set via env (not Cargo.toml) so local debugging keeps
+  # full debuginfo.
+  CARGO_PROFILE_DEV_DEBUG: line-tables-only
+  CARGO_PROFILE_TEST_DEBUG: line-tables-only
 
 jobs:
   test:


### PR DESCRIPTION
## What

Set `CARGO_PROFILE_DEV_DEBUG` / `CARGO_PROFILE_TEST_DEBUG` = `line-tables-only` in the CI workflow env. This is hypothesis #2 (build-cost) from the CI-speedup audit — the debuginfo half.

## Why (measured — controlled local cold-build A/B)

Cold build of workspace test binaries (default features), full debug vs line-tables-only:

| | Full debug | line-tables-only | Δ |
|---|---|---|---|
| Cold build wall time | 42.5s | 38.3s | **−10%** (single-sample, directional) |
| Target dir size | 3.3 GB | 2.0 GB | **−39%** (deterministic) |

The **−39% target size** is the main win: it shrinks every `rust-cache` entry, compounding #131's `save-if` fix and giving more headroom under the 10 GB Actions cache limit (the test-linux cache ~846 MB → ~500 MB). The build-time gain is modest but lands on the critical-path jobs (windows/ubuntu test).

`line-tables-only` keeps file/line numbers in backtraces; only debugger variable inspection is reduced. Applied via **env, not `Cargo.toml`**, so local development keeps full debuginfo.

## Scope

Debuginfo only. The other half of audit #2 — lld/rust-lld linker — is a separate, riskier change (Windows linker swap) that I'm keeping out so this stays a clean one-variable measurement. Can follow up if the windows link time still justifies it.

## Note on measurement in CI

The first `main` run after merge re-warms caches at the new (smaller) debug level — a one-time rebuild. Steady-state PR runs then restore the smaller cache.