### PR TITLE
docs: add docs.rs metadata so non-default feature APIs are documented

### DIFF
--- a/crates/mssql-auth/Cargo.toml
+++ b/crates/mssql-auth/Cargo.toml
@@ -9,6 +9,12 @@ repository.workspace = true
 keywords = ["sql-server", "authentication", "azure", "security"]
 categories = ["authentication", "database"]
 
+[package.metadata.docs.rs]
+# docs.rs builds on Linux x86_64, so document the features that build there.
+# Excluded: sspi-auth + windows-certstore (Windows-only deps) and integrated-auth
+# (libgssapi system library not guaranteed on docs.rs).
+features = ["azure-identity", "cert-auth", "zeroize", "always-encrypted", "azure-keyvault"]
+
 [features]
 default = []
 # Azure Managed Identity and Service Principal authentication

--- a/crates/mssql-client/Cargo.toml
+++ b/crates/mssql-client/Cargo.toml
@@ -9,6 +9,11 @@ repository.workspace = true
 keywords = ["sql-server", "mssql", "database", "async", "tokio"]
 categories = ["database", "asynchronous"]
 
+[package.metadata.docs.rs]
+# docs.rs builds on Linux x86_64. Excluded: sspi-auth (Windows-only) and
+# integrated-auth (libgssapi system library not guaranteed on docs.rs).
+features = ["otel", "json", "always-encrypted", "zeroize", "encoding", "tls", "chrono", "uuid", "decimal", "filestream"]
+
 [features]
 default = ["chrono", "uuid", "decimal", "encoding", "tls"]
 # Type support features — forwarded to mssql-types

--- a/crates/mssql-pool/Cargo.toml
+++ b/crates/mssql-pool/Cargo.toml
@@ -9,6 +9,11 @@ repository.workspace = true
 keywords = ["sql-server", "pool", "connection", "async"]
 categories = ["database", "asynchronous"]
 
+[package.metadata.docs.rs]
+# docs.rs builds on Linux x86_64. Excluded: sspi-auth (Windows-only) and
+# integrated-auth (libgssapi system library not guaranteed on docs.rs).
+features = ["otel", "filestream"]
+
 [features]
 default = []
 # Integrated authentication (Kerberos/SPNEGO) - Linux/macOS

--- a/crates/mssql-types/Cargo.toml
+++ b/crates/mssql-types/Cargo.toml
@@ -9,6 +9,11 @@ repository.workspace = true
 keywords = ["sql-server", "types", "conversion"]
 categories = ["database"]
 
+[package.metadata.docs.rs]
+# Without this, docs.rs builds default features only, hiding non-default public
+# API (json, encoding). All features build on docs.rs (Linux), so document all.
+all-features = true
+
 [features]
 default = ["chrono", "uuid", "decimal"]
 chrono = ["dep:chrono"]

--- a/crates/tds-protocol/Cargo.toml
+++ b/crates/tds-protocol/Cargo.toml
@@ -9,6 +9,11 @@ repository.workspace = true
 keywords = ["tds", "sql-server", "protocol", "no_std"]
 categories = ["parser-implementations", "no-std"]
 
+[package.metadata.docs.rs]
+# Without this, docs.rs builds default features only, hiding non-default public
+# API. All features build on docs.rs (Linux), so document them all.
+all-features = true
+
 [features]
 default = ["std", "encoding"]
 std = []


### PR DESCRIPTION
## What

Add `[package.metadata.docs.rs]` to the 5 published crates that have non-default features, so docs.rs documents those features instead of building default-only.

## Why

Maturity-audit finding **D-01**: with no docs.rs metadata, docs.rs builds **default features only** — so `always-encrypted`, `otel`, Azure auth (`azure-identity`/`cert-auth`/`azure-keyvault`), `json`, `encoding`, and `filestream` public API was **invisible on docs.rs** to anyone evaluating the crate. Verified: 0 of 8 published crates had the metadata.

## Config (each feature set verified to `cargo doc`-build on Linux x86_64 = docs.rs target)

| Crate | Setting |
|---|---|
| `tds-protocol`, `mssql-types` | `all-features = true` (all pure-Rust) |
| `mssql-auth` | `azure-identity, cert-auth, zeroize, always-encrypted, azure-keyvault` |
| `mssql-driver-pool` | `otel, filestream` |
| `mssql-client` | `otel, json, always-encrypted, zeroize, encoding, tls, chrono, uuid, decimal, filestream` |

**Excluded** (would break the Linux docs.rs build): Windows-only `sspi-auth` / `windows-certstore`, and `integrated-auth` (libgssapi system lib not guaranteed on docs.rs). Documenting those would require adding a Windows target to docs.rs — a separate, riskier change I've left out.

`mssql-tls` / `mssql-codec` / `mssql-derive` have no non-default features, so they need no metadata (nothing hidden).

## Verification

- Each feature set above doc-builds cleanly on Linux (ran `cargo doc --no-deps -p <crate> --features <set>`).
- `cargo metadata` parses all manifests; the metadata reads back correctly per crate.
- No effect on any build/test/CI command — this is registry-display metadata consumed only by docs.rs.

## Note

Effect is visible only after the next publish (docs.rs rebuilds per release). It can't be confirmed live until v0.12.0 ships.