### PR TITLE
ci: actually run the ignored live tests in the integration job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -243,8 +243,16 @@ jobs:
             sleep 2
           done
       - name: Run integration tests
-        # Run with all features to test full functionality
-        run: cargo nextest run --all-features
+        # Live tests are #[ignore]d, so the plain `nextest run` this job used
+        # to invoke ran zero of them while the SQL Server container idled.
+        # Run ONLY the ignored set here (non-ignored tests are covered by the
+        # Test matrix). Tests that need infrastructure CI lacks (Azure SQL,
+        # Azure identity, client certificates) are excluded explicitly; they
+        # still fail loudly when run locally without configuration.
+        run: >-
+          cargo nextest run --all-features --run-ignored ignored-only
+          --no-fail-fast
+          -E 'not (binary(azure_sql) or test(azure_identity_auth) or test(cert_auth))'
         env:
           MSSQL_HOST: localhost
           MSSQL_PORT: 1433


### PR DESCRIPTION
## Summary

Review finding 2: the "Integration Tests" job ran `cargo nextest run --all-features`, which skips `#[ignore]`d tests. Every test that connects to a server is ignored, so the job ran **zero live tests** while the SQL Server 2022 service container idled — green on every PR since its introduction. The v0.9.0 AE regression shipped through exactly this gap.

## Change

One command, three parts:

- `--run-ignored ignored-only` — run the live set; the non-ignored tests are already covered by the cross-platform Test matrix, so running them here again added nothing.
- `--no-fail-fast` — first local run proved the need: nextest's default fail-fast cancelled 224 of 244 tests after the first failure, masking the real state of the suite.
- `-E 'not (binary(azure_sql) or test(azure_identity_auth) or test(cert_auth))'` — 12 ignored tests require infrastructure CI does not have (live Azure SQL, Azure managed identity/service principal, client certificates); one of them burns ~99 s in credential retries before failing. Excluded **visibly in the workflow** rather than by softening the tests — they still fail loudly when run locally without configuration.

## Verification

Ran the exact final command locally against the same `mcr.microsoft.com/mssql/server:2022-latest` image CI uses:

- **232/232 ignored tests pass in ~11 s** — pool integration, stress, resilience, collation, bulk insert, RPC round-trip, stored procedures, protocol conformance, version compatibility, edge cases, and the two Always Encrypted live tests (first-ever live exercise of the wire-metadata path with the canonical CEK envelope from #137).
- The unfiltered run confirms the excluded 12 are precisely the external-infrastructure set; everything else passes.

The job's runtime grows by ~11 s of test execution; previously it spent its entire duration compiling and running nothing live.