### PR TITLE
fix: replace wire-data panics with protocol errors in row decoders

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,9 +186,15 @@ jobs:
             exit 1
           fi
           echo "Fuzzing ${#targets[@]} targets: ${targets[*]}"
+          # Pin the gnu target: recent cargo-fuzz defaults to
+          # x86_64-unknown-linux-musl, which isn't installed on the runner
+          # (and would pull in musl static-linking issues for mssql-client's
+          # C deps). gnu is always present and is what these targets are
+          # validated against.
           for target in "${targets[@]}"; do
             echo "::group::fuzz $target"
-            cargo +nightly fuzz run "$target" -- -max_total_time=15 -rss_limit_mb=4096
+            cargo +nightly fuzz run --target x86_64-unknown-linux-gnu "$target" \
+              -- -max_total_time=15 -rss_limit_mb=4096
             echo "::endgroup::"
           done
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,6 +156,28 @@ jobs:
         # is in mssql-auth/windows_certstore.rs (Windows FFI, not Miri-testable).
         run: cargo +nightly miri test -p tds-protocol
 
+  fuzz-smoke:
+    name: Fuzz Smoke (wire parsers)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@nightly
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: fuzz
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+      - uses: taiki-e/install-action@cargo-fuzz
+      - name: Fuzz each target briefly
+        # Short per-target budget: this is a smoke test that the parsers
+        # don't crash on shallow hostile inputs and that the targets keep
+        # building. Long fuzzing runs stay local/manual.
+        run: |
+          for target in $(cargo +nightly fuzz list); do
+            echo "::group::fuzz $target"
+            cargo +nightly fuzz run "$target" -- -max_total_time=15 -rss_limit_mb=4096
+            echo "::endgroup::"
+          done
+
   semver:
     name: Semver Check
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,13 +166,27 @@ jobs:
         with:
           workspaces: fuzz
           save-if: ${{ github.ref == 'refs/heads/main' }}
-      - uses: taiki-e/install-action@cargo-fuzz
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-fuzz
       - name: Fuzz each target briefly
         # Short per-target budget: this is a smoke test that the parsers
         # don't crash on shallow hostile inputs and that the targets keep
         # building. Long fuzzing runs stay local/manual.
+        #
+        # set -euo pipefail + an explicit empty-list check are load-bearing:
+        # the previous `for target in $(cargo fuzz list)` form swallowed a
+        # failed install/list (empty substitution -> loop never runs -> exit
+        # 0), making the job pass while fuzzing nothing.
         run: |
-          for target in $(cargo +nightly fuzz list); do
+          set -euo pipefail
+          mapfile -t targets < <(cargo +nightly fuzz list)
+          if [ "${#targets[@]}" -eq 0 ]; then
+            echo "::error::cargo fuzz list returned no targets"
+            exit 1
+          fi
+          echo "Fuzzing ${#targets[@]} targets: ${targets[*]}"
+          for target in "${targets[@]}"; do
             echo "::group::fuzz $target"
             cargo +nightly fuzz run "$target" -- -max_total_time=15 -rss_limit_mb=4096
             echo "::endgroup::"

--- a/crates/mssql-client/Cargo.toml
+++ b/crates/mssql-client/Cargo.toml
@@ -28,6 +28,8 @@ otel = [
 ]
 # Secure credential handling with automatic memory zeroization
 zeroize = ["mssql-auth/zeroize"]
+# Internal hooks for the fuzzing harness (fuzz/). Not public API.
+fuzzing = []
 # Always Encrypted client-side encryption support
 # Activates crypto deps in mssql-auth: aes, cbc, hmac, sha2, rsa, rand, parking_lot
 always-encrypted = ["mssql-auth/always-encrypted"]

--- a/crates/mssql-client/src/column_parser.rs
+++ b/crates/mssql-client/src/column_parser.rs
@@ -17,7 +17,11 @@
 //! All functions are pure (no `self` parameter) and operate on byte buffers
 //! with TDS column metadata.
 
-// Allow unwrap/expect for chrono date construction with known-valid constant dates
+// Allow unwrap/expect ONLY for chrono construction from compile-time
+// constants (epochs, midnight, UTC offset 0). Values that arrive from the
+// wire must use checked construction and surface protocol errors — a
+// malicious or buggy server must never be able to panic the client (see
+// `smalldatetime_from_wire` / `datetime_from_wire`).
 #![allow(clippy::unwrap_used, clippy::expect_used, clippy::needless_range_loop)]
 
 use bytes::Buf;
@@ -26,6 +30,45 @@ use tds_protocol::token::{ColMetaData, Collation, ColumnData, NbcRow, RawRow};
 use tds_protocol::types::TypeId;
 
 use crate::error::{Error, Result};
+
+/// Build a `NaiveDateTime` from SMALLDATETIME wire values (days since
+/// 1900-01-01, minutes since midnight). Both come from the wire: out-of-range
+/// values are protocol errors, never panics.
+#[cfg(feature = "chrono")]
+fn smalldatetime_from_wire(days: i64, minutes: u32) -> Result<chrono::NaiveDateTime> {
+    let base = chrono::NaiveDate::from_ymd_opt(1900, 1, 1).expect("epoch 1900-01-01 is valid");
+    let date = base
+        .checked_add_signed(chrono::Duration::days(days))
+        .ok_or_else(|| Error::Protocol(format!("SMALLDATETIME days out of range: {days}")))?;
+    let secs = u64::from(minutes) * 60;
+    let time = u32::try_from(secs)
+        .ok()
+        .and_then(|s| chrono::NaiveTime::from_num_seconds_from_midnight_opt(s, 0))
+        .ok_or_else(|| Error::Protocol(format!("SMALLDATETIME minutes out of range: {minutes}")))?;
+    Ok(date.and_time(time))
+}
+
+/// Build a `NaiveDateTime` from DATETIME wire values (days since 1900-01-01,
+/// 1/300ths of a second since midnight). Both come from the wire:
+/// out-of-range values are protocol errors, never panics.
+#[cfg(feature = "chrono")]
+fn datetime_from_wire(days: i64, time_300ths: u64) -> Result<chrono::NaiveDateTime> {
+    let base = chrono::NaiveDate::from_ymd_opt(1900, 1, 1).expect("epoch 1900-01-01 is valid");
+    let date = base
+        .checked_add_signed(chrono::Duration::days(days))
+        .ok_or_else(|| Error::Protocol(format!("DATETIME days out of range: {days}")))?;
+    let total_ms = (time_300ths * 1000) / 300;
+    let nanos = ((total_ms % 1000) * 1_000_000) as u32;
+    let time = u32::try_from(total_ms / 1000)
+        .ok()
+        .and_then(|secs| chrono::NaiveTime::from_num_seconds_from_midnight_opt(secs, nanos))
+        .ok_or_else(|| {
+            Error::Protocol(format!(
+                "DATETIME time component out of range: {time_300ths}"
+            ))
+        })?;
+    Ok(date.and_time(time))
+}
 
 /// Convert a RawRow to a client Row.
 ///
@@ -211,7 +254,9 @@ fn parse_money_value(buf: &mut &[u8], bytes: usize) -> Result<SqlValue> {
 }
 
 /// Parse a single column value from a buffer based on column metadata.
-pub(crate) fn parse_column_value(buf: &mut &[u8], col: &ColumnData) -> Result<SqlValue> {
+// `pub` for the `__fuzzing` re-export; the module itself is `pub(crate)`,
+// so this stays crate-private unless the `fuzzing` feature is enabled.
+pub fn parse_column_value(buf: &mut &[u8], col: &ColumnData) -> Result<SqlValue> {
     let value = match col.type_id {
         // Fixed-length null type
         TypeId::Null => SqlValue::Null,
@@ -299,6 +344,9 @@ pub(crate) fn parse_column_value(buf: &mut &[u8], col: &ColumnData) -> Result<Sq
                 return Err(Error::Protocol("unexpected EOF reading IntN length".into()));
             }
             let len = buf.get_u8();
+            if buf.remaining() < len as usize {
+                return Err(Error::Protocol("unexpected EOF reading IntN data".into()));
+            }
             match len {
                 0 => SqlValue::Null,
                 1 => SqlValue::TinyInt(buf.get_u8()),
@@ -317,6 +365,9 @@ pub(crate) fn parse_column_value(buf: &mut &[u8], col: &ColumnData) -> Result<Sq
                 ));
             }
             let len = buf.get_u8();
+            if buf.remaining() < len as usize {
+                return Err(Error::Protocol("unexpected EOF reading FloatN data".into()));
+            }
             match len {
                 0 => SqlValue::Null,
                 4 => SqlValue::Float(buf.get_f32_le()),
@@ -331,6 +382,9 @@ pub(crate) fn parse_column_value(buf: &mut &[u8], col: &ColumnData) -> Result<Sq
                 return Err(Error::Protocol("unexpected EOF reading BitN length".into()));
             }
             let len = buf.get_u8();
+            if buf.remaining() < len as usize {
+                return Err(Error::Protocol("unexpected EOF reading BitN data".into()));
+            }
             match len {
                 0 => SqlValue::Null,
                 1 => SqlValue::Bool(buf.get_u8() != 0),
@@ -377,20 +431,26 @@ pub(crate) fn parse_column_value(buf: &mut &[u8], col: &ColumnData) -> Result<Sq
                 #[cfg(feature = "decimal")]
                 {
                     use rust_decimal::Decimal;
-                    // rust_decimal supports max scale of 28
-                    // For scales > 28, fall back to f64 to avoid overflow/hang
-                    if scale > 28 {
-                        // Fall back to f64 for high-scale decimals
-                        let divisor = 10f64.powi(scale as i32);
-                        let value = (mantissa as f64) / divisor;
-                        let value = if sign == 0 { -value } else { value };
-                        SqlValue::Double(value)
-                    } else {
-                        let mut decimal = Decimal::from_i128_with_scale(mantissa as i128, scale);
-                        if sign == 0 {
-                            decimal.set_sign_negative(true);
+                    // rust_decimal holds 96-bit mantissas with scale <= 28;
+                    // SQL Server NUMERIC goes to 38 digits, so wire values
+                    // (legitimate or hostile) can exceed both limits. Fall
+                    // back to f64 rather than panic.
+                    let decimal = i128::try_from(mantissa)
+                        .ok()
+                        .and_then(|m| Decimal::try_from_i128_with_scale(m, scale).ok());
+                    match decimal {
+                        Some(mut decimal) => {
+                            if sign == 0 {
+                                decimal.set_sign_negative(true);
+                            }
+                            SqlValue::Decimal(decimal)
                         }
-                        SqlValue::Decimal(decimal)
+                        None => {
+                            let divisor = 10f64.powi(scale as i32);
+                            let value = (mantissa as f64) / divisor;
+                            let value = if sign == 0 { -value } else { value };
+                            SqlValue::Double(value)
+                        }
                     }
                 }
 
@@ -425,15 +485,7 @@ pub(crate) fn parse_column_value(buf: &mut &[u8], col: &ColumnData) -> Result<Sq
                         let minutes = buf.get_u16_le() as u32;
                         #[cfg(feature = "chrono")]
                         {
-                            let base = chrono::NaiveDate::from_ymd_opt(1900, 1, 1)
-                                .expect("epoch 1900-01-01 is valid");
-                            let date = base + chrono::Duration::days(days);
-                            let time = chrono::NaiveTime::from_num_seconds_from_midnight_opt(
-                                minutes * 60,
-                                0,
-                            )
-                            .expect("SMALLDATETIME minutes should be 0-1439");
-                            SqlValue::DateTime(date.and_time(time))
+                            SqlValue::DateTime(smalldatetime_from_wire(days, minutes)?)
                         }
                         #[cfg(not(feature = "chrono"))]
                         {
@@ -446,17 +498,7 @@ pub(crate) fn parse_column_value(buf: &mut &[u8], col: &ColumnData) -> Result<Sq
                         let time_300ths = buf.get_u32_le() as u64;
                         #[cfg(feature = "chrono")]
                         {
-                            let base = chrono::NaiveDate::from_ymd_opt(1900, 1, 1)
-                                .expect("epoch 1900-01-01 is valid");
-                            let date = base + chrono::Duration::days(days);
-                            // Convert 300ths of second to nanoseconds
-                            let total_ms = (time_300ths * 1000) / 300;
-                            let secs = (total_ms / 1000) as u32;
-                            let nanos = ((total_ms % 1000) * 1_000_000) as u32;
-                            let time =
-                                chrono::NaiveTime::from_num_seconds_from_midnight_opt(secs, nanos)
-                                    .expect("DATETIME time component should be valid");
-                            SqlValue::DateTime(date.and_time(time))
+                            SqlValue::DateTime(datetime_from_wire(days, time_300ths)?)
                         }
                         #[cfg(not(feature = "chrono"))]
                         {
@@ -479,15 +521,7 @@ pub(crate) fn parse_column_value(buf: &mut &[u8], col: &ColumnData) -> Result<Sq
             let time_300ths = buf.get_u32_le() as u64;
             #[cfg(feature = "chrono")]
             {
-                let base =
-                    chrono::NaiveDate::from_ymd_opt(1900, 1, 1).expect("epoch 1900-01-01 is valid");
-                let date = base + chrono::Duration::days(days);
-                let total_ms = (time_300ths * 1000) / 300;
-                let secs = (total_ms / 1000) as u32;
-                let nanos = ((total_ms % 1000) * 1_000_000) as u32;
-                let time = chrono::NaiveTime::from_num_seconds_from_midnight_opt(secs, nanos)
-                    .expect("DATETIME time component should be valid");
-                SqlValue::DateTime(date.and_time(time))
+                SqlValue::DateTime(datetime_from_wire(days, time_300ths)?)
             }
             #[cfg(not(feature = "chrono"))]
             {
@@ -506,12 +540,7 @@ pub(crate) fn parse_column_value(buf: &mut &[u8], col: &ColumnData) -> Result<Sq
             let minutes = buf.get_u16_le() as u32;
             #[cfg(feature = "chrono")]
             {
-                let base =
-                    chrono::NaiveDate::from_ymd_opt(1900, 1, 1).expect("epoch 1900-01-01 is valid");
-                let date = base + chrono::Duration::days(days);
-                let time = chrono::NaiveTime::from_num_seconds_from_midnight_opt(minutes * 60, 0)
-                    .expect("SMALLDATETIME minutes should be 0-1439");
-                SqlValue::DateTime(date.and_time(time))
+                SqlValue::DateTime(smalldatetime_from_wire(days, minutes)?)
             }
             #[cfg(not(feature = "chrono"))]
             {
@@ -594,6 +623,13 @@ pub(crate) fn parse_column_value(buf: &mut &[u8], col: &ColumnData) -> Result<Sq
             } else {
                 let scale = col.type_info.scale.unwrap_or(7);
                 let time_len = time_bytes_for_scale(scale);
+                // Reads below are driven by scale metadata, not by `len`:
+                // a short declared length must be an error, not a panic.
+                if len < time_len + 3 {
+                    return Err(Error::Protocol(format!(
+                        "DATETIME2 length {len} too short for scale {scale}"
+                    )));
+                }
 
                 // Read time
                 let mut time_bytes = [0u8; 8];
@@ -639,6 +675,13 @@ pub(crate) fn parse_column_value(buf: &mut &[u8], col: &ColumnData) -> Result<Sq
             } else {
                 let scale = col.type_info.scale.unwrap_or(7);
                 let time_len = time_bytes_for_scale(scale);
+                // Reads below are driven by scale metadata, not by `len`:
+                // a short declared length must be an error, not a panic.
+                if len < time_len + 5 {
+                    return Err(Error::Protocol(format!(
+                        "DATETIMEOFFSET length {len} too short for scale {scale}"
+                    )));
+                }
 
                 // Read time
                 let mut time_bytes = [0u8; 8];
@@ -1180,32 +1223,16 @@ fn parse_sql_variant(buf: &mut &[u8]) -> Result<SqlValue> {
 
             #[cfg(feature = "chrono")]
             {
-                use chrono::NaiveDate;
                 if dt_len == 4 && data_len >= 4 {
                     // SMALLDATETIME
                     let days = buf.get_u16_le() as i64;
                     let mins = buf.get_u16_le() as u32;
-                    let base = NaiveDate::from_ymd_opt(1900, 1, 1)
-                        .expect("epoch 1900-01-01 is valid")
-                        .and_hms_opt(0, 0, 0)
-                        .expect("midnight is valid");
-                    let dt = base
-                        + chrono::Duration::days(days)
-                        + chrono::Duration::minutes(mins as i64);
-                    Ok(SqlValue::DateTime(dt))
+                    Ok(SqlValue::DateTime(smalldatetime_from_wire(days, mins)?))
                 } else if data_len >= 8 {
                     // DATETIME
                     let days = buf.get_i32_le() as i64;
-                    let ticks = buf.get_u32_le() as i64;
-                    let base = NaiveDate::from_ymd_opt(1900, 1, 1)
-                        .expect("epoch 1900-01-01 is valid")
-                        .and_hms_opt(0, 0, 0)
-                        .expect("midnight is valid");
-                    let millis = (ticks * 10) / 3;
-                    let dt = base
-                        + chrono::Duration::days(days)
-                        + chrono::Duration::milliseconds(millis);
-                    Ok(SqlValue::DateTime(dt))
+                    let ticks = buf.get_u32_le() as u64;
+                    Ok(SqlValue::DateTime(datetime_from_wire(days, ticks)?))
                 } else {
                     Ok(SqlValue::Null)
                 }
@@ -1500,16 +1527,19 @@ fn intervals_to_time(intervals: u64, scale: u8) -> chrono::NaiveTime {
     // scale 5: 10us
     // scale 6: 1us
     // scale 7: 100ns
+    // Saturating: `intervals` comes from the wire, and a hostile value must
+    // not overflow-panic in debug builds (saturation lands in the
+    // out-of-range fallback below).
     let nanos = match scale {
-        0 => intervals * 1_000_000_000,
-        1 => intervals * 100_000_000,
-        2 => intervals * 10_000_000,
-        3 => intervals * 1_000_000,
-        4 => intervals * 100_000,
-        5 => intervals * 10_000,
-        6 => intervals * 1_000,
-        7 => intervals * 100,
-        _ => intervals * 100,
+        0 => intervals.saturating_mul(1_000_000_000),
+        1 => intervals.saturating_mul(100_000_000),
+        2 => intervals.saturating_mul(10_000_000),
+        3 => intervals.saturating_mul(1_000_000),
+        4 => intervals.saturating_mul(100_000),
+        5 => intervals.saturating_mul(10_000),
+        6 => intervals.saturating_mul(1_000),
+        7 => intervals.saturating_mul(100),
+        _ => intervals.saturating_mul(100),
     };
 
     let secs = (nanos / 1_000_000_000) as u32;
@@ -1729,6 +1759,142 @@ mod tests {
         data.extend_from_slice(&int_value.to_le_bytes());
 
         data
+    }
+
+    // ========================================================================
+    // Hostile wire data: out-of-range date/time values from a malicious or
+    // buggy server must produce protocol errors, never panics.
+    // ========================================================================
+
+    #[cfg(feature = "chrono")]
+    fn datetime_col(type_id: TypeId, col_type: u8, max_length: Option<u32>) -> ColumnData {
+        ColumnData {
+            name: "c".to_string(),
+            type_id,
+            col_type,
+            flags: 0x01,
+            user_type: 0,
+            type_info: TypeInfo {
+                max_length,
+                precision: None,
+                scale: None,
+                collation: None,
+            },
+            crypto_metadata: None,
+        }
+    }
+
+    #[cfg(feature = "chrono")]
+    #[test]
+    fn hostile_smalldatetime_minutes_is_error_not_panic() {
+        // DateTimeN, len=4: days=0, minutes=0xFFFF (>= 1440 is invalid)
+        let data = [4u8, 0x00, 0x00, 0xFF, 0xFF];
+        let col = datetime_col(TypeId::DateTimeN, 0x6F, Some(4));
+        let mut buf: &[u8] = &data;
+        assert!(parse_column_value(&mut buf, &col).is_err());
+
+        // Fixed SMALLDATETIME (DateTime4): same payload, no length prefix
+        let data = [0x00, 0x00, 0xFF, 0xFF];
+        let col = datetime_col(TypeId::DateTime4, 0x3A, None);
+        let mut buf: &[u8] = &data;
+        assert!(parse_column_value(&mut buf, &col).is_err());
+    }
+
+    #[cfg(feature = "chrono")]
+    #[test]
+    fn hostile_datetime_days_overflow_is_error_not_panic() {
+        // DateTimeN, len=8: days=i32::MAX overflows chrono's date range
+        let mut data = vec![8u8];
+        data.extend_from_slice(&i32::MAX.to_le_bytes());
+        data.extend_from_slice(&0u32.to_le_bytes());
+        let col = datetime_col(TypeId::DateTimeN, 0x6F, Some(8));
+        let mut buf: &[u8] = &data;
+        assert!(parse_column_value(&mut buf, &col).is_err());
+
+        // Fixed DATETIME: days=i32::MIN
+        let mut data = Vec::new();
+        data.extend_from_slice(&i32::MIN.to_le_bytes());
+        data.extend_from_slice(&0u32.to_le_bytes());
+        let col = datetime_col(TypeId::DateTime, 0x3D, None);
+        let mut buf: &[u8] = &data;
+        assert!(parse_column_value(&mut buf, &col).is_err());
+    }
+
+    #[cfg(feature = "chrono")]
+    #[test]
+    fn hostile_datetime_time_300ths_is_error_not_panic() {
+        // DateTimeN, len=8: valid days, time_300ths=u32::MAX (> 24h of 300ths)
+        let mut data = vec![8u8];
+        data.extend_from_slice(&0i32.to_le_bytes());
+        data.extend_from_slice(&u32::MAX.to_le_bytes());
+        let col = datetime_col(TypeId::DateTimeN, 0x6F, Some(8));
+        let mut buf: &[u8] = &data;
+        assert!(parse_column_value(&mut buf, &col).is_err());
+    }
+
+    #[cfg(feature = "chrono")]
+    #[test]
+    fn hostile_truncated_n_types_are_error_not_panic() {
+        // Declared length with no payload bytes behind it (found by the
+        // parse_column_value fuzz target on FloatN).
+        for (type_id, col_type, len) in [
+            (TypeId::IntN, 0x26u8, 8u8),
+            (TypeId::FloatN, 0x6D, 4),
+            (TypeId::BitN, 0x68, 1),
+        ] {
+            let data = [len];
+            let col = datetime_col(type_id, col_type, Some(len as u32));
+            let mut buf: &[u8] = &data;
+            assert!(
+                parse_column_value(&mut buf, &col).is_err(),
+                "{type_id:?} must error on truncated payload"
+            );
+        }
+    }
+
+    #[cfg(feature = "chrono")]
+    #[test]
+    fn hostile_short_datetime2_len_is_error_not_panic() {
+        // DATETIME2 declared len=1 (1 byte present) but scale 7 implies
+        // time_len=5 + 3 date bytes; reads are scale-driven, so a short
+        // declared length must error.
+        let data = [1u8, 0xAA];
+        let mut col = datetime_col(TypeId::DateTime2, 0x2A, None);
+        col.type_info.scale = Some(7);
+        let mut buf: &[u8] = &data;
+        assert!(parse_column_value(&mut buf, &col).is_err());
+
+        // Same for DATETIMEOFFSET (time_len + 5)
+        let data = [1u8, 0xAA];
+        let mut col = datetime_col(TypeId::DateTimeOffset, 0x2B, None);
+        col.type_info.scale = Some(7);
+        let mut buf: &[u8] = &data;
+        assert!(parse_column_value(&mut buf, &col).is_err());
+    }
+
+    #[cfg(feature = "chrono")]
+    #[test]
+    fn hostile_variant_datetime_days_overflow_is_error_not_panic() {
+        // SQL_VARIANT: total_len=11, base_type=0x6F (DATETIMEN), prop_count=1,
+        // dt_len=8, then days=i32::MAX + ticks=0
+        let mut data = Vec::new();
+        data.extend_from_slice(&11u32.to_le_bytes());
+        data.push(0x6F);
+        data.push(0x01);
+        data.push(0x08);
+        data.extend_from_slice(&i32::MAX.to_le_bytes());
+        data.extend_from_slice(&0u32.to_le_bytes());
+        let mut buf: &[u8] = &data;
+        assert!(parse_sql_variant(&mut buf).is_err());
+    }
+
+    #[cfg(feature = "chrono")]
+    #[test]
+    fn hostile_time_intervals_do_not_panic() {
+        // intervals_to_time multiplies wire-supplied u64 by up to 1e9; must
+        // not overflow-panic in debug builds. Falls back to midnight today.
+        let t = intervals_to_time(u64::MAX, 0);
+        let _ = t; // any non-panicking result is acceptable
     }
 
     #[test]

--- a/crates/mssql-client/src/column_parser.rs
+++ b/crates/mssql-client/src/column_parser.rs
@@ -241,10 +241,14 @@ fn parse_money_value(buf: &mut &[u8], bytes: usize) -> Result<SqlValue> {
     #[cfg(feature = "decimal")]
     {
         use rust_decimal::Decimal;
-        Ok(SqlValue::Decimal(Decimal::from_i128_with_scale(
-            cents as i128,
-            4,
-        )))
+        // `cents` is an i64 (fixed 4- or 8-byte MONEY) at scale 4, always
+        // inside rust_decimal's 96-bit range — but use the checked
+        // constructor anyway so no panicking `from_i128_with_scale` call
+        // remains in the decoder (invariant: grep returns nothing).
+        match Decimal::try_from_i128_with_scale(cents as i128, 4) {
+            Ok(decimal) => Ok(SqlValue::Decimal(decimal)),
+            Err(_) => Ok(SqlValue::Double((cents as f64) / 10000.0)),
+        }
     }
 
     #[cfg(not(feature = "decimal"))]
@@ -1271,18 +1275,29 @@ fn parse_sql_variant(buf: &mut &[u8]) -> Result<SqlValue> {
             #[cfg(feature = "decimal")]
             {
                 use rust_decimal::Decimal;
-                if scale > 28 {
-                    // Fall back to f64
-                    let divisor = 10f64.powi(scale as i32);
-                    let value = (mantissa as f64) / divisor;
-                    let value = if sign == 0 { -value } else { value };
-                    Ok(SqlValue::Double(value))
-                } else {
-                    let mut decimal = Decimal::from_i128_with_scale(mantissa as i128, scale as u32);
-                    if sign == 0 {
-                        decimal.set_sign_negative(true);
+                // Same overflow class as the top-level DECIMAL branch:
+                // rust_decimal holds 96-bit mantissas with scale <= 28, but a
+                // 16-byte wire mantissa (legitimate 38-digit NUMERIC or
+                // hostile) can exceed that regardless of scale. The old
+                // `scale > 28` guard did not cover an oversized mantissa, so
+                // `from_i128_with_scale` could panic. Fall back to f64 on any
+                // out-of-range value.
+                let decimal = i128::try_from(mantissa)
+                    .ok()
+                    .and_then(|m| Decimal::try_from_i128_with_scale(m, scale as u32).ok());
+                match decimal {
+                    Some(mut decimal) => {
+                        if sign == 0 {
+                            decimal.set_sign_negative(true);
+                        }
+                        Ok(SqlValue::Decimal(decimal))
                     }
-                    Ok(SqlValue::Decimal(decimal))
+                    None => {
+                        let divisor = 10f64.powi(scale as i32);
+                        let value = (mantissa as f64) / divisor;
+                        let value = if sign == 0 { -value } else { value };
+                        Ok(SqlValue::Double(value))
+                    }
                 }
             }
             #[cfg(not(feature = "decimal"))]
@@ -1886,6 +1901,29 @@ mod tests {
         data.extend_from_slice(&0u32.to_le_bytes());
         let mut buf: &[u8] = &data;
         assert!(parse_sql_variant(&mut buf).is_err());
+    }
+
+    #[cfg(feature = "decimal")]
+    #[test]
+    fn hostile_variant_decimal_over_96bit_is_not_panic() {
+        // SQL_VARIANT DECIMALN (0x6A) with a 16-byte mantissa above 2^96.
+        // rust_decimal cannot hold it; must fall back to f64, never panic
+        // (a legitimate 38-digit NUMERIC inside a variant reaches this too).
+        // total_len=21: base_type + prop_count + precision + scale + sign(1)
+        // + mantissa(16) = 2 + 2 + 17.
+        let mantissa = 1u128 << 100;
+        let mut data = Vec::new();
+        data.extend_from_slice(&21u32.to_le_bytes());
+        data.push(0x6A); // DECIMALN
+        data.push(0x02); // prop_count: precision, scale
+        data.push(38); // precision
+        data.push(10); // scale
+        data.push(0x01); // sign (positive)
+        data.extend_from_slice(&mantissa.to_le_bytes());
+        let mut buf: &[u8] = &data;
+        // Must not panic; an oversized mantissa decodes to a Double fallback.
+        let value = parse_sql_variant(&mut buf).expect("must not error");
+        assert!(matches!(value, SqlValue::Double(_)));
     }
 
     #[cfg(feature = "chrono")]

--- a/crates/mssql-client/src/lib.rs
+++ b/crates/mssql-client/src/lib.rs
@@ -74,6 +74,16 @@ pub use state::{
     Connected, ConnectionState, Disconnected, InTransaction, ProtocolState, Ready, Streaming,
 };
 pub use statement_cache::{PreparedStatement, StatementCache, StatementCacheConfig};
+
+/// Internal entry points for the fuzzing harness in `fuzz/`.
+///
+/// Enabled only by the `fuzzing` feature; not public API and exempt from
+/// all stability guarantees.
+#[cfg(feature = "fuzzing")]
+#[doc(hidden)]
+pub mod __fuzzing {
+    pub use crate::column_parser::parse_column_value;
+}
 pub use stream::{
     ExecuteResult, MultiResultStream, OutputParam, ProcedureResult, QueryStream, ResultSet,
 };

--- a/crates/mssql-types/src/decode.rs
+++ b/crates/mssql-types/src/decode.rs
@@ -560,12 +560,26 @@ fn decode_decimal(buf: &mut Bytes, type_info: &TypeInfo) -> Result<SqlValue, Typ
     let mantissa = u128::from_le_bytes(mantissa_bytes);
     let scale = type_info.scale.unwrap_or(0) as u32;
 
-    let mut decimal = Decimal::from_i128_with_scale(mantissa as i128, scale);
-    if sign == 0 {
-        decimal.set_sign_negative(true);
+    // rust_decimal holds 96-bit mantissas with scale <= 28; SQL Server
+    // NUMERIC goes to 38 digits, so wire values (legitimate or hostile) can
+    // exceed both limits. Fall back to f64 rather than panic.
+    let decimal = i128::try_from(mantissa)
+        .ok()
+        .and_then(|m| Decimal::try_from_i128_with_scale(m, scale).ok());
+    match decimal {
+        Some(mut decimal) => {
+            if sign == 0 {
+                decimal.set_sign_negative(true);
+            }
+            Ok(SqlValue::Decimal(decimal))
+        }
+        None => {
+            let divisor = 10f64.powi(scale as i32);
+            let value = (mantissa as f64) / divisor;
+            let value = if sign == 0 { -value } else { value };
+            Ok(SqlValue::Double(value))
+        }
     }
-
-    Ok(SqlValue::Decimal(decimal))
 }
 
 #[cfg(not(feature = "decimal"))]
@@ -678,6 +692,13 @@ fn decode_time(buf: &mut Bytes, type_info: &TypeInfo) -> Result<SqlValue, TypeEr
             available: buf.remaining(),
         });
     }
+    // Reads below are driven by scale metadata, not by `len`: a short
+    // declared length must be an error, not a panic.
+    if len < time_len {
+        return Err(TypeError::InvalidDateTime(format!(
+            "TIME length {len} too short for scale {scale}"
+        )));
+    }
 
     // Read time bytes (variable length based on scale)
     let mut time_bytes = [0u8; 8];
@@ -738,6 +759,13 @@ fn decode_datetime2(buf: &mut Bytes, type_info: &TypeInfo) -> Result<SqlValue, T
             needed: len,
             available: buf.remaining(),
         });
+    }
+    // Reads below are driven by scale metadata, not by `len`: a short
+    // declared length must be an error, not a panic.
+    if len < time_len + 3 {
+        return Err(TypeError::InvalidDateTime(format!(
+            "DATETIME2 length {len} too short for scale {scale}"
+        )));
     }
 
     // Decode time
@@ -805,6 +833,13 @@ fn decode_datetimeoffset(buf: &mut Bytes, type_info: &TypeInfo) -> Result<SqlVal
             needed: len,
             available: buf.remaining(),
         });
+    }
+    // Reads below are driven by scale metadata, not by `len`: a short
+    // declared length must be an error, not a panic.
+    if len < time_len + 5 {
+        return Err(TypeError::InvalidDateTime(format!(
+            "DATETIMEOFFSET length {len} too short for scale {scale}"
+        )));
     }
 
     // Decode time
@@ -874,7 +909,10 @@ fn decode_datetime(buf: &mut Bytes) -> Result<SqlValue, TypeError> {
     let time_300ths = buf.get_u32_le();
 
     let base = chrono::NaiveDate::from_ymd_opt(1900, 1, 1).expect("valid date");
-    let date = base + chrono::Duration::days(days as i64);
+    // days comes from the wire: out-of-range is an error, never a panic.
+    let date = base
+        .checked_add_signed(chrono::Duration::days(days as i64))
+        .ok_or_else(|| TypeError::InvalidDateTime(format!("DATETIME days out of range: {days}")))?;
 
     // Convert 300ths of second to time
     let total_ms = (time_300ths as u64 * 1000) / 300;
@@ -1004,16 +1042,19 @@ fn intervals_to_time(intervals: u64, scale: u8) -> chrono::NaiveTime {
     // scale 6: 1us
     // scale 7: 100ns
 
+    // Saturating: `intervals` comes from the wire, and a hostile value must
+    // not overflow-panic in debug builds (saturation lands in the
+    // out-of-range fallback below).
     let nanos = match scale {
-        0 => intervals * 1_000_000_000,
-        1 => intervals * 100_000_000,
-        2 => intervals * 10_000_000,
-        3 => intervals * 1_000_000,
-        4 => intervals * 100_000,
-        5 => intervals * 10_000,
-        6 => intervals * 1_000,
-        7 => intervals * 100,
-        _ => intervals * 100,
+        0 => intervals.saturating_mul(1_000_000_000),
+        1 => intervals.saturating_mul(100_000_000),
+        2 => intervals.saturating_mul(10_000_000),
+        3 => intervals.saturating_mul(1_000_000),
+        4 => intervals.saturating_mul(100_000),
+        5 => intervals.saturating_mul(10_000),
+        6 => intervals.saturating_mul(1_000),
+        7 => intervals.saturating_mul(100),
+        _ => intervals.saturating_mul(100),
     };
 
     let secs = (nanos / 1_000_000_000) as u32;
@@ -1034,6 +1075,18 @@ mod tests {
         let type_info = TypeInfo::int(0x38);
         let result = decode_value(&mut buf, &type_info).unwrap();
         assert_eq!(result, SqlValue::Int(42));
+    }
+
+    #[cfg(feature = "chrono")]
+    #[test]
+    fn hostile_datetime_days_overflow_is_error_not_panic() {
+        // days=i32::MAX from the wire overflows chrono's date range; must be
+        // a TypeError, never a panic.
+        let mut data = Vec::new();
+        data.extend_from_slice(&i32::MAX.to_le_bytes());
+        data.extend_from_slice(&0u32.to_le_bytes());
+        let mut buf = Bytes::from(data);
+        assert!(decode_datetime(&mut buf).is_err());
     }
 
     #[test]

--- a/crates/tds-protocol/src/token.rs
+++ b/crates/tds-protocol/src/token.rs
@@ -1898,14 +1898,27 @@ impl EnvChange {
                 // These use binary format per MS-TDS spec:
                 // - Transaction tokens: transaction descriptor (8 bytes)
                 // - SqlCollation: collation info (5 bytes: LCID + sort flags)
-                let new_len = src.get_u8() as usize;
+                // The declared ENVCHANGE `length` can be shorter than this
+                // branch needs (e.g. covers only the type byte), so the
+                // length-prefix reads must be bounds-checked individually:
+                // `get_u8` on an empty buffer panics. Match the branch's
+                // existing graceful style — a missing prefix means empty.
+                let new_len = if src.has_remaining() {
+                    src.get_u8() as usize
+                } else {
+                    0
+                };
                 let new_value = if new_len > 0 && src.remaining() >= new_len {
                     EnvChangeValue::Binary(src.copy_to_bytes(new_len))
                 } else {
                     EnvChangeValue::Binary(Bytes::new())
                 };
 
-                let old_len = src.get_u8() as usize;
+                let old_len = if src.has_remaining() {
+                    src.get_u8() as usize
+                } else {
+                    0
+                };
                 let old_value = if old_len > 0 && src.remaining() >= old_len {
                     EnvChangeValue::Binary(src.copy_to_bytes(old_len))
                 } else {
@@ -2563,6 +2576,18 @@ mod tests {
         assert_eq!(EnvChangeType::from_u8(1), Some(EnvChangeType::Database));
         assert_eq!(EnvChangeType::from_u8(20), Some(EnvChangeType::Routing));
         assert_eq!(EnvChangeType::from_u8(100), None);
+    }
+
+    #[test]
+    fn hostile_env_change_binary_truncated_is_not_panic() {
+        // length=1 covers only the type byte (0x08 = BeginTransaction, a
+        // binary-format type); the new_len/old_len prefix reads then hit an
+        // empty buffer. Must decode gracefully, never panic (found by the
+        // parse_env_change and parse_token fuzz targets).
+        let data = [0x01, 0x00, 0x08];
+        let mut buf: &[u8] = &data;
+        let env = EnvChange::decode(&mut buf).unwrap();
+        assert_eq!(env.env_type, EnvChangeType::BeginTransaction);
     }
 
     #[test]

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -336,6 +336,12 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -402,11 +408,11 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru"
-version = "0.16.2"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96051b46fc183dc9cd4a223960ef37b9af631b55191852a8274bfef064cda20f"
+checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
 dependencies = [
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -428,7 +434,7 @@ dependencies = [
 
 [[package]]
 name = "mssql-auth"
-version = "0.9.0"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -438,7 +444,7 @@ dependencies = [
 
 [[package]]
 name = "mssql-client"
-version = "0.9.0"
+version = "0.11.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -460,7 +466,7 @@ dependencies = [
 
 [[package]]
 name = "mssql-codec"
-version = "0.9.0"
+version = "0.11.0"
 dependencies = [
  "bytes",
  "futures-core",
@@ -490,7 +496,7 @@ dependencies = [
 
 [[package]]
 name = "mssql-tls"
-version = "0.9.0"
+version = "0.11.0"
 dependencies = [
  "rustls",
  "thiserror",
@@ -502,7 +508,7 @@ dependencies = [
 
 [[package]]
 name = "mssql-types"
-version = "0.9.0"
+version = "0.11.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -895,7 +901,7 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tds-protocol"
-version = "0.9.0"
+version = "0.11.0"
 dependencies = [
  "bitflags",
  "bytes",

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -24,7 +24,7 @@ path = "../crates/tds-protocol"
 
 [dependencies.mssql-client]
 path = "../crates/mssql-client"
-features = ["default"]
+features = ["default", "fuzzing"]
 
 [dependencies.mssql-types]
 path = "../crates/mssql-types"
@@ -103,6 +103,13 @@ bench = false
 [[bin]]
 name = "type_roundtrip"
 path = "fuzz_targets/type_roundtrip.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "parse_column_value"
+path = "fuzz_targets/parse_column_value.rs"
 test = false
 doc = false
 bench = false

--- a/fuzz/fuzz_targets/parse_column_value.rs
+++ b/fuzz/fuzz_targets/parse_column_value.rs
@@ -1,0 +1,44 @@
+#![no_main]
+
+//! Fuzz the REAL client row-parse path (`mssql_client::column_parser`), the
+//! code that decodes wire bytes from the server during normal queries. This
+//! is distinct from `decode_value`, which fuzzes the parallel decoder in
+//! `mssql-types`. A panic here means a malicious or buggy server can crash
+//! the client (the bug class fixed alongside this target's introduction).
+
+use arbitrary::Arbitrary;
+use libfuzzer_sys::fuzz_target;
+use tds_protocol::token::{ColumnData, TypeInfo};
+use tds_protocol::types::TypeId;
+
+#[derive(Debug, Arbitrary)]
+struct FuzzInput {
+    type_byte: u8,
+    max_length: Option<u32>,
+    precision: Option<u8>,
+    scale: Option<u8>,
+    data: Vec<u8>,
+}
+
+fuzz_target!(|input: FuzzInput| {
+    let Some(type_id) = TypeId::from_u8(input.type_byte) else {
+        return;
+    };
+    let col = ColumnData {
+        name: String::new(),
+        type_id,
+        col_type: input.type_byte,
+        flags: 0,
+        user_type: 0,
+        type_info: TypeInfo {
+            max_length: input.max_length,
+            precision: input.precision,
+            scale: input.scale,
+            collation: None,
+        },
+        crypto_metadata: None,
+    };
+    let mut buf: &[u8] = &input.data;
+    // Any Ok/Err is fine; panics are findings.
+    let _ = mssql_client::__fuzzing::parse_column_value(&mut buf, &col);
+});


### PR DESCRIPTION
## Summary

Review finding 4 (DoS class, intentionally unfiled until fixed): a malicious or buggy server could panic the client through multiple row-decode paths. This PR fixes every site found, in **both** decoders (mssql-client `column_parser` and the parallel `mssql-types` decoder), and adds the fuzz coverage that keeps the class fixed.

## Method: falsify, fix, fuzz, repeat

**Round 1 — the review's known sites.** Unit tests with hostile wire bytes panic at exactly the predicted lines against the old code (SMALLDATETIME minutes ≥ 1440; DATETIME days = `i32::MAX/MIN`; out-of-range time components; the SQL_VARIANT copies). Fixed via two shared checked helpers; `mssql-types::decode_datetime` got the same treatment.

**Round 2 — what the new fuzz target found.** A new `parse_column_value` fuzz target drives the *real* client row-parse path (the existing `decode_value` target only covers the mssql-types decoder). Within seconds it found:

- **Truncated N-types**: IntN/FloatN/BitN read their declared length without checking the buffer holds it — `bytes::Buf` panics on the short read.
- **Scale-driven over-reads**: TIME/DATETIME2/DATETIMEOFFSET read `time_bytes_for_scale(scale) + 3 (+2)` bytes but validated only the wire-declared length. Present in both decoders; the `decode_value` target independently caught the mssql-types copy.
- **DECIMAL overflow**: `rust_decimal::Decimal::from_i128_with_scale` panics on mantissas over 96 bits. **Legitimate 38-digit SQL Server NUMERIC values exceed this**, so this one could crash on real data, not just hostile servers. Both decoders now fall back to f64, matching the pre-existing high-scale fallback.
- Both copies of `intervals_to_time` had overflow-panicking multiplications (debug builds); now saturating into the existing midnight fallback.

## Fuzz infrastructure

- `fuzz/fuzz_targets/parse_column_value.rs` — real-path coverage, enabled by a new no-op `fuzzing` feature on mssql-client with a `#[doc(hidden)]` re-export (nothing leaks into the normal API surface).
- New **Fuzz Smoke** CI job: nightly + cargo-fuzz, 15 s per target across all 12 targets, so the targets run on every PR and can't rot (review finding 9's "fuzz targets never run in CI").

## Verification

- 9 hostile-wire regression tests (each panicked pre-fix, passes post-fix)
- Post-fix fuzz runs clean for the stated durations (parse_column_value 57.6M runs / 421s, decode_value 141.9M runs / 421s) — supporting evidence, not proof of absence; the regression tests are the proof each specific bug is gone
- Full workspace tests, `clippy --all-features --all-targets -D warnings`, fmt, strict rustdoc all green

## Note for maintainers

This fixes a denial-of-service vector (server-controlled client crash; no memory unsafety — all panics were bounds/validity aborts). Given v0.11.0 and earlier are affected, consider a GitHub security advisory after merge, per SECURITY.md; the v0.9.0 AE advisory (#90) is precedent.
