### PR TITLE
docs: correct claims that drifted from implementation reality

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -537,12 +537,18 @@ if results.next_result().await? {
 
 **Decision:** Results are streamed by default with optional buffering.
 
+> **Implementation status (2026-06):** what ships today is *lazy decode over
+> a buffered response*: the full TDS payload is reassembled in memory, then
+> rows are decoded one at a time as pulled (peak memory ≈ raw payload size,
+> not payload + `Vec<Row>`). True incremental network streaming is not
+> implemented. See the `mssql-client` `stream` module docs.
+
 **Streaming (Default):**
 ```rust
 let rows = client.query("SELECT * FROM large_table", &[]).await?;
 for row in rows {
     let _row = row?;
-    // Process row - memory usage stays constant
+    // Rows decode lazily; peak memory ~ raw response payload
 }
 ```
 
@@ -1330,6 +1336,12 @@ impl Default for TimeoutConfig {
 
 ### 4.5 Prepared Statement Lifecycle
 
+> **Implementation status (2026-06):** this section documents the intended
+> design. The `StatementCache` type exists but is not consulted by any query
+> path — all parameterized queries currently go through `sp_executesql`
+> (SQL Server's server-side plan cache still provides plan reuse). See
+> LIMITATIONS.md § Prepared Statement Cache.
+
 SQL Server supports server-side prepared statements via RPC calls. The driver manages statement handles transparently to optimize repeated query execution.
 
 #### Protocol Flow
@@ -1414,7 +1426,8 @@ When a connection is returned to the pool:
 #### Usage Example
 
 ```rust
-// Automatic statement caching (the only mode — there is no explicit prepare API)
+// Intended behavior once the cache is wired (today every iteration goes
+// through sp_executesql; there is no explicit prepare API either way):
 for user_id in user_ids {
     // First iteration: sp_prepare + sp_execute
     // Subsequent iterations: sp_execute only (cache hit)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ Refer to `ARCHITECTURE.md` (v1.2.0) for complete details. Critical decisions:
 Always Encrypted is fully implemented via the `always-encrypted` feature with production-ready key providers:
 1. **`InMemoryKeyStore`** - For development/testing
 2. **`AzureKeyVaultProvider`** - For Azure Key Vault (`azure-identity` feature)
-3. **`WindowsCertStoreProvider`** - For Windows Certificate Store (`sspi-auth` feature, Windows only)
+3. **`WindowsCertStoreProvider`** - For Windows Certificate Store (`windows-certstore` feature, Windows only)
 4. Implement the `KeyStoreProvider` trait for custom key storage
 5. **Do NOT use ENCRYPTBYKEY** - it does not provide the same security guarantees
 
@@ -131,6 +131,11 @@ impl Client<Ready> {
 ```
 
 ### Prepared Statement Lifecycle
+
+**Status: designed, not wired.** The LRU cache exists in
+`mssql-client/src/statement_cache.rs` but no query path consults it — every
+parameterized query uses `sp_executesql` (server-side plan cache still gives
+plan reuse). The intended design when wiring lands:
 
 1. Hash SQL → check LRU cache
 2. Cache miss → `sp_prepare` → store handle
@@ -282,8 +287,8 @@ Key differences for migrators:
 | `Client::connect()` | `Client::connect()` (type-state) |
 | External pooling (bb8) | Built-in `Pool` |
 | Runtime agnostic | Tokio-only |
-| `QueryResult` iterator | Streaming `RowStream` |
-| Manual prepared | Auto-cached prepared statements |
+| `QueryResult` iterator | `RowStream` (lazy decode; response buffered) |
+| Manual prepared | `sp_executesql` (client cache planned) |
 | Manual Azure redirect | Automatic redirect handling |
 
 ## Commit Standards

--- a/LIMITATIONS.md
+++ b/LIMITATIONS.md
@@ -17,6 +17,8 @@ For supported features, see [README.md](README.md).
 | Data Types | GEOMETRY, GEOGRAPHY | Use `STAsText()` or `STAsGeoJSON()` |
 | Data Types | HIERARCHYID | Use `.ToString()` |
 | Data Types | CLR UDTs | Cast to VARBINARY |
+| Performance | Prepared statement cache (not wired) | `sp_executesql` server plan cache |
+| Auth | Kerberos untested against live KDC | SQL auth, NTLM, or Azure AD |
 | Platforms | SQL Server 2005 and earlier | Upgrade to SQL Server 2008+ |
 | Platforms | 32-bit systems | Use 64-bit |
 | Runtime | Non-Tokio runtimes | Use Tokio |
@@ -95,11 +97,30 @@ tokio::spawn(async move {
 
 ### Prepared Statement Cache
 
-**Status:** LRU only (no TTL)
+**Status:** Not wired — all parameterized queries use `sp_executesql`
 
-Cached statements are evicted by LRU policy, not time-based expiration.
+An LRU statement cache exists in the codebase but is not consulted by any
+query path: the driver never issues `sp_prepare`/`sp_execute`. Every
+parameterized query goes through `sp_executesql`, which still benefits from
+SQL Server's server-side plan cache, so repeated queries reuse plans —
+there is just no client-side handle caching yet.
 
-**Workaround:** Configure appropriate cache size or periodically recycle connections via `idle_timeout`.
+**Workaround:** None needed for plan reuse (`sp_executesql` provides it).
+Client-side handle caching is planned.
+
+---
+
+### Kerberos / Integrated Authentication (Untested Live)
+
+**Status:** Implemented but never validated against a live KDC
+
+The `integrated-auth` feature (Kerberos/GSSAPI via libgssapi) compiles and
+has unit tests, but no end-to-end authentication against a real KDC or
+domain-joined SQL Server has been performed. Treat it as experimental until
+live validation lands.
+
+**Workaround:** SQL authentication, cross-platform NTLM, or Azure AD are
+the validated paths.
 
 ---
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -23,10 +23,11 @@ Maintainers are responsible for:
    [Security Advisory](https://github.com/praxiomlabs/rust-mssql-driver/security/advisories/new)
    channel rather than discussing them publicly.
 
-3. **Releases** — Following [RELEASING.md](RELEASING.md) to cut new versions
-   when the dev branch has accumulated meaningful changes. Maintainers must
-   ensure all Cardinal Rules in RELEASING.md are satisfied before pushing a
-   release tag.
+3. **Releases** — Releases are automated by release-plz: merging the
+   Release PR it maintains *is* the release (publish, tag, GitHub Release).
+   Maintainers must ensure all Cardinal Rules in
+   [RELEASING.md](RELEASING.md) are satisfied before merging a Release PR,
+   and never publish or tag by hand.
 
 4. **Stewardship** — Keeping the project's documented policies (STABILITY.md,
    SECURITY.md, CODE_OF_CONDUCT.md, this file) honest and up to date. When a

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -10,7 +10,7 @@ This guide helps you migrate from [tiberius](https://github.com/prisma/tiberius)
 | Type-state | No | Yes (compile-time safety) |
 | Connection pooling | External (bb8/deadpool) | Built-in |
 | TDS 8.0 strict | Not supported | Yes |
-| Prepared statements | Manual | Auto-cached LRU |
+| Prepared statements | Manual | `sp_executesql` (client-side cache planned) |
 | Azure redirects | Manual handling | Automatic |
 | Result streaming | Iterator | Stream with collect |
 | Transaction safety | Runtime checks | Compile-time checks |
@@ -378,10 +378,11 @@ for user_id in user_ids {
 ### rust-mssql-driver
 
 ```rust
-// Automatic LRU caching
+// Same model as Tiberius today: each parameterized execution goes through
+// sp_executesql. SQL Server's server-side plan cache reuses the plan across
+// calls; client-side handle caching (sp_prepare/sp_execute) is planned but
+// not yet wired (see LIMITATIONS.md).
 for user_id in user_ids {
-    // First call: sp_prepare + sp_execute
-    // Subsequent calls: sp_execute only (cache hit)
     let mut stream = client.query(
         "SELECT * FROM users WHERE id = @p1",
         &[&user_id]

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ An async Microsoft SQL Server driver for Rust.
 | TDS 7.3 (Legacy) | Yes | SQL Server 2008/2008 R2 |
 | TDS 8.0 Strict Mode | Yes | SQL Server 2022+ |
 | Azure Managed Identity | Yes | Via `azure-identity` |
-| Kerberos/GSSAPI | Yes | Unix via `libgssapi` |
+| Kerberos/GSSAPI | Untested | Unix via `libgssapi`; not yet validated against a live KDC |
 | Windows SSPI | Yes | Via `sspi-auth` feature |
 | Table-Valued Parameters | Yes | Via `Tvp` type |
 | OpenTelemetry Metrics | Yes | Query + pool lifecycle via `otel` feature |
@@ -330,20 +330,20 @@ Compared with the other Rust options for SQL Server connectivity, based on sourc
 | Always Encrypted (read) | Yes | No (#54) | Via ODBC | No |
 | Always Encrypted (write) | Partial — NULL only | No | Via ODBC | No |
 | Built-in connection pool | Yes | No (#146) | No | No |
-| Prepared statement cache | Yes (LRU) | No (#30) | Via ODBC | Yes |
+| Prepared statement cache | Planned | No (#30) | Via ODBC | Yes |
 | Table-valued parameters | Yes | No | Via ODBC | No (#46) |
 | Bulk insert (BCP) | Yes | Partial (#322, #358) | Yes | No |
 | Query cancellation | Yes (attention) | No (#79, #300) | Via ODBC | No |
 | Azure AD / Managed Identity | Yes | No (#175) | Via ODBC | No |
 | Cross-platform NTLM | Yes | Windows only (#97) | Via ODBC | No (#13) |
-| Kerberos / SPNEGO | Yes | Unix only | Via ODBC | No |
+| Kerberos / SPNEGO | Yes (untested live) | Unix only | Via ODBC | No |
 | ADO.NET connection strings | Yes | Yes | N/A | No (#411, #605) |
 | `deny(unsafe_code)` | Yes, audited FFI exceptions | No (4 unsafe) | No (372 unsafe) | No |
 | Runtime agnostic | No (Tokio only) | Yes | N/A (sync) | Yes |
 | Compile-time query checking | No | No | No | Yes (limited) |
 | MARS | No | No | Via ODBC | No |
 
-**Authentication:** mssql-driver supports SQL auth, cross-platform Windows/NTLM, Kerberos/SPNEGO (`integrated-auth`), Azure AD token, Managed Identity and Service Principal (`azure-identity`), client certificate (`cert-auth`), and Windows SSPI (`sspi-auth`). Tiberius is Windows-only for NTLM and lacks Managed Identity; sqlx-oldapi has no Windows authentication at all (called a "blocker" by enterprise users, #13).
+**Authentication:** mssql-driver supports SQL auth, cross-platform Windows/NTLM, Kerberos/SPNEGO (`integrated-auth`, not yet validated against a live KDC — see LIMITATIONS.md), Azure AD token, Managed Identity and Service Principal (`azure-identity`), client certificate (`cert-auth`), and Windows SSPI (`sspi-auth`). Tiberius is Windows-only for NTLM and lacks Managed Identity; sqlx-oldapi has no Windows authentication at all (called a "blocker" by enterprise users, #13).
 
 **Pure-Rust deployment:** mssql-driver has no C/FFI dependencies (outside optional Windows SSPI), which avoids the problems odbc-api users report: can't compile for musl/Alpine (#526), static linking blocked by LGPL unixODBC (#781), driver-manager conflicts (#503), connections that aren't `Send`/`Sync` (#354), and FFI panics on drop (#574). It is `Send + Sync` and Tokio-native by design.
 

--- a/STABILITY.md
+++ b/STABILITY.md
@@ -46,7 +46,7 @@ The following APIs are considered stable and covered by semver guarantees:
 | `Client::close()` | Stable |
 | `Client::begin_transaction()` | Stable |
 | `Config::from_connection_string()` | Stable |
-| `Config::builder()` | Stable |
+| `Config::new()` + `with_*` builders | Stable |
 | `Row::get()` | Stable |
 | `Row::try_get()` | Stable |
 | `Transaction::commit()` | Stable |
@@ -120,9 +120,8 @@ APIs behind these feature flags depend on platform-specific libraries and may ha
 
 ### Unstable Functions
 
-| API | Reason |
-|-----|--------|
-| `Client::with_raw_connection()` | Low-level access, may change |
+None currently. APIs considered unstable will be listed here with the
+reason; expect additions as low-level access points are exposed.
 
 ## Deprecation Policy
 
@@ -141,12 +140,14 @@ When an API is deprecated:
 
 ### Example Deprecation
 
+A hypothetical illustration of the format:
+
 ```rust
 #[deprecated(
     since = "0.2.0",
-    note = "Use `Config::builder()` instead. Will be removed in 0.4.0."
+    note = "Use `connect_with_config()` instead. Will be removed in 0.4.0."
 )]
-pub fn Config::new() -> Config { ... }
+pub async fn connect_legacy(/* ... */) { /* ... */ }
 ```
 
 ## Minimum Supported Rust Version (MSRV)
@@ -231,7 +232,9 @@ We take backwards compatibility seriously and will work to resolve issues prompt
 | 2019 | Full (TDS 7.4) |
 | 2017 | Full (TDS 7.4) |
 | 2016 | Full (TDS 7.4) |
-| 2014 and earlier | Not supported |
+| 2012 / 2014 | Supported (TDS 7.4) |
+| 2008 / 2008 R2 | Legacy (TDS 7.3; usually needs `Encrypt=no_tls`, see LIMITATIONS.md) |
+| 2005 and earlier | Not supported |
 | Azure SQL Database | Full |
 | Azure SQL Managed Instance | Full |
 


### PR DESCRIPTION
## Summary

Review findings 3, 8, and the honest half of 6, plus two follow-ups from the #137 review. Every corrected claim was re-verified at source before editing (cache wiring, RowStream internals, API existence, TDS version constants).

| Claim | Where | Reality |
|---|---|---|
| Auto-cached prepared statements (LRU) | README comparison table, MIGRATION.md, ARCHITECTURE.md §4.5, CLAUDE.md, LIMITATIONS.md | `StatementCache` exists but no query path consults it; everything goes through `sp_executesql` (server plan cache still reuses plans). Design kept, explicitly marked intended-not-wired. |
| Constant-memory streaming | ADR-007 snippet comment, CLAUDE.md migration table | Lazy decode over a fully buffered response; peak memory ≈ raw payload. Implementation-status note added to ADR-007 (true streaming is a separate work item). |
| `Config::builder()` Stable / `Client::with_raw_connection()` Unstable | STABILITY.md | Neither API exists. Replaced with `Config::new()` + `with_*` (real) and an explicitly hypothetical deprecation example. |
| SQL Server "2014 and earlier: Not supported" | STABILITY.md | Contradicted README and code (TDS 7.3/7.4 negotiation, `V7_3A/B` constants): 2012/2014 supported, 2008/2008 R2 legacy with the `no_tls` caveat. |
| Kerberos/GSSAPI "Yes" | README feature + comparison tables | Implemented but never validated against a live KDC. Marked Untested with a LIMITATIONS.md entry. |
| Cut releases by pushing a release tag | MAINTAINERS.md | Releases belong to release-plz; merging the Release PR is the release. |
| `WindowsCertStoreProvider` behind `sspi-auth` | CLAUDE.md | Real feature is `windows-certstore` (spotted in the #137 review). |

Not touched: README's "integration suite runs in CI" claims — those became true when #138 merged.

## Verification

- `just doc-consistency`: all 24 checks pass
- `typos` clean on all edited files
- No code changes; docs-only diff (7 files, +71/−27)