### PR TITLE
refactor(api): make the public surface self-contained (item 5)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,6 +141,22 @@ jobs:
       - name: Build examples
         run: cargo build --examples --all-features
 
+  api-self-containment:
+    name: API Self-Containment
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+      - uses: ./.github/actions/setup-linux-deps
+      - name: Build the api-smoke guard
+        # api-smoke depends ONLY on mssql-client (not the internal crates), so
+        # this fails to compile if any public entry point — including derive
+        # macro output — needs a direct dependency on an internal crate.
+        run: cargo build -p api-smoke
+
   miri:
     name: Miri (unsafe code detection)
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,6 +137,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "api-smoke"
+version = "0.11.0"
+dependencies = [
+ "mssql-client",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,12 +26,14 @@ mssql-types = { version = "0.11.0", path = "crates/mssql-types" }
 mssql-auth = { version = "0.11.0", path = "crates/mssql-auth" }
 mssql-driver-pool = { version = "0.11.0", path = "crates/mssql-pool" }
 mssql-client = { version = "0.11.0", path = "crates/mssql-client" }
-# Path-only (no version): mssql-derive is consumed solely as a dev-dependency
-# (mssql-client's tests). Cargo strips versionless path dev-deps from published
-# manifests, which breaks the publish-order cycle that blocked the v0.11.0
-# release: a versioned dev-dep made packaging mssql-client require
-# mssql-derive@0.11.0 to already exist on crates.io.
-mssql-derive = { path = "crates/mssql-derive" }
+# Versioned: mssql-derive is now an optional NORMAL dependency of mssql-client
+# (the `derive` feature re-exports its macros), so it must carry a version to
+# be packaged into mssql-client's published manifest, and release-plz publishes
+# it before mssql-client (a simple linear order — mssql-derive only depends on
+# proc-macro2/quote/syn, so there is no cycle). The v0.11.0 incident this list
+# guards against was a versioned *dev*-dependency; the publish-invariants check
+# only flags dev/build-deps, which this is not.
+mssql-derive = { version = "0.11.0", path = "crates/mssql-derive" }
 # Path-only for the same reason as mssql-derive: never published
 # (publish = false), so a version field can only drift (it was stuck at 0.10.0
 # while the crate itself moved with the workspace).

--- a/crates/api-smoke/Cargo.toml
+++ b/crates/api-smoke/Cargo.toml
@@ -1,0 +1,22 @@
+# Public-API self-containment guard.
+#
+# Depends ONLY on `mssql-client` — deliberately NOT on the internal crates
+# (mssql-types, tds-protocol, mssql-auth, mssql-tls, mssql-codec, mssql-derive).
+# If any public entry point (including the derive macros' generated code)
+# requires one of those crates to be a direct dependency, THIS CRATE FAILS TO
+# COMPILE. That is the point: it reproduces an external consumer and turns
+# self-containment from an assertion into a CI-enforced fact.
+#
+# Not published; build-only.
+[package]
+name = "api-smoke"
+version.workspace = true
+edition = "2024"
+publish = false
+
+[dependencies]
+mssql-client = { workspace = true, features = ["derive", "always-encrypted"] }
+
+
+[lints]
+workspace = true

--- a/crates/api-smoke/Cargo.toml
+++ b/crates/api-smoke/Cargo.toml
@@ -13,6 +13,7 @@ name = "api-smoke"
 version.workspace = true
 edition = "2024"
 publish = false
+license.workspace = true
 
 [dependencies]
 mssql-client = { workspace = true, features = ["derive", "always-encrypted"] }

--- a/crates/api-smoke/src/lib.rs
+++ b/crates/api-smoke/src/lib.rs
@@ -1,0 +1,75 @@
+//! Compile-time public-API self-containment guard. See Cargo.toml.
+//!
+//! Every item below is named through `mssql_client` only. If any requires a
+//! direct dependency on an internal crate, this crate fails to build.
+#![allow(dead_code)]
+
+use mssql_client::{
+    AuthError, CertificateDer, CodecError, Collation, Config, Error, FromSql, KeyStoreProvider,
+    ProtocolError, Row, SqlValue, TlsConfig, ToSql, TypeError,
+};
+
+// --- Derive macros (the actual self-containment break this guard exists for) ---
+#[derive(mssql_client::FromRow)]
+struct Loaded {
+    id: i32,
+    name: String,
+}
+
+#[derive(mssql_client::ToParams)]
+struct Params {
+    id: i32,
+    name: String,
+}
+
+#[derive(mssql_client::Tvp)]
+#[mssql(type_name = "dbo.MyType")]
+struct TvpRow {
+    a: i32,
+    b: String,
+}
+
+// --- Error sub-types must be nameable (Decision A) ---
+fn classify(e: &Error) -> &'static str {
+    match e {
+        Error::Type(_) => "type",
+        Error::Authentication(_) => "auth",
+        Error::ProtocolError(_) => "protocol",
+        Error::Codec(_) => "codec",
+        _ => "other",
+    }
+}
+
+fn name_sub_errors(
+    _: Option<TypeError>,
+    _: Option<AuthError>,
+    _: Option<ProtocolError>,
+    _: Option<CodecError>,
+) {
+}
+
+// --- TypeError is the FromSql/ToSql trait error: implementable without mssql-types ---
+struct MyId(i32);
+impl FromSql for MyId {
+    fn from_sql(value: &SqlValue) -> Result<Self, TypeError> {
+        Ok(MyId(i32::from_sql(value)?))
+    }
+}
+
+// --- Additive re-exports (this session) must be nameable ---
+fn touch_tls() -> TlsConfig {
+    TlsConfig::new().add_root_certificate(CertificateDer::from(vec![0u8; 4]))
+}
+
+fn touch_collation(col: &mssql_client::Column) -> Option<Collation> {
+    col.collation
+}
+
+fn touch_provider<P: KeyStoreProvider>(_: P) {}
+
+fn touch_config() -> Config {
+    Config::new()
+}
+
+fn use_to_sql<T: ToSql>(_: &T) {}
+fn use_row(_: &Row) {}

--- a/crates/mssql-client/Cargo.toml
+++ b/crates/mssql-client/Cargo.toml
@@ -15,7 +15,11 @@ categories = ["database", "asynchronous"]
 features = ["otel", "json", "always-encrypted", "zeroize", "encoding", "tls", "chrono", "uuid", "decimal", "filestream"]
 
 [features]
-default = ["chrono", "uuid", "decimal", "encoding", "tls"]
+default = ["chrono", "uuid", "decimal", "encoding", "tls", "derive"]
+# Derive macros (`#[derive(FromRow, ToParams, Tvp)]`), re-exported from
+# `mssql-derive` so users need only the `mssql-client` dependency. On by
+# default; disable with `default-features = false` if you don't use them.
+derive = ["dep:mssql-derive"]
 # Type support features — forwarded to mssql-types
 chrono = ["mssql-types/chrono", "dep:chrono"]
 uuid = ["mssql-types/uuid", "dep:uuid"]
@@ -57,6 +61,7 @@ mssql-tls = { workspace = true, optional = true }
 mssql-codec = { workspace = true }
 mssql-types = { workspace = true }
 mssql-auth = { workspace = true }
+mssql-derive = { workspace = true, optional = true }
 bytes = { workspace = true }
 tokio = { workspace = true }
 thiserror = { workspace = true }
@@ -82,7 +87,6 @@ tracing-opentelemetry = { workspace = true, optional = true }
 
 [dev-dependencies]
 tokio-test = { workspace = true }
-mssql-derive = { workspace = true }
 trybuild = { workspace = true }
 # Note: mssql-driver-pool removed to break circular dev-dependency.
 # Pool-dependent tests are in mssql-testing crate.
@@ -134,10 +138,10 @@ name = "client"
 harness = false
 
 [package.metadata.cargo-machete]
-# tokio-test and mssql-derive are dev-dependencies for tests
+# tokio-test is a dev-dependency for tests
 # opentelemetry_sdk and tracing-opentelemetry are behind the otel feature flag
-# mssql-tls is behind the tls feature flag
-ignored = ["tokio-test", "mssql-derive", "opentelemetry_sdk", "tracing-opentelemetry", "mssql-tls"]
+# mssql-tls is behind the tls feature flag; mssql-derive behind the derive feature flag
+ignored = ["tokio-test", "opentelemetry_sdk", "tracing-opentelemetry", "mssql-tls", "mssql-derive"]
 
 [lints]
 workspace = true

--- a/crates/mssql-client/examples/derive_macros.rs
+++ b/crates/mssql-client/examples/derive_macros.rs
@@ -13,9 +13,12 @@
 
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
-use mssql_client::{Client, Column, Config, Error, FromRow, Row, ToParams, Tvp, TvpValue};
-use mssql_derive::{FromRow, ToParams, Tvp};
-use mssql_types::SqlValue;
+// Everything comes from `mssql_client` alone — the derive macros are
+// re-exported under the `derive` feature, so no direct dependency on
+// `mssql-derive` or `mssql-types` is needed.
+use mssql_client::{
+    Client, Column, Config, Error, FromRow, Row, SqlValue, ToParams, Tvp, TvpValue,
+};
 
 /// A user struct that can be populated from query results.
 ///

--- a/crates/mssql-client/src/lib.rs
+++ b/crates/mssql-client/src/lib.rs
@@ -38,7 +38,10 @@ pub mod procedure;
 pub mod query;
 pub mod row;
 pub mod state;
-pub mod statement_cache;
+// Not yet wired into the query path (queries use sp_executesql); kept
+// crate-private until the cache is actually used, so the public API does not
+// expose types for an unshipped feature. Re-export when it lands.
+pub(crate) mod statement_cache;
 pub mod stream;
 pub mod to_params;
 pub mod transaction;
@@ -53,6 +56,52 @@ pub use cancel::CancelHandle;
 pub use client::Client;
 pub use config::{ApplicationIntent, Config, RedirectConfig, RetryPolicy, TimeoutConfig};
 pub use error::{Error, SharedIoError};
+// Sub-error types carried by `Error` variants and the `FromSql`/`ToSql` trait
+// return type. Re-exported so downstream crates can name them (e.g. match on
+// `Error::Type(e)`, or write `fn from_sql(..) -> Result<Self, TypeError>`)
+// without depending on the internal crates directly. `EncryptionError` is
+// intentionally NOT here: `Error` stringifies it (see `error.rs`) so key
+// material cannot leak, and it appears in no other public signature.
+pub use mssql_auth::AuthError;
+pub use mssql_codec::CodecError;
+#[cfg(feature = "tls")]
+pub use mssql_tls::TlsError;
+pub use mssql_types::TypeError;
+pub use tds_protocol::ProtocolError;
+
+// TLS configuration: re-export so the `Config::tls` field is usable (custom
+// root certificates, client auth) without a direct `mssql-tls` dependency.
+// `CertificateDer` is needed to add a root certificate.
+#[cfg(feature = "tls")]
+pub use mssql_tls::{CertificateDer, TlsConfig};
+
+// `KeyStoreProvider` extension trait: users implement it for custom Always
+// Encrypted key stores (per the encryption-module docs) without a direct
+// `mssql-auth` dependency.
+#[cfg(feature = "always-encrypted")]
+pub use mssql_auth::KeyStoreProvider;
+
+// `Collation` appears on `Column::collation` and the `with_collation` builders
+// (Column, BulkColumn); re-export so those are usable without a direct
+// `tds-protocol` dependency.
+pub use tds_protocol::token::Collation;
+
+// Derive macros, re-exported under the `derive` feature so users need only a
+// single `mssql-client` dependency (the macros' generated code resolves all
+// its paths through `mssql_client`, including `__private` below). The macro
+// names intentionally match the trait names — they live in the macro
+// namespace, so `#[derive(FromRow)]` and `impl FromRow` coexist (as with
+// serde's `Serialize`).
+#[cfg(feature = "derive")]
+pub use mssql_derive::{FromRow, ToParams, Tvp};
+
+/// Items the derive macros' generated code references. Not public API: hidden
+/// from docs and exempt from stability guarantees. Centralizing them here
+/// keeps the proc-macro crate decoupled from internal restructuring.
+#[doc(hidden)]
+pub mod __private {
+    pub use mssql_types::{ToSql, TypeError};
+}
 
 // Re-export TDS version for configuration
 pub use from_row::{FromRow, MapRows, RowIteratorExt};
@@ -73,7 +122,6 @@ pub use row::{Column, Row};
 pub use state::{
     Connected, ConnectionState, Disconnected, InTransaction, ProtocolState, Ready, Streaming,
 };
-pub use statement_cache::{PreparedStatement, StatementCache, StatementCacheConfig};
 
 /// Internal entry points for the fuzzing harness in `fuzz/`.
 ///
@@ -239,9 +287,10 @@ mod auto_trait_tests {
         assert_sync::<Column>();
     }
 
-    // --- Statement cache ---
+    // --- Statement cache (crate-private until wired) ---
     #[test]
     fn statement_cache_is_send_sync() {
+        use crate::statement_cache::StatementCache;
         assert_send::<StatementCache>();
         assert_sync::<StatementCache>();
     }

--- a/crates/mssql-client/src/statement_cache.rs
+++ b/crates/mssql-client/src/statement_cache.rs
@@ -1,5 +1,13 @@
 //! Prepared statement caching with LRU eviction.
 //!
+//! **Status: implemented but not yet wired into the query path.** Queries
+//! currently go through `sp_executesql` (the server still reuses plans), so
+//! this cache is constructed but never consulted; its types are crate-private
+//! until it is wired. The implementation is kept ready for that integration —
+//! hence the `dead_code` allowance below. See LIMITATIONS.md § Prepared
+//! Statement Cache.
+#![allow(dead_code)]
+//!
 //! This module provides automatic caching of prepared statements to improve performance
 //! for repeated query execution. The cache uses an LRU (Least Recently Used) eviction
 //! policy to manage memory and server-side resources.

--- a/crates/mssql-derive/src/to_params.rs
+++ b/crates/mssql-derive/src/to_params.rs
@@ -59,7 +59,7 @@ pub(crate) fn impl_to_params(input: &DeriveInput) -> syn::Result<TokenStream2> {
         impl #impl_generics mssql_client::ToParams for #name #ty_generics #where_clause {
             fn to_params(&self) -> ::std::result::Result<
                 ::std::vec::Vec<mssql_client::NamedParam>,
-                mssql_types::TypeError
+                mssql_client::__private::TypeError
             > {
                 Ok(::std::vec![
                     #(#param_creations),*

--- a/crates/mssql-derive/src/tvp.rs
+++ b/crates/mssql-derive/src/tvp.rs
@@ -65,7 +65,7 @@ pub(crate) fn impl_tvp(input: &DeriveInput) -> syn::Result<TokenStream2> {
         });
 
         value_extractions.push(quote! {
-            mssql_types::ToSql::to_sql(&self.#field_name)?
+            mssql_client::__private::ToSql::to_sql(&self.#field_name)?
         });
 
         ordinal += 1;
@@ -83,7 +83,7 @@ pub(crate) fn impl_tvp(input: &DeriveInput) -> syn::Result<TokenStream2> {
                 ]
             }
 
-            fn to_row(&self) -> ::std::result::Result<mssql_client::TvpRow, mssql_types::TypeError> {
+            fn to_row(&self) -> ::std::result::Result<mssql_client::TvpRow, mssql_client::__private::TypeError> {
                 Ok(mssql_client::TvpRow::new(::std::vec![
                     #(#value_extractions),*
                 ]))


### PR DESCRIPTION
## Summary

Item 5 (public-API self-containment). External review found the concrete break I missed in my first analysis: it's in the **derive macros**, not the error enum.

`ToParams` and `Tvp` emit literal `mssql_types::` paths, so any external crate using `#[derive(ToParams)]` / `#[derive(Tvp)]` fails to compile with `E0433: unresolved crate mssql_types` unless it adds a direct `mssql-types` dependency. `FromRow` was already clean (it routes through `mssql_client::`). The in-crate derive tests masked it because `mssql-types` is always in scope there. I proved it end-to-end for both `ToParams` and `Tvp`.

## Fixes (falsification-first — the guard failed E0432/E0433 before these)

- **Derive facade (serde-style):** macros emit `mssql_client::__private::{TypeError, ToSql}`; added `#[doc(hidden)] pub mod __private`. Generated code resolves entirely through `mssql_client`.
- **New `derive` feature (default-on)** re-exports the macros, so users need **one** dependency instead of three. `mssql-derive` moves from dev-dependency to optional dependency.
- **Re-export the five real error sub-types** carried by `Error` variants and the `FromSql`/`ToSql` contract: `TypeError`, `AuthError`, `ProtocolError`, `CodecError`, `TlsError`. **Not** `EncryptionError` — `Error` deliberately stringifies it (error.rs) so key material can't leak; it's not a `#[from]` leak. (My earlier list of six was wrong; the review caught it.)
- **Re-export `KeyStoreProvider`, `TlsConfig`, `CertificateDer`, `Collation`** so the documented extension points and the `Config.tls` / `Column.collation` fields are usable without internal-crate deps.
- **Unexport the unwired statement-cache types** (`pub(crate)`; the cache isn't consulted yet). Re-export when wired.

## The guard (the durable part)

`crates/api-smoke` depends **only** on `mssql-client` and exercises the derives plus every re-exported type. A new **API Self-Containment** CI job builds it, so self-containment is now a CI-enforced fact, not an assertion. This is what keeps it from silently rotting again (the same masking that hid the bug).

`cargo public-api` confirms: the five error sub-types + four extension types are now nameable, the statement-cache types are gone from the surface, and `__private` stays hidden.

## Deferred to item 9 (parameter encryption, coming soon)

The AE wire structs (`ParameterEncryptionInfo` / `ResultSetEncryptionInfo` / `ParameterCryptoInfo` + `EncryptionContext` wire methods) and the two `TypeInfo` leaks (`output_raw` / `to_type_info`). Both posture decisions interact with the write path, so reshaping now risks doing it twice.

## Verification

Workspace tests, `clippy --workspace --all-features --all-targets -D warnings`, `--no-default-features` build, strict rustdoc, fmt, and `just doc-consistency` (25/25) all green. Derive functional + trybuild compile-fail tests pass. The `derive_macros` example now imports from `mssql_client` alone.