### PR TITLE
fix: wire Config.tls through connect; make Pool::close() actually close

### DIFF
--- a/crates/mssql-client/src/client/connect.rs
+++ b/crates/mssql-client/src/client/connect.rs
@@ -313,11 +313,9 @@ impl Client<Disconnected> {
     async fn connect_tds_8(config: &Config, tcp_stream: TcpStream) -> Result<Client<Ready>> {
         tracing::debug!("using TDS 8.0 strict mode (TLS first)");
 
-        // Build TLS configuration with TDS 8.0 ALPN protocol
-        let tls_config = TlsConfig::new()
-            .strict_mode(true)
-            .trust_server_certificate(config.trust_server_certificate)
-            .with_alpn_protocols(vec![b"tds/8.0".to_vec()]);
+        // Build TLS configuration from the user's `config.tls` plus the
+        // TDS 8.0 strict-mode requirements (see `connection_tls_config`).
+        let tls_config = connection_tls_config(config, true);
 
         let tls_connector = TlsConnector::new(tls_config)?;
 
@@ -536,10 +534,11 @@ impl Client<Disconnected> {
         let use_tls = negotiated_encryption != EncryptionLevel::NotSupported;
 
         if use_tls {
-            // Upgrade to TLS with PreLogin wrapping (TDS 7.x style)
-            // In TDS 7.x, the TLS handshake is wrapped inside TDS PreLogin packets
-            let tls_config =
-                TlsConfig::new().trust_server_certificate(config.trust_server_certificate);
+            // Upgrade to TLS with PreLogin wrapping (TDS 7.x style).
+            // In TDS 7.x, the TLS handshake is wrapped inside TDS PreLogin
+            // packets. Honor the user's `config.tls` (custom root certs,
+            // client auth) without the TDS 8.0 strict ALPN.
+            let tls_config = connection_tls_config(config, false);
 
             let tls_connector = TlsConnector::new(tls_config)?;
 
@@ -1279,5 +1278,91 @@ impl Client<Disconnected> {
                 }
             }
         }
+    }
+}
+
+/// Build the TLS configuration for an outbound connection.
+///
+/// Starts from the user's [`Config::tls`] so custom root certificates, client
+/// auth, and protocol-version bounds are honored, then layers the
+/// connection-specific requirements. `trust_server_certificate` is taken from
+/// the authoritative top-level [`Config`] field: both the builder and the
+/// connection-string parser set it, but the parser does not mirror it into
+/// `config.tls`, so reading it here is what keeps `TrustServerCertificate=...`
+/// connection strings working.
+///
+/// `strict` selects TDS 8.0 strict mode (TLS-first) and adds the `tds/8.0`
+/// ALPN protocol; TDS 7.x leaves both off (its TLS is wrapped in PreLogin).
+#[cfg(feature = "tls")]
+fn connection_tls_config(config: &Config, strict: bool) -> TlsConfig {
+    let tls = config
+        .tls
+        .clone()
+        .trust_server_certificate(config.trust_server_certificate);
+    if strict {
+        tls.strict_mode(true)
+            .with_alpn_protocols(vec![b"tds/8.0".to_vec()])
+    } else {
+        tls
+    }
+}
+
+#[cfg(all(test, feature = "tls"))]
+mod tls_config_tests {
+    use super::*;
+    use mssql_tls::CertificateDer;
+
+    fn config_with_root(cert: Vec<u8>) -> Config {
+        let mut config = Config::new();
+        config.tls = config
+            .tls
+            .clone()
+            .add_root_certificate(CertificateDer::from(cert));
+        config
+    }
+
+    #[test]
+    fn custom_root_certificate_reaches_connector_config() {
+        // The bug: connect built a fresh TlsConfig and dropped config.tls,
+        // so a custom CA was unreachable. Assert it survives into the
+        // connection's TLS config, in both strict and non-strict paths.
+        let config = config_with_root(vec![0xCA; 32]);
+
+        for strict in [true, false] {
+            let tls = connection_tls_config(&config, strict);
+            assert_eq!(
+                tls.root_certificates.len(),
+                1,
+                "custom root must reach the connector (strict={strict})"
+            );
+            assert_eq!(tls.root_certificates[0].as_ref(), &[0xCA; 32][..]);
+        }
+    }
+
+    #[test]
+    fn trust_server_certificate_taken_from_top_level_field() {
+        // Mirrors the connection-string path, which sets the top-level field
+        // without updating config.tls.
+        let mut config = Config::new();
+        config.trust_server_certificate = true;
+        // config.tls still has the default (false) trust flag.
+        assert!(!config.tls.trust_server_certificate);
+
+        let tls = connection_tls_config(&config, false);
+        assert!(
+            tls.trust_server_certificate,
+            "top-level trust flag must win"
+        );
+    }
+
+    #[test]
+    fn strict_mode_adds_tds8_alpn() {
+        let config = Config::new();
+        let strict = connection_tls_config(&config, true);
+        assert!(strict.strict_mode);
+        assert!(strict.alpn_protocols.iter().any(|p| p == b"tds/8.0"));
+
+        let non_strict = connection_tls_config(&config, false);
+        assert!(!non_strict.strict_mode);
     }
 }

--- a/crates/mssql-client/src/client/connect.rs
+++ b/crates/mssql-client/src/client/connect.rs
@@ -1293,6 +1293,14 @@ impl Client<Disconnected> {
 ///
 /// `strict` selects TDS 8.0 strict mode (TLS-first) and adds the `tds/8.0`
 /// ALPN protocol; TDS 7.x leaves both off (its TLS is wrapped in PreLogin).
+///
+/// Note the asymmetry: root certificates and client auth come from
+/// `config.tls`, but `trust_server_certificate` is taken from the top-level
+/// field and overrides whatever `config.tls` holds. So setting *only*
+/// `config.tls = TlsConfig::new().trust_server_certificate(true)` while
+/// leaving the top-level field at its `false` default does not trust the
+/// server — set it via the connection string (`TrustServerCertificate=true`)
+/// or `Config::trust_server_certificate(true)`, which is the supported path.
 #[cfg(feature = "tls")]
 fn connection_tls_config(config: &Config, strict: bool) -> TlsConfig {
     let tls = config

--- a/crates/mssql-pool/src/pool.rs
+++ b/crates/mssql-pool/src/pool.rs
@@ -816,19 +816,23 @@ impl Pool {
     ///
     /// Marks the pool closed (further [`Pool::get`] calls return
     /// [`PoolError::PoolClosed`]), drains and closes all idle connections
-    /// immediately, and stops the idle reaper. Connections currently checked
-    /// out are closed when their handles are dropped rather than returned to
-    /// the pool, so the pool holds no connections once all outstanding
-    /// handles are gone. Idempotent.
+    /// immediately, and signals the idle reaper to stop (the reaper polls the
+    /// closed flag and exits on its next tick, so it may linger briefly).
+    /// Connections currently checked out are closed when their handles are
+    /// dropped rather than returned to the pool, so the pool holds no
+    /// connections once all outstanding handles are gone. Idempotent.
     pub async fn close(&self) {
-        self.inner.closed.store(true, Ordering::Release);
-
-        // Drain idle connections and drop them, closing their sockets. New
-        // checkouts already fail with `PoolError::PoolClosed` (see `get`), and
-        // connections currently in use are closed when returned rather than
-        // re-pooled (see `Drop for PooledConnection`), so after this the pool
-        // holds nothing once outstanding handles are dropped.
-        let drained = std::mem::take(&mut *self.inner.idle_connections.lock());
+        // Set the closed flag *and* drain the idle queue while holding the
+        // idle lock, so this is atomic with respect to `Drop for
+        // PooledConnection`, which re-checks the flag under the same lock
+        // before re-pooling. Without this serialization a connection returning
+        // concurrently with `close()` could load `closed == false`, then get
+        // pushed into the idle queue after the drain — leaking past close.
+        let drained = {
+            let mut idle = self.inner.idle_connections.lock();
+            self.inner.closed.store(true, Ordering::Release);
+            std::mem::take(&mut *idle)
+        };
         let closed = drained.len() as u64;
         drop(drained); // closes the TCP sockets
 
@@ -1207,9 +1211,10 @@ impl Drop for PooledConnection {
         self.pool.in_use_count.fetch_sub(1, Ordering::Relaxed);
 
         if let Some(mut client) = self.client.take() {
-            // If the pool has been closed, discard the connection instead of
-            // returning it to the idle queue — otherwise `close()` could not
-            // actually empty the pool while connections were in use.
+            // Fast path: if the pool is already closed, discard rather than
+            // returning to the idle queue. This is an opportunistic check —
+            // the authoritative one happens under the idle lock at the
+            // push-back site below, which closes the race against `close()`.
             if self.pool.closed.load(Ordering::Acquire) {
                 tracing::trace!(
                     connection_id = self.metadata.id,
@@ -1287,7 +1292,26 @@ impl Drop for PooledConnection {
                 needs_health_check,
             };
 
-            self.pool.idle_connections.lock().push_back(entry);
+            // Re-check the closed flag while holding the idle lock and push
+            // atomically. `close()` sets the flag under this same lock before
+            // draining, so either it runs first (we see closed and discard) or
+            // we push first (its drain then removes this entry). Either way the
+            // connection cannot linger in the idle queue past `close()`.
+            {
+                let mut idle = self.pool.idle_connections.lock();
+                if self.pool.closed.load(Ordering::Acquire) {
+                    drop(idle);
+                    drop(entry); // closes the socket
+                    tracing::trace!(
+                        connection_id = self.metadata.id,
+                        "pool closed during return - discarding connection"
+                    );
+                    self.pool.otel_metrics.record_connection_closed();
+                    self.pool.record_pool_status();
+                    return;
+                }
+                idle.push_back(entry);
+            }
             self.pool.record_pool_status();
         } else {
             tracing::trace!(

--- a/crates/mssql-pool/src/pool.rs
+++ b/crates/mssql-pool/src/pool.rs
@@ -812,10 +812,34 @@ impl Pool {
         }
     }
 
-    /// Close the pool, dropping all connections.
+    /// Close the pool.
+    ///
+    /// Marks the pool closed (further [`Pool::get`] calls return
+    /// [`PoolError::PoolClosed`]), drains and closes all idle connections
+    /// immediately, and stops the idle reaper. Connections currently checked
+    /// out are closed when their handles are dropped rather than returned to
+    /// the pool, so the pool holds no connections once all outstanding
+    /// handles are gone. Idempotent.
     pub async fn close(&self) {
         self.inner.closed.store(true, Ordering::Release);
-        tracing::info!("connection pool closed");
+
+        // Drain idle connections and drop them, closing their sockets. New
+        // checkouts already fail with `PoolError::PoolClosed` (see `get`), and
+        // connections currently in use are closed when returned rather than
+        // re-pooled (see `Drop for PooledConnection`), so after this the pool
+        // holds nothing once outstanding handles are dropped.
+        let drained = std::mem::take(&mut *self.inner.idle_connections.lock());
+        let closed = drained.len() as u64;
+        drop(drained); // closes the TCP sockets
+
+        if closed > 0 {
+            self.inner.metrics.lock().connections_closed += closed;
+            for _ in 0..closed {
+                self.inner.otel_metrics.record_connection_closed();
+            }
+        }
+        self.inner.record_pool_status();
+        tracing::info!(closed_idle = closed, "connection pool closed");
     }
 
     /// Check if the pool is closed.
@@ -1183,6 +1207,19 @@ impl Drop for PooledConnection {
         self.pool.in_use_count.fetch_sub(1, Ordering::Relaxed);
 
         if let Some(mut client) = self.client.take() {
+            // If the pool has been closed, discard the connection instead of
+            // returning it to the idle queue — otherwise `close()` could not
+            // actually empty the pool while connections were in use.
+            if self.pool.closed.load(Ordering::Acquire) {
+                tracing::trace!(
+                    connection_id = self.metadata.id,
+                    "pool closed - discarding returned connection"
+                );
+                self.pool.otel_metrics.record_connection_closed();
+                self.pool.record_pool_status();
+                return;
+            }
+
             // Check if a request was in-flight (sent but response not fully read).
             // This happens when a query future is dropped mid-execution (e.g.,
             // via tokio::select! or a timeout). The TCP buffer has unread response

--- a/crates/mssql-pool/tests/integration.rs
+++ b/crates/mssql-pool/tests/integration.rs
@@ -61,8 +61,55 @@ async fn test_pool_create_and_close() {
     assert_eq!(status.max, 5);
     assert_eq!(status.in_use, 0);
 
+    // Warm the pool so there are idle connections to drain.
+    {
+        let _c1 = pool.get().await.expect("checkout 1");
+        let _c2 = pool.get().await.expect("checkout 2");
+    } // returned to idle here
+    assert!(pool.status().available > 0, "pool should have idle conns");
+
     pool.close().await;
     assert!(pool.is_closed());
+
+    // close() must actually drain the idle connections, not just flip a flag.
+    assert_eq!(
+        pool.status().available,
+        0,
+        "close() must drain idle connections"
+    );
+
+    // And new checkouts must be refused.
+    assert!(
+        matches!(pool.get().await, Err(PoolError::PoolClosed)),
+        "checkout after close must fail with PoolClosed"
+    );
+}
+
+#[tokio::test]
+#[ignore = "Requires SQL Server"]
+async fn test_pool_close_discards_in_use_connection_on_return() {
+    let client_config = get_test_config().expect("SQL Server config required");
+
+    let pool = Pool::builder()
+        .client_config(client_config)
+        .max_connections(5)
+        .build()
+        .await
+        .expect("Failed to create pool");
+
+    // Hold a connection across close(), then return it.
+    let conn = pool.get().await.expect("checkout");
+    pool.close().await;
+    assert_eq!(pool.status().in_use, 1, "still in use during close");
+
+    drop(conn); // returned after close — must be discarded, not re-pooled
+
+    let status = pool.status();
+    assert_eq!(status.in_use, 0, "in_use decremented on return");
+    assert_eq!(
+        status.available, 0,
+        "connection returned after close must be discarded, not idle"
+    );
 }
 
 #[tokio::test]

--- a/crates/mssql-pool/tests/integration.rs
+++ b/crates/mssql-pool/tests/integration.rs
@@ -114,6 +114,55 @@ async fn test_pool_close_discards_in_use_connection_on_return() {
 
 #[tokio::test]
 #[ignore = "Requires SQL Server"]
+async fn test_pool_close_under_concurrent_churn_does_not_deadlock() {
+    // Robustness smoke test, NOT a race-leak detector. The return-vs-close
+    // leak window is a few microseconds inside `Drop`, too narrow to hit
+    // reliably from a test — verified empirically: an `available == 0`
+    // assertion here passes even against the pre-fix (racy) code, so it would
+    // be false confidence. This asserts only liveness: `close()` racing many
+    // concurrent checkouts/returns must not deadlock or panic. The leak
+    // property is guaranteed instead by lock ordering — `close()` sets the
+    // closed flag and drains the idle queue under the same lock that `Drop`
+    // re-checks before re-pooling — and the non-racy path is covered by the
+    // two tests above.
+    let client_config = get_test_config().expect("SQL Server config required");
+
+    let pool = Arc::new(
+        Pool::builder()
+            .client_config(client_config)
+            .max_connections(4)
+            .build()
+            .await
+            .expect("Failed to create pool"),
+    );
+
+    let mut handles = Vec::new();
+    for _ in 0..8 {
+        let pool = pool.clone();
+        handles.push(tokio::spawn(async move {
+            for _ in 0..50 {
+                match pool.get().await {
+                    Ok(conn) => {
+                        tokio::task::yield_now().await;
+                        drop(conn);
+                    }
+                    Err(_) => break, // PoolClosed once close() lands
+                }
+            }
+        }));
+    }
+
+    tokio::task::yield_now().await;
+    pool.close().await;
+
+    for handle in handles {
+        handle.await.expect("task panicked or deadlocked");
+    }
+    assert!(pool.is_closed());
+}
+
+#[tokio::test]
+#[ignore = "Requires SQL Server"]
 async fn test_pool_with_otel_name() {
     // Exercises the OTel metric hooks end-to-end: create, warmup, checkout,
     // checkin, close. When built without the `otel` feature this calls the


### PR DESCRIPTION
## Summary

Two pieces of dead configuration from the review (findings 5 and 7).

### `Config.tls` was ignored (finding 5)

Both connect paths — TDS 8.0 strict (`connect_tds_8`) and the TDS 7.x PreLogin upgrade — built a fresh `TlsConfig::new()` and set only `trust_server_certificate`, silently discarding `config.tls`. So custom root certificates and client auth set programmatically were **unreachable**: a user adding a private CA via `config.tls` would still get system-roots validation.

Both paths now build from `config.tls` through a shared `connection_tls_config()` helper that layers TDS 8.0 strict mode + `tds/8.0` ALPN only for the strict path. A subtlety the review didn't name: the connection-string parser sets the **top-level** `config.trust_server_certificate` without mirroring it into `config.tls`, so the helper reads the trust flag from the top-level field (keeping `TrustServerCertificate=...` connection strings working) while taking root certs / client auth from `config.tls`.

Three unit tests, including the falsification one: a custom root now reaches the connector config (it didn't before), the top-level trust flag wins, and strict mode adds the TDS 8.0 ALPN.

### `Pool::close()` set a flag and closed nothing (finding 7)

`close()` now drains and closes all idle connections immediately. I also found a second leak the review didn't name: `Drop for PooledConnection` re-pooled returns **without checking the closed flag**, so any connection in use at close time leaked back into the idle queue — defeating the close. The return path now discards when the pool is closed. Checkout rejection already worked (`get()` returns `PoolError::PoolClosed`).

The doc comment is rewritten to describe the real behavior (drain idle, refuse checkouts, discard in-use on return, idempotent). Integration tests assert idle drains to zero after close and a connection returned post-close is discarded, not re-pooled.

## Verification

- Pool close tests pass against live SQL Server 2022 (`test_pool_create_and_close`, `test_pool_close_discards_in_use_connection_on_return`)
- TLS config unit tests pass
- Full workspace tests, `clippy --all-features --all-targets -D warnings`, the `--no-default-features` build, `fmt`, and strict `rustdoc` all green

No live TLS endpoint is exercised here — the TLS test verifies the config plumbing (custom root reaches the connector); end-to-end TLS against a server with a private CA remains live-server (#87) territory.