### PR TITLE
fix: capability-audit sweep — cancellation, redirects, TVP collation, OTel metrics, Change Tracking

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -746,10 +746,10 @@ webpki-roots = "1.0"
 thiserror = "2.0"
 
 # Observability (optional `otel` feature)
-opentelemetry = { version = "0.31", optional = true }
-opentelemetry_sdk = { version = "0.31", optional = true }
-opentelemetry-otlp = { version = "0.31", optional = true }
-tracing-opentelemetry = { version = "0.32", optional = true }
+opentelemetry = { version = "0.32", optional = true }
+opentelemetry_sdk = { version = "0.32", optional = true }
+opentelemetry-otlp = { version = "0.32", optional = true }
+tracing-opentelemetry = { version = "0.33", optional = true }
 
 # Testing
 criterion = { version = "0.8", features = ["async_tokio"] }
@@ -780,7 +780,7 @@ Dependencies use **minimum version constraints** (caret requirements) rather tha
 # PREFERRED: Allows compatible updates (default Cargo behavior)
 tokio = "1.48"           # Equivalent to "^1.48", allows 1.48.x and 1.49.x etc.
 rustls = "0.23"          # Allows 0.23.x updates
-opentelemetry = "0.31"   # Allows 0.31.x updates
+opentelemetry = "0.32"   # Allows 0.32.x updates
 
 # AVOID: Creates immediate tech debt, blocks security patches
 tokio = "=1.48.0"        # Exact pin - requires manual update for every patch
@@ -829,37 +829,38 @@ src/
 
 **API:**
 ```rust
-let bulk = client
-    .bulk_insert("dbo.Users")
-    .with_columns(&["id", "name", "email"])
+let builder = BulkInsertBuilder::new("dbo.Users")
+    .with_typed_columns(vec![
+        BulkColumn::new("id", "INT", 0)?,
+        BulkColumn::new("name", "NVARCHAR(100)", 1)?,
+        BulkColumn::new("email", "NVARCHAR(200)", 2)?,
+    ])
     .with_options(BulkOptions {
-        batch_size: 1000,
+        batch_size: 1000, // sent as a ROWS_PER_BATCH hint
         check_constraints: true,
         fire_triggers: false,
         keep_nulls: true,
         table_lock: true,
-    })
-    .build()
-    .await?;
+        order_hint: None,
+    });
 
-// Stream rows
+let mut writer = client.bulk_insert(&builder).await?;
 for user in users {
-    bulk.send_row(&[&user.id, &user.name, &user.email]).await?;
+    writer.send_row_values(&[
+        SqlValue::Int(user.id),
+        SqlValue::String(user.name),
+        SqlValue::String(user.email),
+    ])?;
 }
 
-let result = bulk.finish().await?;
+let result = writer.finish().await?;
 println!("Inserted {} rows", result.rows_affected);
 ```
 
-**Streaming from CSV:**
-```rust
-let file = File::open("users.csv").await?;
-let reader = csv_async::AsyncReader::from_reader(file);
-
-let bulk = client.bulk_insert("dbo.Users").build().await?;
-bulk.send_stream(reader).await?;
-let result = bulk.finish().await?;
-```
+**Current limits:** rows are buffered in memory and sent as a single batch on
+`finish()` — `BulkOptions::batch_size` is only a `ROWS_PER_BATCH` server hint.
+Incremental client-side flushing and a streaming input API are planned
+alongside the response-streaming work.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ Refer to `ARCHITECTURE.md` (v1.2.0) for complete details. Critical decisions:
 | TLS | rustls | Pure Rust, auditable, no OpenSSL dependency |
 | Async Runtime | Tokio 1.48+ | Dominant ecosystem, hard dependency simplifies design |
 | Error Handling | thiserror 2.0 | Derive macros, stable API |
-| Observability | OpenTelemetry 0.31 | Industry standard, version-aligned crates |
+| Observability | OpenTelemetry 0.32 | Industry standard, version-aligned crates |
 | Edition | Rust 2024 | Latest language features, MSRV 1.88 |
 
 ## Security-Critical Guidelines
@@ -262,13 +262,13 @@ All workflows use `concurrency: cancel-in-progress` for non-main branches to sav
 
 ## OpenTelemetry Dependencies
 
-The three core otel crates are version-aligned at 0.31. `tracing-opentelemetry` tracks 0.32, which depends on otel 0.31 (see the note in `Cargo.toml`):
+The three core otel crates are version-aligned at 0.32. `tracing-opentelemetry` tracks 0.33, which depends on otel 0.32 (see the note in `Cargo.toml`):
 
 ```toml
-opentelemetry = "0.31"
-opentelemetry_sdk = "0.31"
-opentelemetry-otlp = "0.31"
-tracing-opentelemetry = "0.32"
+opentelemetry = "0.32"
+opentelemetry_sdk = "0.32"
+opentelemetry-otlp = "0.32"
+tracing-opentelemetry = "0.33"
 ```
 
 ## Testing Strategy

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2573,6 +2573,8 @@ dependencies = [
  "bytes",
  "mssql-client",
  "mssql-tls",
+ "opentelemetry",
+ "opentelemetry_sdk",
  "rcgen",
  "rustls",
  "tds-protocol",
@@ -2844,6 +2846,7 @@ dependencies = [
  "portable-atomic",
  "rand 0.9.2",
  "thiserror 2.0.18",
+ "tokio",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ An async Microsoft SQL Server driver for Rust.
 | Named Instance Resolution | Yes | SQL Browser service (UDP 1434) |
 | MultiSubnetFailover (AG) | Yes | Parallel TCP connect for listener failover |
 | Connection Retry | Yes | `ConnectRetryCount` / `ConnectRetryInterval` |
-| FILESTREAM BLOB Access | Yes | Windows only, via `filestream` feature |
+| FILESTREAM BLOB Access | Untested | Windows only via `filestream` feature; not yet validated against a FILESTREAM-enabled instance |
 
 ## Installation
 

--- a/crates/mssql-client/src/bulk.rs
+++ b/crates/mssql-client/src/bulk.rs
@@ -70,11 +70,15 @@ use crate::error::Error;
 /// affect performance, logging, and constraint checking.
 #[derive(Debug, Clone)]
 pub struct BulkOptions {
-    /// Number of rows per batch commit.
+    /// Rows-per-batch hint sent to the server.
     ///
-    /// Smaller batches use less memory but have more overhead.
-    /// Larger batches are more efficient but hold locks longer.
-    /// Default: 0 (single batch for entire operation).
+    /// When non-zero this is emitted as the `ROWS_PER_BATCH` hint on the
+    /// `INSERT BULK` statement, which helps the server pick a query plan.
+    /// It does **not** change client-side behavior: [`BulkWriter`] buffers
+    /// all rows in memory and sends them as a single batch on
+    /// [`finish()`](BulkWriter::finish). Incremental flushing is planned
+    /// alongside the response-streaming work.
+    /// Default: 0 (no hint).
     pub batch_size: usize,
 
     /// Check constraints during insert.
@@ -335,6 +339,8 @@ pub struct BulkInsertResult {
     /// Total number of rows inserted.
     pub rows_affected: u64,
     /// Number of batches committed.
+    ///
+    /// [`BulkWriter`] always sends a single batch, so this is currently 1.
     pub batches_committed: u32,
     /// Whether any errors were encountered.
     pub has_errors: bool,
@@ -1299,6 +1305,10 @@ impl BulkInsert {
     }
 
     /// Check if a batch flush is needed.
+    ///
+    /// Note: [`BulkWriter`] does not consult this — it buffers every row and
+    /// sends one batch on finish. This is a helper for callers driving the
+    /// lower-level [`BulkInsert`] packet API manually.
     pub fn should_flush(&self) -> bool {
         self.batch_size > 0 && self.rows_in_batch >= self.batch_size
     }

--- a/crates/mssql-client/src/change_tracking.rs
+++ b/crates/mssql-client/src/change_tracking.rs
@@ -573,10 +573,16 @@ impl ChangeTracking {
     /// `dbo.Items` → `[dbo].[Items]`. Bracketing the whole string as one
     /// identifier (`[dbo.Items]`) names a table literally called
     /// "dbo.Items", which fails with error 4902 on real servers.
+    ///
+    /// Interior `]` characters are doubled (the T-SQL QUOTENAME rule), so a
+    /// hostile name like ``foo]; DROP TABLE bar--`` stays a single quoted
+    /// identifier instead of terminating it early and smuggling a second
+    /// statement into the batch. Pass names unbracketed; pre-bracketed input
+    /// is treated as literal characters of the name.
     fn bracket_table_name(table_name: &str) -> String {
         table_name
             .split('.')
-            .map(|part| format!("[{}]", part.trim_matches(['[', ']'])))
+            .map(|part| format!("[{}]", part.replace(']', "]]")))
             .collect::<Vec<_>>()
             .join(".")
     }
@@ -711,6 +717,13 @@ mod tests {
         assert!(sql.contains("CHANGETABLE(CHANGES Products, 42)"));
         assert!(sql.contains("SYS_CHANGE_VERSION"));
         assert!(sql.contains("SYS_CHANGE_OPERATION"));
+        // SQL Server rejects CHANGETABLE without an alias (error 22104) —
+        // the substring above matches the broken pre-alias SQL too, so pin
+        // the alias explicitly.
+        assert!(
+            sql.contains(") AS CT"),
+            "CHANGETABLE must be aliased or the query is not executable: {sql}"
+        );
     }
 
     #[test]
@@ -784,6 +797,25 @@ mod tests {
         assert!(qualified.contains("ALTER TABLE [dbo].[Products]"));
         let disable = ChangeTracking::disable_table_sql("dbo.Products");
         assert!(disable.contains("ALTER TABLE [dbo].[Products]"));
+    }
+
+    /// PR #143 review, Blocker 2: interior `]` must be doubled (QUOTENAME
+    /// rule) so a hostile table name cannot terminate the bracketed
+    /// identifier early and smuggle a second statement into the batch.
+    #[test]
+    fn test_bracket_escapes_closing_brackets() {
+        let sql = ChangeTracking::enable_table_sql("foo]; DROP TABLE bar--", true);
+        assert!(
+            sql.contains("ALTER TABLE [foo]]; DROP TABLE bar--]"),
+            "interior ] must be doubled, got: {sql}"
+        );
+        assert!(
+            !sql.contains("ALTER TABLE [foo];"),
+            "the identifier must not be terminated early: {sql}"
+        );
+
+        let sql = ChangeTracking::disable_table_sql("we]ird.na]me");
+        assert!(sql.contains("ALTER TABLE [we]]ird].[na]]me]"));
     }
 
     #[test]

--- a/crates/mssql-client/src/change_tracking.rs
+++ b/crates/mssql-client/src/change_tracking.rs
@@ -324,9 +324,11 @@ impl ChangeTrackingQuery {
         // Build the SELECT column list
         let select_cols = self.build_select_columns();
 
+        // SQL Server requires an alias on CHANGETABLE ("A table returned by
+        // the CHANGETABLE function must be aliased.", error 22104).
         format!(
-            "SELECT {} FROM CHANGETABLE(CHANGES {}, {}{})",
-            select_cols, self.table_name, self.last_sync_version, force_seek
+            "SELECT {} FROM CHANGETABLE(CHANGES {}, {}{}) AS {}",
+            select_cols, self.table_name, self.last_sync_version, force_seek, self.alias
         )
     }
 
@@ -553,8 +555,9 @@ impl ChangeTracking {
     #[must_use]
     pub fn enable_table_sql(table_name: &str, track_columns_updated: bool) -> String {
         let track_cols = if track_columns_updated { "ON" } else { "OFF" };
+        let table = Self::bracket_table_name(table_name);
         format!(
-            "ALTER TABLE [{table_name}] ENABLE CHANGE_TRACKING \
+            "ALTER TABLE {table} ENABLE CHANGE_TRACKING \
              WITH (TRACK_COLUMNS_UPDATED = {track_cols})"
         )
     }
@@ -562,7 +565,20 @@ impl ChangeTracking {
     /// Generate SQL to disable change tracking on a table.
     #[must_use]
     pub fn disable_table_sql(table_name: &str) -> String {
-        format!("ALTER TABLE [{table_name}] DISABLE CHANGE_TRACKING")
+        let table = Self::bracket_table_name(table_name);
+        format!("ALTER TABLE {table} DISABLE CHANGE_TRACKING")
+    }
+
+    /// Bracket a possibly schema-qualified table name part by part:
+    /// `dbo.Items` → `[dbo].[Items]`. Bracketing the whole string as one
+    /// identifier (`[dbo.Items]`) names a table literally called
+    /// "dbo.Items", which fails with error 4902 on real servers.
+    fn bracket_table_name(table_name: &str) -> String {
+        table_name
+            .split('.')
+            .map(|part| format!("[{}]", part.trim_matches(['[', ']'])))
+            .collect::<Vec<_>>()
+            .join(".")
     }
 
     /// Generate SQL to disable change tracking on a database.
@@ -760,6 +776,14 @@ mod tests {
         let table_sql = ChangeTracking::enable_table_sql("Products", true);
         assert!(table_sql.contains("[Products]"));
         assert!(table_sql.contains("TRACK_COLUMNS_UPDATED = ON"));
+
+        // Schema-qualified names must be bracketed part by part —
+        // `[dbo.Products]` is a single (nonexistent) identifier and fails
+        // with error 4902 on a real server.
+        let qualified = ChangeTracking::enable_table_sql("dbo.Products", true);
+        assert!(qualified.contains("ALTER TABLE [dbo].[Products]"));
+        let disable = ChangeTracking::disable_table_sql("dbo.Products");
+        assert!(disable.contains("ALTER TABLE [dbo].[Products]"));
     }
 
     #[test]

--- a/crates/mssql-client/src/client.rs
+++ b/crates/mssql-client/src/client.rs
@@ -340,15 +340,7 @@ impl<S: ConnectionState> Client<S> {
         let meta_query = format!("SELECT TOP 0 * FROM {}", builder.table_name());
         self.send_sql_batch(&meta_query).await?;
 
-        let connection = self.connection.as_mut().ok_or(Error::ConnectionClosed)?;
-        let message = match connection {
-            #[cfg(feature = "tls")]
-            ConnectionHandle::Tls(conn) => conn.read_message().await?,
-            #[cfg(feature = "tls")]
-            ConnectionHandle::TlsPrelogin(conn) => conn.read_message().await?,
-            ConnectionHandle::Plain(conn) => conn.read_message().await?,
-        }
-        .ok_or(Error::ConnectionClosed)?;
+        let message = self.read_response_message().await?;
         self.in_flight = false;
 
         // Capture both the raw COLMETADATA bytes and parsed column info
@@ -691,6 +683,10 @@ impl Client<Ready> {
         let instrumentation = self.instrumentation.clone();
         #[cfg(feature = "otel")]
         let mut span = instrumentation.query_span(sql);
+        #[cfg(feature = "otel")]
+        let timer = crate::instrumentation::OperationTimer::start(
+            crate::instrumentation::extract_operation(sql),
+        );
 
         let result = async {
             if params.is_empty() {
@@ -714,6 +710,8 @@ impl Client<Ready> {
             Ok(_) => InstrumentationContext::record_success(&mut span, None),
             Err(e) => InstrumentationContext::record_error(&mut span, e),
         }
+        #[cfg(feature = "otel")]
+        timer.finish(instrumentation.metrics(), result.is_ok());
 
         // Drop the span before returning
         #[cfg(feature = "otel")]
@@ -854,6 +852,10 @@ impl Client<Ready> {
         let instrumentation = self.instrumentation.clone();
         #[cfg(feature = "otel")]
         let mut span = instrumentation.query_span(sql);
+        #[cfg(feature = "otel")]
+        let timer = crate::instrumentation::OperationTimer::start(
+            crate::instrumentation::extract_operation(sql),
+        );
 
         let result = async {
             if params.is_empty() {
@@ -877,6 +879,8 @@ impl Client<Ready> {
             Ok(rows) => InstrumentationContext::record_success(&mut span, Some(*rows)),
             Err(e) => InstrumentationContext::record_error(&mut span, e),
         }
+        #[cfg(feature = "otel")]
+        timer.finish(instrumentation.metrics(), result.is_ok());
 
         // Drop the span before returning
         #[cfg(feature = "otel")]
@@ -1239,6 +1243,10 @@ impl Client<InTransaction> {
         let instrumentation = self.instrumentation.clone();
         #[cfg(feature = "otel")]
         let mut span = instrumentation.query_span(sql);
+        #[cfg(feature = "otel")]
+        let timer = crate::instrumentation::OperationTimer::start(
+            crate::instrumentation::extract_operation(sql),
+        );
 
         let result = async {
             if params.is_empty() {
@@ -1262,6 +1270,8 @@ impl Client<InTransaction> {
             Ok(_) => InstrumentationContext::record_success(&mut span, None),
             Err(e) => InstrumentationContext::record_error(&mut span, e),
         }
+        #[cfg(feature = "otel")]
+        timer.finish(instrumentation.metrics(), result.is_ok());
 
         // Drop the span before returning
         #[cfg(feature = "otel")]
@@ -1305,6 +1315,10 @@ impl Client<InTransaction> {
         let instrumentation = self.instrumentation.clone();
         #[cfg(feature = "otel")]
         let mut span = instrumentation.query_span(sql);
+        #[cfg(feature = "otel")]
+        let timer = crate::instrumentation::OperationTimer::start(
+            crate::instrumentation::extract_operation(sql),
+        );
 
         let result = async {
             if params.is_empty() {
@@ -1328,6 +1342,8 @@ impl Client<InTransaction> {
             Ok(rows) => InstrumentationContext::record_success(&mut span, Some(*rows)),
             Err(e) => InstrumentationContext::record_error(&mut span, e),
         }
+        #[cfg(feature = "otel")]
+        timer.finish(instrumentation.metrics(), result.is_ok());
 
         // Drop the span before returning
         #[cfg(feature = "otel")]

--- a/crates/mssql-client/src/client/params.rs
+++ b/crates/mssql-client/src/client/params.rs
@@ -9,7 +9,8 @@ use tds_protocol::rpc::{RpcParam, TypeInfo as RpcTypeInfo};
 use tds_protocol::tvp::encode_tvp_decimal;
 use tds_protocol::tvp::{
     TvpColumnDef as TvpWireColumnDef, TvpEncoder, TvpWireType, encode_tvp_bit, encode_tvp_float,
-    encode_tvp_int, encode_tvp_null, encode_tvp_nvarchar, encode_tvp_varbinary, encode_tvp_varchar,
+    encode_tvp_int, encode_tvp_null, encode_tvp_nvarchar, encode_tvp_varbinary,
+    encode_tvp_varchar_with_collation,
 };
 #[cfg(feature = "chrono")]
 use tds_protocol::tvp::{encode_tvp_datetime, encode_tvp_smalldatetime};
@@ -153,7 +154,7 @@ impl<S: ConnectionState> Client<S> {
             }
             #[cfg(feature = "json")]
             SqlValue::Json(j) => RpcParam::nvarchar(name, &j.to_string()),
-            SqlValue::Tvp(tvp_data) => Self::encode_tvp_param(name, tvp_data)?,
+            SqlValue::Tvp(tvp_data) => Self::encode_tvp_param(name, tvp_data, collation)?,
             _ => {
                 return Err(Error::Type(mssql_types::TypeError::UnsupportedConversion {
                     from: sql_value.type_name().to_string(),
@@ -238,8 +239,14 @@ impl<S: ConnectionState> Client<S> {
     /// Encode a TVP parameter for RPC.
     ///
     /// This encodes the complete TVP structure including metadata and row data
-    /// into the TDS wire format.
-    fn encode_tvp_param(name: &str, tvp_data: &mssql_types::TvpData) -> Result<RpcParam> {
+    /// into the TDS wire format. `collation` (captured from the login
+    /// ENVCHANGE) determines the codepage VARCHAR cells are encoded with and
+    /// declared as; without it they fall back to Windows-1252.
+    fn encode_tvp_param(
+        name: &str,
+        tvp_data: &mssql_types::TvpData,
+        collation: Option<&tds_protocol::token::Collation>,
+    ) -> Result<RpcParam> {
         // Convert mssql-types column definitions to wire format
         let wire_columns: Vec<TvpWireColumnDef> = tvp_data
             .columns
@@ -261,14 +268,14 @@ impl<S: ConnectionState> Client<S> {
         let mut buf = BytesMut::with_capacity(256);
 
         // Encode metadata
-        encoder.encode_metadata(&mut buf);
+        encoder.encode_metadata_with_collation(&mut buf, collation);
 
         // Encode each row
         for row in &tvp_data.rows {
             encoder.encode_row(&mut buf, |row_buf| {
                 for (col_idx, value) in row.iter().enumerate() {
                     let wire_type = &wire_columns[col_idx].wire_type;
-                    Self::encode_tvp_value(value, wire_type, row_buf);
+                    Self::encode_tvp_value(value, wire_type, collation, row_buf);
                 }
             });
         }
@@ -348,6 +355,7 @@ impl<S: ConnectionState> Client<S> {
     fn encode_tvp_value(
         value: &mssql_types::SqlValue,
         wire_type: &TvpWireType,
+        collation: Option<&tds_protocol::token::Collation>,
         buf: &mut BytesMut,
     ) {
         use mssql_types::SqlValue;
@@ -382,7 +390,7 @@ impl<S: ConnectionState> Client<S> {
                     encode_tvp_nvarchar(s, *max_length, buf);
                 }
                 TvpWireType::VarChar { max_length } => {
-                    encode_tvp_varchar(s, *max_length, buf);
+                    encode_tvp_varchar_with_collation(s, *max_length, collation, buf);
                 }
                 _ => {
                     encode_tvp_nvarchar(s, 4000, buf);

--- a/crates/mssql-client/src/client/response.rs
+++ b/crates/mssql-client/src/client/response.rs
@@ -11,6 +11,33 @@ use crate::state::ConnectionState;
 use super::{Client, ConnectionHandle};
 
 impl<S: ConnectionState> Client<S> {
+    /// Read the next response message from the connection.
+    ///
+    /// Translates the codec's cancellation signal: when the in-flight request
+    /// was cancelled via [`crate::CancelHandle`], the codec drains through the
+    /// server's DONE_ATTN acknowledgement and reports
+    /// `CodecError::Cancelled` — the connection is clean again, so
+    /// `in_flight` is cleared and the caller gets [`Error::Cancelled`].
+    pub(crate) async fn read_response_message(&mut self) -> Result<mssql_codec::Message> {
+        let connection = self.connection.as_mut().ok_or(Error::ConnectionClosed)?;
+        let result = match connection {
+            #[cfg(feature = "tls")]
+            ConnectionHandle::Tls(conn) => conn.read_message().await,
+            #[cfg(feature = "tls")]
+            ConnectionHandle::TlsPrelogin(conn) => conn.read_message().await,
+            ConnectionHandle::Plain(conn) => conn.read_message().await,
+        };
+        match result {
+            Ok(Some(message)) => Ok(message),
+            Ok(None) => Err(Error::ConnectionClosed),
+            Err(mssql_codec::CodecError::Cancelled) => {
+                self.in_flight = false;
+                Err(Error::Cancelled)
+            }
+            Err(e) => Err(e.into()),
+        }
+    }
+
     /// Create a TokenParser with encryption awareness when configured.
     pub(super) fn create_parser(&self, payload: bytes::Bytes) -> TokenParser {
         let parser = TokenParser::new(payload);
@@ -100,16 +127,7 @@ impl<S: ConnectionState> Client<S> {
     /// the "payload + `Vec<Row>` simultaneously in memory" doubling that the
     /// prior eager path had.
     pub(super) async fn read_query_response(&mut self) -> Result<RawQueryResponse> {
-        let connection = self.connection.as_mut().ok_or(Error::ConnectionClosed)?;
-
-        let message = match connection {
-            #[cfg(feature = "tls")]
-            ConnectionHandle::Tls(conn) => conn.read_message().await?,
-            #[cfg(feature = "tls")]
-            ConnectionHandle::TlsPrelogin(conn) => conn.read_message().await?,
-            ConnectionHandle::Plain(conn) => conn.read_message().await?,
-        }
-        .ok_or(Error::ConnectionClosed)?;
+        let message = self.read_response_message().await?;
 
         // Full response received from wire — connection is clean for next request
         self.in_flight = false;
@@ -245,18 +263,9 @@ impl<S: ConnectionState> Client<S> {
 
     /// Read execute result (row count) from the response.
     pub(super) async fn read_execute_result(&mut self) -> Result<u64> {
-        let connection = self.connection.as_mut().ok_or(Error::ConnectionClosed)?;
-
-        let message = match connection {
-            #[cfg(feature = "tls")]
-            ConnectionHandle::Tls(conn) => conn.read_message().await?,
-            #[cfg(feature = "tls")]
-            ConnectionHandle::TlsPrelogin(conn) => conn.read_message().await?,
-            // Note: execute() doesn't read row values, so no decryption needed.
-            // But we still need the encryption-aware parser for ColMetaData/Row token parsing.
-            ConnectionHandle::Plain(conn) => conn.read_message().await?,
-        }
-        .ok_or(Error::ConnectionClosed)?;
+        // Note: execute() doesn't read row values, so no decryption needed.
+        // But we still need the encryption-aware parser for ColMetaData/Row token parsing.
+        let message = self.read_response_message().await?;
 
         // Full response received from wire — connection is clean for next request
         self.in_flight = false;
@@ -353,16 +362,7 @@ impl<S: ConnectionState> Client<S> {
     /// the transaction descriptor (8-byte value) that must be included in subsequent
     /// ALL_HEADERS sections for requests within this transaction.
     pub(super) async fn read_transaction_begin_result(&mut self) -> Result<u64> {
-        let connection = self.connection.as_mut().ok_or(Error::ConnectionClosed)?;
-
-        let message = match connection {
-            #[cfg(feature = "tls")]
-            ConnectionHandle::Tls(conn) => conn.read_message().await?,
-            #[cfg(feature = "tls")]
-            ConnectionHandle::TlsPrelogin(conn) => conn.read_message().await?,
-            ConnectionHandle::Plain(conn) => conn.read_message().await?,
-        }
-        .ok_or(Error::ConnectionClosed)?;
+        let message = self.read_response_message().await?;
 
         // Full response received from wire — connection is clean for next request
         self.in_flight = false;
@@ -450,16 +450,7 @@ impl<S: ConnectionState> Client<S> {
     /// - `DoneProc`: final token, break when `!more`
     /// - `Error` / `Info` / `EnvChange`: standard handling
     pub(crate) async fn read_procedure_result(&mut self) -> Result<crate::stream::ProcedureResult> {
-        let connection = self.connection.as_mut().ok_or(Error::ConnectionClosed)?;
-
-        let message = match connection {
-            #[cfg(feature = "tls")]
-            ConnectionHandle::Tls(conn) => conn.read_message().await?,
-            #[cfg(feature = "tls")]
-            ConnectionHandle::TlsPrelogin(conn) => conn.read_message().await?,
-            ConnectionHandle::Plain(conn) => conn.read_message().await?,
-        }
-        .ok_or(Error::ConnectionClosed)?;
+        let message = self.read_response_message().await?;
 
         // Full response received from wire — connection is clean for next request
         self.in_flight = false;
@@ -678,16 +669,7 @@ impl Client<Ready> {
     pub(super) async fn read_multi_result_response(
         &mut self,
     ) -> Result<Vec<crate::stream::ResultSet>> {
-        let connection = self.connection.as_mut().ok_or(Error::ConnectionClosed)?;
-
-        let message = match connection {
-            #[cfg(feature = "tls")]
-            ConnectionHandle::Tls(conn) => conn.read_message().await?,
-            #[cfg(feature = "tls")]
-            ConnectionHandle::TlsPrelogin(conn) => conn.read_message().await?,
-            ConnectionHandle::Plain(conn) => conn.read_message().await?,
-        }
-        .ok_or(Error::ConnectionClosed)?;
+        let message = self.read_response_message().await?;
 
         // Full response received from wire — connection is clean for next request
         self.in_flight = false;

--- a/crates/mssql-client/src/instrumentation.rs
+++ b/crates/mssql-client/src/instrumentation.rs
@@ -243,7 +243,7 @@ pub fn extract_operation(sql: &str) -> &'static str {
 
 /// Instrumentation context for database operations.
 #[cfg(feature = "otel")]
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct InstrumentationContext {
     /// Server address.
     pub server_address: String,
@@ -253,6 +253,21 @@ pub struct InstrumentationContext {
     pub database: Option<String>,
     /// Sanitization configuration.
     pub sanitization: SanitizationConfig,
+    /// Operation-level metrics (duration histogram, operation/error counters)
+    /// bound to this connection's server attributes.
+    metrics: std::sync::Arc<DatabaseMetrics>,
+}
+
+#[cfg(feature = "otel")]
+impl std::fmt::Debug for InstrumentationContext {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("InstrumentationContext")
+            .field("server_address", &self.server_address)
+            .field("server_port", &self.server_port)
+            .field("database", &self.database)
+            .field("sanitization", &self.sanitization)
+            .finish_non_exhaustive()
+    }
 }
 
 #[cfg(feature = "otel")]
@@ -260,12 +275,20 @@ impl InstrumentationContext {
     /// Create a new instrumentation context.
     #[must_use]
     pub fn new(server_address: String, server_port: u16) -> Self {
+        let metrics = std::sync::Arc::new(DatabaseMetrics::new(None, &server_address, server_port));
         Self {
             server_address,
             server_port,
             database: None,
             sanitization: SanitizationConfig::default(),
+            metrics,
         }
+    }
+
+    /// Operation-level metrics for this connection.
+    #[must_use]
+    pub fn metrics(&self) -> &DatabaseMetrics {
+        &self.metrics
     }
 
     /// Set the database name.

--- a/crates/mssql-client/tests/bulk_insert.rs
+++ b/crates/mssql-client/tests/bulk_insert.rs
@@ -654,6 +654,104 @@ async fn test_bulk_insert_varbinary_max() {
     client.close().await.expect("Failed to close");
 }
 
+/// Falsification test for the "full BCP" claim at realistic LOB sizes: the
+/// existing PLP tests top out at 10 KB, which never leaves a single packet.
+/// 16 MiB VARBINARY(MAX) + ~8 MB NVARCHAR(MAX) in one batch forces the PLP
+/// chunk and the codec packet-chunking paths through thousands of packets.
+#[tokio::test]
+#[ignore = "Requires SQL Server"]
+async fn test_bulk_insert_large_plp_round_trip() {
+    let config = get_test_config().expect("SQL Server config required");
+    let mut client = Client::connect(config).await.expect("Failed to connect");
+
+    client
+        .execute(
+            "CREATE TABLE #BulkLargePlp (id INT NOT NULL, blob VARBINARY(MAX) NULL, doc NVARCHAR(MAX) NULL)",
+            &[],
+        )
+        .await
+        .expect("Failed to create table");
+
+    let builder = BulkInsertBuilder::new("#BulkLargePlp").with_typed_columns(vec![
+        BulkColumn::new("id", "INT", 0).unwrap(),
+        BulkColumn::new("blob", "VARBINARY(MAX)", 1)
+            .unwrap()
+            .with_nullable(true),
+        BulkColumn::new("doc", "NVARCHAR(MAX)", 2)
+            .unwrap()
+            .with_nullable(true),
+    ]);
+
+    // Position-dependent pattern so truncation, reordering, or off-by-one
+    // chunking shows up as inequality, not just a length mismatch.
+    let blob: Vec<u8> = (0..16 * 1024 * 1024u32)
+        .map(|i| (i.wrapping_mul(31).wrapping_add(i >> 8)) as u8)
+        .collect();
+    let mut doc = String::with_capacity(4 * 1024 * 1024 + 8);
+    doc.push_str("é₿");
+    for i in 0..262_144u32 {
+        // 16 chars per block, hex-stamped with the block index every block.
+        doc.push_str(&format!("{i:08x}-block-\u{00e9}"));
+    }
+    doc.push_str("₿é");
+
+    let mut writer = client
+        .bulk_insert(&builder)
+        .await
+        .expect("Failed to start bulk insert");
+    writer
+        .send_row_values(&[
+            SqlValue::Int(1),
+            SqlValue::Binary(blob.clone().into()),
+            SqlValue::String(doc.clone()),
+        ])
+        .expect("send large row");
+    writer
+        .send_row_values(&[SqlValue::Int(2), SqlValue::Null, SqlValue::Null])
+        .expect("send null row");
+
+    let result = writer.finish().await.expect("Failed to finish bulk insert");
+    assert_eq!(result.rows_affected, 2);
+
+    let rows = client
+        .query(
+            "SELECT id, DATALENGTH(blob), DATALENGTH(doc), blob, doc FROM #BulkLargePlp ORDER BY id",
+            &[],
+        )
+        .await
+        .expect("Query failed");
+
+    type LargePlpRow = (
+        i32,
+        Option<i64>,
+        Option<i64>,
+        Option<Vec<u8>>,
+        Option<String>,
+    );
+    let data: Vec<LargePlpRow> = rows
+        .filter_map(|r| r.ok())
+        .map(|row| {
+            (
+                row.get(0).unwrap(),
+                row.get(1).unwrap(),
+                row.get(2).unwrap(),
+                row.get(3).unwrap(),
+                row.get(4).unwrap(),
+            )
+        })
+        .collect();
+
+    assert_eq!(data.len(), 2);
+    assert_eq!(data[0].1, Some(16 * 1024 * 1024));
+    assert_eq!(data[0].2, Some(2 * (doc.chars().count() as i64)));
+    assert_eq!(data[0].3.as_deref(), Some(blob.as_slice()));
+    assert_eq!(data[0].4.as_deref(), Some(doc.as_str()));
+    assert_eq!(data[1].3, None);
+    assert_eq!(data[1].4, None);
+
+    client.close().await.expect("Failed to close");
+}
+
 // =============================================================================
 // Bulk Options
 // =============================================================================

--- a/crates/mssql-client/tests/change_tracking_live.rs
+++ b/crates/mssql-client/tests/change_tracking_live.rs
@@ -1,0 +1,195 @@
+//! Live end-to-end test for the Change Tracking helpers.
+//!
+//! The `change_tracking` module ships SQL builders (`ChangeTrackingQuery`,
+//! `ChangeTracking`) that were previously validated only as strings. This
+//! exercises the generated SQL against a real CT-enabled database: enable
+//! CT, perform DML, and read the changes back through the builder output —
+//! proving the generated CHANGETABLE queries, the FORCESEEK variant, the
+//! enable/disable DDL, and the version helpers all execute and report the
+//! right operations.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+use mssql_client::change_tracking::{
+    ChangeOperation, ChangeTracking, ChangeTrackingQuery, SyncVersionStatus,
+};
+use mssql_client::{Client, Config, Error};
+
+fn get_test_config(database: &str) -> Option<Config> {
+    let host = std::env::var("MSSQL_HOST").ok()?;
+    let port = std::env::var("MSSQL_PORT")
+        .ok()
+        .and_then(|p| p.parse::<u16>().ok())
+        .unwrap_or(1433);
+    let user = std::env::var("MSSQL_USER").unwrap_or_else(|_| "sa".into());
+    let password = std::env::var("MSSQL_PASSWORD").unwrap_or_else(|_| "MyStrongPassw0rd".into());
+    let encrypt = std::env::var("MSSQL_ENCRYPT").unwrap_or_else(|_| "false".into());
+
+    let conn_str = format!(
+        "Server={host},{port};Database={database};User Id={user};Password={password};\
+         TrustServerCertificate=true;Encrypt={encrypt}"
+    );
+    Config::from_connection_string(&conn_str).ok()
+}
+
+async fn scalar_i64(client: &mut Client<mssql_client::Ready>, sql: &str) -> i64 {
+    let rows = client.query(sql, &[]).await.expect("scalar query");
+    rows.into_iter()
+        .next()
+        .expect("scalar row")
+        .expect("scalar row ok")
+        .get(0)
+        .expect("scalar value")
+}
+
+#[tokio::test]
+#[ignore = "Requires SQL Server"]
+async fn test_change_tracking_end_to_end() -> Result<(), Error> {
+    let db_name = format!(
+        "mssql_driver_test_ct_{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0)
+    );
+
+    let setup_config = get_test_config("master").expect("SQL Server config required");
+
+    {
+        let mut setup = Client::connect(setup_config.clone()).await?;
+        setup
+            .execute(&format!("CREATE DATABASE {db_name}"), &[])
+            .await?;
+        // Builder-generated DDL: enable CT on the database.
+        setup
+            .execute(&ChangeTracking::enable_database_sql(&db_name, 2, true), &[])
+            .await?;
+        setup.close().await?;
+    }
+
+    let run = async {
+        let mut client = Client::connect(get_test_config(&db_name).expect("config")).await?;
+
+        client
+            .execute(
+                "CREATE TABLE dbo.Items (id INT NOT NULL PRIMARY KEY, name NVARCHAR(50) NOT NULL)",
+                &[],
+            )
+            .await?;
+        // Builder-generated DDL: enable CT on the table.
+        client
+            .execute(&ChangeTracking::enable_table_sql("dbo.Items", true), &[])
+            .await?;
+
+        // Seed two rows, then capture the sync baseline.
+        client
+            .execute(
+                "INSERT INTO dbo.Items (id, name) VALUES (1, N'one'), (2, N'two')",
+                &[],
+            )
+            .await?;
+        let baseline = scalar_i64(&mut client, ChangeTracking::current_version_sql()).await;
+
+        // Tracked window: one update, one delete.
+        client
+            .execute("UPDATE dbo.Items SET name = N'uno' WHERE id = 1", &[])
+            .await?;
+        client
+            .execute("DELETE FROM dbo.Items WHERE id = 2", &[])
+            .await?;
+
+        // The baseline must still be valid for synchronization.
+        let min_valid = scalar_i64(
+            &mut client,
+            &ChangeTracking::min_valid_version_sql("dbo.Items"),
+        )
+        .await;
+        assert_eq!(
+            SyncVersionStatus::check(baseline, Some(min_valid)),
+            SyncVersionStatus::Valid,
+            "fresh baseline must be a valid sync version"
+        );
+
+        // Builder-generated CHANGETABLE query. Column order per the builder:
+        // SYS_CHANGE_VERSION, SYS_CHANGE_CREATION_VERSION,
+        // SYS_CHANGE_OPERATION, SYS_CHANGE_COLUMNS, SYS_CHANGE_CONTEXT,
+        // then the primary keys.
+        let sql = ChangeTrackingQuery::changes("dbo.Items", baseline)
+            .with_primary_keys(&["id"])
+            .to_sql();
+        let rows = client.query(&sql, &[]).await?;
+        let mut changes: Vec<(ChangeOperation, i32)> = Vec::new();
+        for row in rows {
+            let row = row?;
+            let op: String = row.get(2)?;
+            let id: i32 = row.get(5)?;
+            changes.push((
+                ChangeOperation::from_sql(&op).expect("known operation code"),
+                id,
+            ));
+        }
+        changes.sort_by_key(|(_, id)| *id);
+        assert_eq!(
+            changes,
+            vec![(ChangeOperation::Update, 1), (ChangeOperation::Delete, 2)],
+            "the tracked window contains exactly one update and one delete"
+        );
+
+        // The data-join variant (with FORCESEEK) must also execute and join
+        // live column values for surviving rows.
+        let sql = ChangeTrackingQuery::changes("dbo.Items", baseline)
+            .with_primary_keys(&["id"])
+            .with_force_seek()
+            .to_sql_with_data(&["name"]);
+        let rows = client.query(&sql, &[]).await?;
+        let mut joined: Vec<(String, i32, Option<String>)> = Vec::new();
+        for row in rows {
+            let row = row?;
+            // ct columns (5), then CT.id (pk), then T.name (per to_sql_with_data).
+            let op: String = row.get(2)?;
+            let id: i32 = row.get(5)?;
+            let name: Option<String> = row.get(6)?;
+            joined.push((op, id, name));
+        }
+        joined.sort_by_key(|(_, id, _)| *id);
+        assert_eq!(joined.len(), 2);
+        assert_eq!(joined[0].0, "U");
+        assert_eq!(
+            joined[0].2.as_deref(),
+            Some("uno"),
+            "updated row must join its live column value"
+        );
+        assert_eq!(joined[1].0, "D");
+        assert_eq!(
+            joined[1].2, None,
+            "deleted row has no live column value to join"
+        );
+
+        // Builder-generated disable DDL must execute cleanly.
+        client
+            .execute(&ChangeTracking::disable_table_sql("dbo.Items"), &[])
+            .await?;
+
+        client.close().await?;
+        Ok::<_, Error>(())
+    }
+    .await;
+
+    {
+        let mut cleanup = Client::connect(setup_config).await?;
+        let _ = cleanup
+            .execute(
+                &format!(
+                    "IF DB_ID('{db_name}') IS NOT NULL BEGIN \
+                        ALTER DATABASE {db_name} SET SINGLE_USER WITH ROLLBACK IMMEDIATE; \
+                        DROP DATABASE {db_name}; \
+                     END"
+                ),
+                &[],
+            )
+            .await;
+        cleanup.close().await?;
+    }
+
+    run
+}

--- a/crates/mssql-client/tests/collation_test.rs
+++ b/crates/mssql-client/tests/collation_test.rs
@@ -216,6 +216,179 @@ async fn test_nvarchar_unicode() -> Result<(), Error> {
 /// Verify VARCHAR RPC param round-trip when the server's default collation
 /// is NOT the hardcoded Latin1_General_CI_AS fallback.
 ///
+/// Capability audit: TVP string cells on a non-Latin1 server.
+///
+/// Two scenarios against a Chinese_PRC_CI_AS (GB18030 / CP936) database:
+///
+/// 1. **NVARCHAR-declared TVP column** (what `#[derive(Tvp)]` always produces
+///    for `String` fields) feeding a `VARCHAR` table column: the server
+///    converts NVARCHAR → VARCHAR using the column's collation, so CJK data
+///    must round-trip verbatim.
+/// 2. **VARCHAR-declared TVP column** (reachable only via a hand-written
+///    `Tvp` impl or raw `TvpData`): the encoder transcodes cells with the
+///    declared collation. CJK data must round-trip — if it comes back as
+///    `????`, TVP VARCHAR cells are stuck on the hardcoded Windows-1252
+///    fallback (the same defect class fixed for plain VARCHAR params in
+///    v0.10) and corrupt silently.
+#[tokio::test]
+#[ignore = "Requires SQL Server"]
+async fn test_tvp_varchar_collation_round_trip() -> Result<(), Error> {
+    use mssql_client::{Tvp, TvpColumn, TvpRow, TvpValue};
+    use mssql_types::SqlValue;
+
+    let host = std::env::var("MSSQL_HOST").unwrap_or_else(|_| "localhost".into());
+    let user = std::env::var("MSSQL_USER").unwrap_or_else(|_| "sa".into());
+    let password = std::env::var("MSSQL_PASSWORD").unwrap_or_else(|_| "YourStrong@Passw0rd".into());
+
+    let db_name = format!(
+        "mssql_driver_test_tvp_cn_{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0)
+    );
+
+    let setup_conn = format!(
+        "Server={host};Database=master;User Id={user};Password={password};\
+         TrustServerCertificate=true;Encrypt=true"
+    );
+    let setup_config = Config::from_connection_string(&setup_conn)?;
+
+    {
+        let mut setup = Client::connect(setup_config.clone()).await?;
+        setup
+            .execute(
+                &format!("CREATE DATABASE {db_name} COLLATE Chinese_PRC_CI_AS"),
+                &[],
+            )
+            .await?;
+        setup.close().await?;
+    }
+
+    let run = async {
+        let conn = format!(
+            "Server={host};Database={db_name};User Id={user};Password={password};\
+             TrustServerCertificate=true;Encrypt=true"
+        );
+        let mut client = Client::connect(Config::from_connection_string(&conn)?).await?;
+
+        client
+            .execute("CREATE TYPE dbo.NvcList AS TABLE (txt NVARCHAR(100))", &[])
+            .await?;
+        client
+            .execute("CREATE TYPE dbo.VcList AS TABLE (txt VARCHAR(100))", &[])
+            .await?;
+        client
+            .execute(
+                "CREATE TABLE dbo.tvp_vc_target (id INT IDENTITY, txt VARCHAR(100))",
+                &[],
+            )
+            .await?;
+
+        let chinese = "你好世界";
+
+        // Scenario 1: derive-shaped NVARCHAR TVP column into a VARCHAR table
+        // column. Server-side conversion uses the column collation.
+        #[derive(Debug)]
+        struct NvcRow {
+            txt: String,
+        }
+        impl Tvp for NvcRow {
+            fn type_name() -> &'static str {
+                "dbo.NvcList"
+            }
+            fn columns() -> Vec<TvpColumn> {
+                vec![TvpColumn::new("txt", "NVARCHAR(100)", 0)]
+            }
+            fn to_row(&self) -> Result<TvpRow, mssql_types::TypeError> {
+                Ok(TvpRow::new(vec![SqlValue::String(self.txt.clone())]))
+            }
+        }
+
+        let nvc = vec![NvcRow {
+            txt: chinese.into(),
+        }];
+        client
+            .execute(
+                "INSERT INTO dbo.tvp_vc_target (txt) SELECT txt FROM @p1",
+                &[&TvpValue::new(&nvc)?],
+            )
+            .await?;
+
+        let rows = client
+            .query(
+                "SELECT txt, DATALENGTH(txt) FROM dbo.tvp_vc_target WHERE id = 1",
+                &[],
+            )
+            .await?;
+        let row = rows.into_iter().next().expect("row from NVARCHAR TVP")?;
+        let txt: String = row.get(0)?;
+        let len: i32 = row.get(1)?;
+        assert_eq!(
+            txt, chinese,
+            "NVARCHAR-declared TVP cell into VARCHAR column must round-trip via \
+             server-side conversion"
+        );
+        assert_eq!(len, 8, "GB18030 stores these four code points as 8 bytes");
+
+        // Scenario 2: VARCHAR-declared TVP column, read straight back out of
+        // the TVP. The cell bytes and the declared collation both come from
+        // the client encoder.
+        #[derive(Debug)]
+        struct VcRow {
+            txt: String,
+        }
+        impl Tvp for VcRow {
+            fn type_name() -> &'static str {
+                "dbo.VcList"
+            }
+            fn columns() -> Vec<TvpColumn> {
+                vec![TvpColumn::new("txt", "VARCHAR(100)", 0)]
+            }
+            fn to_row(&self) -> Result<TvpRow, mssql_types::TypeError> {
+                Ok(TvpRow::new(vec![SqlValue::String(self.txt.clone())]))
+            }
+        }
+
+        let vc = vec![VcRow {
+            txt: chinese.into(),
+        }];
+        let rows = client
+            .query("SELECT txt FROM @p1", &[&TvpValue::new(&vc)?])
+            .await?;
+        let row = rows.into_iter().next().expect("row from VARCHAR TVP")?;
+        let txt: String = row.get(0)?;
+        assert_eq!(
+            txt, chinese,
+            "VARCHAR-declared TVP cell must round-trip on a GB18030 server; \
+             \"????\" means TVP VARCHAR encoding ignores the server collation \
+             (hardcoded Windows-1252) and corrupts silently"
+        );
+
+        client.close().await?;
+        Ok::<_, Error>(())
+    }
+    .await;
+
+    {
+        let mut cleanup = Client::connect(setup_config).await?;
+        let _ = cleanup
+            .execute(
+                &format!(
+                    "IF DB_ID('{db_name}') IS NOT NULL BEGIN \
+                        ALTER DATABASE {db_name} SET SINGLE_USER WITH ROLLBACK IMMEDIATE; \
+                        DROP DATABASE {db_name}; \
+                     END"
+                ),
+                &[],
+            )
+            .await;
+        cleanup.close().await?;
+    }
+
+    run
+}
+
 /// Regression pin for item 3.9: when `SendStringParametersAsUnicode=false` is
 /// active, the driver must encode VARCHAR parameters via the collation captured
 /// from the SqlCollation ENVCHANGE during login, not the hardcoded

--- a/crates/mssql-client/tests/resilience.rs
+++ b/crates/mssql-client/tests/resilience.rs
@@ -466,6 +466,127 @@ async fn test_query_cancelled_by_timeout() {
     // Depending on driver implementation, it may or may not be reusable
 }
 
+/// Capability audit: explicit cancellation must actually kill the query
+/// **server-side**, not just abandon the client-side future.
+///
+/// The claims under test (cancel.rs rustdoc): `CancelHandle::cancel()` sends
+/// Attention, the current query returns an error, the response is drained
+/// (DONE_ATTN), and the same connection remains usable. This proves all four
+/// plus the part no other test covers: the request disappears from
+/// `sys.dm_exec_requests`, observed from a second connection.
+#[tokio::test]
+#[ignore = "Requires SQL Server"]
+async fn test_explicit_cancel_terminates_query_server_side() {
+    let config = get_test_config().expect("SQL Server config required");
+    let mut client = Client::connect(config.clone()).await.expect("connect A");
+    let mut observer = Client::connect(config).await.expect("connect B");
+
+    // Identify connection A's session so the observer can watch its request.
+    let rows = client
+        .query("SELECT CAST(@@SPID AS INT)", &[])
+        .await
+        .expect("spid query");
+    let spid: i32 = rows
+        .into_iter()
+        .next()
+        .expect("spid row")
+        .expect("spid row ok")
+        .get(0)
+        .expect("spid value");
+
+    let canceller = client.cancel_handle();
+
+    // While A is stuck in WAITFOR: positive control (the request must be
+    // visible server-side), then cancel.
+    let watcher = tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(800)).await;
+        let rows = observer
+            .query(
+                "SELECT COUNT(*) FROM sys.dm_exec_requests \
+                 WHERE session_id = @p1 AND command = 'WAITFOR'",
+                &[&spid],
+            )
+            .await
+            .expect("observer query");
+        let running: i32 = rows
+            .into_iter()
+            .next()
+            .expect("count row")
+            .expect("count row ok")
+            .get(0)
+            .expect("count value");
+
+        canceller.cancel().await.expect("cancel send");
+        (observer, running)
+    });
+
+    let started = std::time::Instant::now();
+    let result = client.query("WAITFOR DELAY '00:00:30'", &[]).await;
+    let elapsed = started.elapsed();
+
+    let err = result.err().expect("cancelled query must return an error");
+    assert!(
+        matches!(err, mssql_client::Error::Cancelled),
+        "cancelled query must return Error::Cancelled, got {err:?}"
+    );
+    assert!(
+        elapsed < Duration::from_secs(10),
+        "cancel must interrupt the 30s WAITFOR promptly; took {elapsed:?}"
+    );
+
+    let (mut observer, running_before) = watcher.await.expect("watcher task");
+    assert_eq!(
+        running_before, 1,
+        "positive control: the WAITFOR request must be visible in \
+         sys.dm_exec_requests before cancellation"
+    );
+
+    // Server side: the request must be gone shortly after the cancel.
+    let mut still_running = i32::MAX;
+    for _ in 0..30 {
+        let rows = observer
+            .query(
+                "SELECT COUNT(*) FROM sys.dm_exec_requests \
+                 WHERE session_id = @p1 AND command = 'WAITFOR'",
+                &[&spid],
+            )
+            .await
+            .expect("observer recheck");
+        still_running = rows
+            .into_iter()
+            .next()
+            .expect("recheck row")
+            .expect("recheck row ok")
+            .get(0)
+            .expect("recheck value");
+        if still_running == 0 {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    assert_eq!(
+        still_running, 0,
+        "the WAITFOR request must terminate server-side after Attention"
+    );
+
+    // Same connection must be clean and reusable (DONE_ATTN drained).
+    let rows = client
+        .query("SELECT 42", &[])
+        .await
+        .expect("query on the same connection after cancel must succeed");
+    let value: i32 = rows
+        .into_iter()
+        .next()
+        .expect("reuse row")
+        .expect("reuse row ok")
+        .get(0)
+        .expect("reuse value");
+    assert_eq!(value, 42);
+
+    observer.close().await.expect("close observer");
+    client.close().await.expect("close client");
+}
+
 // =============================================================================
 // Error Boundary Tests
 // =============================================================================

--- a/crates/mssql-codec/src/connection.rs
+++ b/crates/mssql-codec/src/connection.rs
@@ -138,7 +138,7 @@ where
                         // stays latched and a later drain eats the *next*
                         // request's response.
                         if self.is_cancelling() {
-                            if Self::payload_has_attention_done(&message.payload) {
+                            if Self::payload_ends_with_attention_done(&message.payload) {
                                 tracing::debug!(
                                     "received DONE with ATTENTION, cancellation complete"
                                 );
@@ -246,7 +246,7 @@ where
         writer.flush().await
     }
 
-    /// Drain packets after cancellation until DONE with ATTENTION is received.
+    /// Drain messages after cancellation until DONE with ATTENTION is received.
     ///
     /// Returns [`CodecError::Cancelled`] once the acknowledgement is consumed;
     /// the connection is then clean for the next request.
@@ -259,15 +259,18 @@ where
         loop {
             match self.reader.next().await {
                 Some(Ok(packet)) => {
-                    // Check for DONE token with ATTENTION flag
-                    // The DONE token is at the start of the payload
-                    if packet.header.packet_type == PacketType::TabularResult
-                        && !packet.payload.is_empty()
-                        && self.check_attention_done(&packet)
-                    {
-                        tracing::debug!("received DONE with ATTENTION, cancellation complete");
-                        self.finish_cancel();
-                        return Err(CodecError::Cancelled);
+                    // Assemble complete messages so the acknowledgement check
+                    // runs on the message trailer — a per-packet check would
+                    // miss a DONE token straddling a packet boundary.
+                    if let Some(message) = self.assembler.push(packet) {
+                        if message.packet_type == PacketType::TabularResult
+                            && Self::payload_ends_with_attention_done(&message.payload)
+                        {
+                            tracing::debug!("received DONE with ATTENTION, cancellation complete");
+                            self.finish_cancel();
+                            return Err(CodecError::Cancelled);
+                        }
+                        tracing::debug!("discarding message from cancelled request");
                     }
                     // Continue draining
                 }
@@ -294,32 +297,25 @@ where
         self.cancel_notify.notify_waiters();
     }
 
-    /// Check if a packet contains a DONE token with ATTENTION flag.
-    fn check_attention_done(&self, packet: &Packet) -> bool {
-        Self::payload_has_attention_done(&packet.payload)
-    }
-
-    /// Scan a message payload for a DONE token (0xFD) with the ATTN status
-    /// flag (0x0020).
+    /// Check whether a message payload terminates in a DONE token carrying
+    /// the ATTN status flag (the attention acknowledgement).
     ///
-    /// DONE token format: token_type(1) + status(2) + cur_cmd(2) + row_count(8).
-    /// This is a byte scan, not a token parse, so it can in principle
-    /// false-positive on 0xFD bytes inside row data — acceptable here because
-    /// it is only consulted for messages that arrive while a cancellation is
-    /// pending, where the stream carries DONE tokens rather than rows.
-    fn payload_has_attention_done(payload: &[u8]) -> bool {
-        for i in 0..payload.len() {
-            if payload[i] == 0xFD && i + 3 <= payload.len() {
-                // Found DONE token, check status
-                let status = u16::from_le_bytes([payload[i + 1], payload[i + 2]]);
-                // DONE_ATTN = 0x0020
-                if status & 0x0020 != 0 {
-                    return true;
-                }
-            }
-        }
-
-        false
+    /// Every tabular response message ends with a fixed 13-byte DONE-family
+    /// token (token(1) + status(2) + cur_cmd(2) + row_count(8)), and per
+    /// MS-TDS 2.2.7.6 the acknowledgement is a DONE (0xFD) with DONE_ATTN as
+    /// the final token of the cancelled stream. Anchoring the check to the
+    /// trailer means row bytes that happen to contain `0xFD, 0x20` (entirely
+    /// possible in binary/integer cell data arriving during the cancel
+    /// window) cannot be mistaken for the acknowledgement — an interior byte
+    /// scan was proven to clear the cancel flag early and leak the real
+    /// acknowledgement into the next request.
+    fn payload_ends_with_attention_done(payload: &[u8]) -> bool {
+        let Some(start) = payload.len().checked_sub(13) else {
+            return false;
+        };
+        // DONE token type = 0xFD; DONE_ATTN = 0x0020 in the LE status word.
+        payload[start] == 0xFD
+            && u16::from_le_bytes([payload[start + 1], payload[start + 2]]) & 0x0020 != 0
     }
 
     /// Get a reference to the read codec.
@@ -476,14 +472,24 @@ mod tests {
         let packet_no_attn = Packet::new(header, payload_no_attn);
 
         assert!(
-            Connection::<tokio::io::DuplexStream>::payload_has_attention_done(
+            Connection::<tokio::io::DuplexStream>::payload_ends_with_attention_done(
                 &packet_with_attn.payload
             )
         );
         assert!(
-            !Connection::<tokio::io::DuplexStream>::payload_has_attention_done(
+            !Connection::<tokio::io::DuplexStream>::payload_ends_with_attention_done(
                 &packet_no_attn.payload
             )
+        );
+
+        // Interior 0xFD,0x20 bytes (e.g. row data) must not register: only
+        // the trailing token position counts.
+        let mut interior = vec![0xD1, 0x08, 0xFD, 0x20, 0xAA, 0xBB];
+        interior.extend_from_slice(&[
+            0xFD, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        ]);
+        assert!(
+            !Connection::<tokio::io::DuplexStream>::payload_ends_with_attention_done(&interior)
         );
     }
 
@@ -601,6 +607,74 @@ mod tests {
         assert_eq!(
             u16::from_le_bytes([message.payload[1], message.payload[2]]),
             0x0010
+        );
+    }
+
+    /// PR #143 review, Blocker 1: row bytes that happen to contain
+    /// `0xFD, 0x20` must NOT be mistaken for the DONE_ATTN acknowledgement.
+    ///
+    /// During the cancel window the cancelled request's *data* (rows already
+    /// in flight) can arrive before the real acknowledgement. A byte-scan
+    /// for any interior 0xFD with bit 5 set false-positives on such data,
+    /// clears the cancel flag early, and the genuine ack then poisons the
+    /// next request — the exact failure the cancellation fix claims to
+    /// eliminate.
+    #[tokio::test]
+    async fn test_cancel_race_row_bytes_do_not_fake_the_attention_ack() {
+        use std::task::{Context, Poll};
+        use tokio::io::AsyncWriteExt;
+
+        let (client_io, mut server_io) = tokio::io::duplex(4096);
+        let mut conn = Connection::new(client_io);
+        let cancel = conn.cancel_handle();
+
+        // Park a read, then cancel while it waits (the realistic ordering).
+        let mut read_fut = Box::pin(conn.read_message());
+        let waker = std::task::Waker::noop();
+        let mut cx = Context::from_waker(waker);
+        assert!(matches!(read_fut.as_mut().poll(&mut cx), Poll::Pending));
+        cancel.cancel().await.expect("send attention");
+
+        // Message 1: the cancelled request's data — row-ish bytes whose
+        // *interior* contains 0xFD followed by a byte with bit 5 set (e.g. a
+        // BIGINT cell value), terminated by a DONE with MORE and no ATTN.
+        let mut row_data = vec![0xD1, 0x08]; // ROW token, length-ish prefix
+        row_data.extend_from_slice(&[0xFD, 0x20, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF]);
+        row_data.extend_from_slice(&done_token(0x0001)); // DONE_MORE, no ATTN
+        server_io.write_all(&raw_message(&row_data)).await.unwrap();
+
+        // Message 2: the genuine acknowledgement.
+        server_io
+            .write_all(&raw_message(&done_token(0x0020)))
+            .await
+            .unwrap();
+
+        // Message 3: the next request's response.
+        server_io
+            .write_all(&raw_message(&done_token(0x0010)))
+            .await
+            .unwrap();
+
+        let result = read_fut.await;
+        assert!(
+            matches!(result, Err(CodecError::Cancelled)),
+            "cancelled read must end in Cancelled, got {result:?}"
+        );
+        assert!(!conn.is_cancelling());
+
+        // The next read must deliver message 3 — not the stale ack from
+        // message 2.
+        let message = conn
+            .read_message()
+            .await
+            .expect("next read")
+            .expect("next message");
+        let status = u16::from_le_bytes([message.payload[1], message.payload[2]]);
+        assert_eq!(
+            status, 0x0010,
+            "next request's response must come through intact; 0x0020 means \
+             the interior row bytes were mistaken for the ack and the real \
+             ack leaked into the next request"
         );
     }
 }

--- a/crates/mssql-codec/src/connection.rs
+++ b/crates/mssql-codec/src/connection.rs
@@ -115,6 +115,10 @@ where
     /// Read the next complete message from the connection.
     ///
     /// This handles multi-packet message reassembly automatically.
+    ///
+    /// Returns [`CodecError::Cancelled`] when the in-flight request was
+    /// cancelled via Attention and the server's DONE_ATTN acknowledgement has
+    /// been consumed — the connection is then clean for the next request.
     pub async fn read_message(&mut self) -> Result<Option<Message>, CodecError> {
         loop {
             // Check for cancellation
@@ -126,6 +130,24 @@ where
             match self.reader.next().await {
                 Some(Ok(packet)) => {
                     if let Some(message) = self.assembler.push(packet) {
+                        // The cancel flag may have been set while this read was
+                        // parked in `next()`. In that case the message belongs
+                        // to the request being cancelled (the server discards
+                        // it and acknowledges with DONE_ATTN), so it must not
+                        // be surfaced as a response — otherwise `cancelling`
+                        // stays latched and a later drain eats the *next*
+                        // request's response.
+                        if self.is_cancelling() {
+                            if Self::payload_has_attention_done(&message.payload) {
+                                tracing::debug!(
+                                    "received DONE with ATTENTION, cancellation complete"
+                                );
+                                self.finish_cancel();
+                                return Err(CodecError::Cancelled);
+                            }
+                            tracing::debug!("discarding message from cancelled request");
+                            continue;
+                        }
                         return Ok(Some(message));
                     }
                     // Continue reading packets until message complete
@@ -225,6 +247,9 @@ where
     }
 
     /// Drain packets after cancellation until DONE with ATTENTION is received.
+    ///
+    /// Returns [`CodecError::Cancelled`] once the acknowledgement is consumed;
+    /// the connection is then clean for the next request.
     async fn drain_after_cancel(&mut self) -> Result<Option<Message>, CodecError> {
         tracing::debug!("draining packets after cancellation");
 
@@ -238,17 +263,11 @@ where
                     // The DONE token is at the start of the payload
                     if packet.header.packet_type == PacketType::TabularResult
                         && !packet.payload.is_empty()
+                        && self.check_attention_done(&packet)
                     {
-                        // TokenType::Done = 0xFD
-                        // Check if this packet contains a Done token
-                        // and the status has ATTN flag (0x0020)
-                        if self.check_attention_done(&packet) {
-                            tracing::debug!("received DONE with ATTENTION, cancellation complete");
-                            self.cancelling
-                                .store(false, std::sync::atomic::Ordering::Release);
-                            self.cancel_notify.notify_waiters();
-                            return Ok(None);
-                        }
+                        tracing::debug!("received DONE with ATTENTION, cancellation complete");
+                        self.finish_cancel();
+                        return Err(CodecError::Cancelled);
                     }
                     // Continue draining
                 }
@@ -258,20 +277,37 @@ where
                     return Err(e);
                 }
                 None => {
+                    // EOF while waiting for the acknowledgement: the
+                    // connection really is gone.
                     self.cancelling
                         .store(false, std::sync::atomic::Ordering::Release);
-                    return Ok(None);
+                    return Err(CodecError::ConnectionClosed);
                 }
             }
         }
     }
 
+    /// Mark the in-flight cancellation as acknowledged and wake waiters.
+    fn finish_cancel(&self) {
+        self.cancelling
+            .store(false, std::sync::atomic::Ordering::Release);
+        self.cancel_notify.notify_waiters();
+    }
+
     /// Check if a packet contains a DONE token with ATTENTION flag.
     fn check_attention_done(&self, packet: &Packet) -> bool {
-        // Look for DONE token (0xFD) with ATTN status flag (bit 5)
-        // DONE token format: token_type(1) + status(2) + cur_cmd(2) + row_count(8)
-        let payload = &packet.payload;
+        Self::payload_has_attention_done(&packet.payload)
+    }
 
+    /// Scan a message payload for a DONE token (0xFD) with the ATTN status
+    /// flag (0x0020).
+    ///
+    /// DONE token format: token_type(1) + status(2) + cur_cmd(2) + row_count(8).
+    /// This is a byte scan, not a token parse, so it can in principle
+    /// false-positive on 0xFD bytes inside row data — acceptable here because
+    /// it is only consulted for messages that arrive while a cancellation is
+    /// pending, where the stream carries DONE tokens rather than rows.
+    fn payload_has_attention_done(payload: &[u8]) -> bool {
         for i in 0..payload.len() {
             if payload[i] == 0xFD && i + 3 <= payload.len() {
                 // Found DONE token, check status
@@ -396,7 +432,7 @@ where
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 
@@ -439,22 +475,132 @@ mod tests {
         );
         let packet_no_attn = Packet::new(header, payload_no_attn);
 
-        // We can't easily test check_attention_done without a Connection,
-        // so we verify the token detection logic directly
-        let check_done = |packet: &Packet| -> bool {
-            let payload = &packet.payload;
-            for i in 0..payload.len() {
-                if payload[i] == 0xFD && i + 3 <= payload.len() {
-                    let status = u16::from_le_bytes([payload[i + 1], payload[i + 2]]);
-                    if status & 0x0020 != 0 {
-                        return true;
-                    }
-                }
-            }
-            false
-        };
+        assert!(
+            Connection::<tokio::io::DuplexStream>::payload_has_attention_done(
+                &packet_with_attn.payload
+            )
+        );
+        assert!(
+            !Connection::<tokio::io::DuplexStream>::payload_has_attention_done(
+                &packet_no_attn.payload
+            )
+        );
+    }
 
-        assert!(check_done(&packet_with_attn));
-        assert!(!check_done(&packet_no_attn));
+    /// Build a raw single-packet TabularResult TDS message around `payload`.
+    fn raw_message(payload: &[u8]) -> Vec<u8> {
+        let mut v = vec![0x04, 0x01]; // TabularResult, END_OF_MESSAGE
+        v.extend_from_slice(&((payload.len() + 8) as u16).to_be_bytes());
+        v.extend_from_slice(&[0, 0, 1, 0]); // spid, packet id, window
+        v.extend_from_slice(payload);
+        v
+    }
+
+    /// DONE token bytes with the given status.
+    fn done_token(status: u16) -> [u8; 13] {
+        let s = status.to_le_bytes();
+        [
+            0xFD, s[0], s[1], 0xC1, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        ]
+    }
+
+    /// Regression test for the cancel-mid-read race.
+    ///
+    /// When `cancel()` fires while `read_message()` is already parked on the
+    /// socket, the cancelled request's response stream (here: DONE(ERROR)
+    /// followed by the DONE(ATTN) acknowledgement) arrives through the
+    /// *normal* read path. It must be discarded — not surfaced as a query
+    /// response — and the read must end in `CodecError::Cancelled` with the
+    /// `cancelling` flag cleared, so the next request's response is delivered
+    /// intact. Before the fix, the first DONE was returned as the response,
+    /// the flag stayed latched, and a later drain ate the next response.
+    #[tokio::test]
+    async fn test_cancel_mid_read_discards_cancelled_stream() {
+        use std::task::{Context, Poll};
+        use tokio::io::AsyncWriteExt;
+
+        let (client_io, mut server_io) = tokio::io::duplex(4096);
+        let mut conn = Connection::new(client_io);
+        let cancel = conn.cancel_handle();
+
+        // Park a read with nothing to deliver yet (mimics waiting on a slow
+        // query). A noop waker is fine: the future is re-polled via `.await`
+        // below after data is written.
+        let mut read_fut = Box::pin(conn.read_message());
+        let waker = std::task::Waker::noop();
+        let mut cx = Context::from_waker(waker);
+        assert!(matches!(read_fut.as_mut().poll(&mut cx), Poll::Pending));
+
+        // Cancel while the read is parked, then deliver the cancelled
+        // request's stream plus the next request's response.
+        cancel.cancel().await.expect("send attention");
+        server_io
+            .write_all(&raw_message(&done_token(0x0002))) // DONE_ERROR
+            .await
+            .unwrap();
+        server_io
+            .write_all(&raw_message(&done_token(0x0020))) // DONE_ATTN ack
+            .await
+            .unwrap();
+        server_io
+            .write_all(&raw_message(&done_token(0x0010))) // next response
+            .await
+            .unwrap();
+
+        let result = read_fut.await;
+        assert!(
+            matches!(result, Err(CodecError::Cancelled)),
+            "parked read must consume the cancelled stream and report \
+             Cancelled, got {result:?}"
+        );
+        assert!(!conn.is_cancelling(), "cancel flag must be cleared");
+
+        // The next request's response must come through untouched.
+        let message = conn
+            .read_message()
+            .await
+            .expect("next read")
+            .expect("next message");
+        assert_eq!(message.payload[0], 0xFD);
+        assert_eq!(
+            u16::from_le_bytes([message.payload[1], message.payload[2]]),
+            0x0010,
+            "next response must not be eaten by a stale drain"
+        );
+    }
+
+    /// Cancellation requested before the read starts takes the drain path and
+    /// must behave identically to the mid-read race.
+    #[tokio::test]
+    async fn test_cancel_before_read_drains_to_attention_ack() {
+        use tokio::io::AsyncWriteExt;
+
+        let (client_io, mut server_io) = tokio::io::duplex(4096);
+        let mut conn = Connection::new(client_io);
+        let cancel = conn.cancel_handle();
+
+        cancel.cancel().await.expect("send attention");
+        server_io
+            .write_all(&raw_message(&done_token(0x0022))) // ERROR | ATTN ack
+            .await
+            .unwrap();
+        server_io
+            .write_all(&raw_message(&done_token(0x0010))) // next response
+            .await
+            .unwrap();
+
+        let result = conn.read_message().await;
+        assert!(matches!(result, Err(CodecError::Cancelled)));
+        assert!(!conn.is_cancelling());
+
+        let message = conn
+            .read_message()
+            .await
+            .expect("next read")
+            .expect("next message");
+        assert_eq!(
+            u16::from_le_bytes([message.payload[1], message.payload[2]]),
+            0x0010
+        );
     }
 }

--- a/crates/mssql-codec/src/error.rs
+++ b/crates/mssql-codec/src/error.rs
@@ -38,6 +38,12 @@ pub enum CodecError {
     #[error("connection closed")]
     ConnectionClosed,
 
+    /// The in-flight request was cancelled via an Attention signal and the
+    /// server acknowledged the cancellation (DONE_ATTN). The connection is
+    /// drained and remains usable for new requests.
+    #[error("request cancelled")]
+    Cancelled,
+
     /// Encoding error.
     #[error("encoding error: {0}")]
     Encoding(String),

--- a/crates/mssql-testing/Cargo.toml
+++ b/crates/mssql-testing/Cargo.toml
@@ -12,6 +12,8 @@ publish = false
 
 [features]
 default = []
+# Enables the OTel metrics emission test against the mock server.
+otel = ["mssql-client/otel"]
 
 [dependencies]
 mssql-client = { workspace = true }
@@ -27,6 +29,12 @@ testcontainers = { workspace = true }
 
 [dev-dependencies]
 mssql-tls = { workspace = true }
+opentelemetry = { workspace = true }
+opentelemetry_sdk = { workspace = true, features = ["testing"] }
+
+[[test]]
+name = "otel_metrics"
+required-features = ["otel"]
 
 [package.metadata.cargo-machete]
 # mssql-client is a peer dependency for test consumers

--- a/crates/mssql-testing/src/mock_server.rs
+++ b/crates/mssql-testing/src/mock_server.rs
@@ -322,6 +322,15 @@ pub struct MockServerConfig {
     database: String,
     /// TLS acceptor for encrypted connections (None = plaintext only).
     tls_acceptor: Option<TlsAcceptor>,
+    /// When set, respond to LOGIN7 with an ENVCHANGE Routing token redirecting
+    /// to this `(host, port)` instead of completing the login (simulates the
+    /// Azure SQL Gateway redirect).
+    login_routing: Option<(String, u16)>,
+    /// Route every login back to this server's own address (resolved after
+    /// bind). Simulates a routing loop.
+    login_routing_to_self: bool,
+    /// Socket address to bind (default `127.0.0.1:0`).
+    bind_addr: String,
 }
 
 /// Builder for `MockTdsServer`.
@@ -340,6 +349,9 @@ impl MockServerBuilder {
                 tds_version: 0x74000004, // TDS 7.4
                 database: "master".to_string(),
                 tls_acceptor: None,
+                login_routing: None,
+                login_routing_to_self: false,
+                bind_addr: "127.0.0.1:0".to_string(),
             },
         }
     }
@@ -365,6 +377,27 @@ impl MockServerBuilder {
     /// Set the default database.
     pub fn with_database(mut self, db: impl Into<String>) -> Self {
         self.config.database = db.into();
+        self
+    }
+
+    /// Respond to LOGIN7 with an ENVCHANGE Routing token redirecting to
+    /// `(host, port)`, simulating the Azure SQL Gateway redirect during login.
+    pub fn with_login_routing(mut self, host: impl Into<String>, port: u16) -> Self {
+        self.config.login_routing = Some((host.into(), port));
+        self
+    }
+
+    /// Respond to every LOGIN7 with a routing token pointing back at this
+    /// server's own address, simulating an endless redirect loop.
+    pub fn with_login_routing_to_self(mut self) -> Self {
+        self.config.login_routing_to_self = true;
+        self
+    }
+
+    /// Bind to a specific socket address instead of the default
+    /// `127.0.0.1:0` (e.g. `[::1]:1433` to listen on the IPv6 loopback).
+    pub fn with_bind_addr(mut self, addr: impl Into<String>) -> Self {
+        self.config.bind_addr = addr.into();
         self
     }
 
@@ -411,6 +444,8 @@ pub struct MockTdsServer {
     config: Arc<MockServerConfig>,
     /// Connection count.
     connection_count: Arc<Mutex<usize>>,
+    /// Cumulative number of connections ever accepted (never decremented).
+    total_connections: Arc<Mutex<usize>>,
 }
 
 impl MockTdsServer {
@@ -420,18 +455,24 @@ impl MockTdsServer {
     }
 
     /// Start the mock server on an available port.
-    pub async fn start(config: MockServerConfig) -> Result<Self> {
-        let listener = TcpListener::bind("127.0.0.1:0").await?;
+    pub async fn start(mut config: MockServerConfig) -> Result<Self> {
+        let listener = TcpListener::bind(config.bind_addr.as_str()).await?;
         let addr = listener.local_addr()?;
+        // Self-routing can only be resolved once the ephemeral port is known.
+        if config.login_routing_to_self {
+            config.login_routing = Some((addr.ip().to_string(), addr.port()));
+        }
         let (shutdown_tx, _) = broadcast::channel(1);
         let config = Arc::new(config);
         let connection_count = Arc::new(Mutex::new(0usize));
+        let total_connections = Arc::new(Mutex::new(0usize));
 
         let server = Self {
             addr,
             shutdown_tx: shutdown_tx.clone(),
             config: config.clone(),
             connection_count: connection_count.clone(),
+            total_connections: total_connections.clone(),
         };
 
         // Spawn the accept loop
@@ -444,6 +485,10 @@ impl MockTdsServer {
                             Ok((stream, _peer_addr)) => {
                                 let config = config.clone();
                                 let count = connection_count.clone();
+                                {
+                                    let mut t = total_connections.lock().await;
+                                    *t += 1;
+                                }
                                 tokio::spawn(async move {
                                     {
                                         let mut c = count.lock().await;
@@ -497,6 +542,15 @@ impl MockTdsServer {
     /// Get the current connection count.
     pub async fn connection_count(&self) -> usize {
         *self.connection_count.lock().await
+    }
+
+    /// Get the cumulative number of connections ever accepted.
+    ///
+    /// Unlike [`connection_count`](Self::connection_count), this never
+    /// decreases when connections close — useful for asserting how many
+    /// connection *attempts* a scenario produced (e.g. redirect chains).
+    pub async fn total_connection_count(&self) -> usize {
+        *self.total_connections.lock().await
     }
 
     /// Stop the server.
@@ -782,11 +836,21 @@ async fn send_prelogin_response_with_encryption(
 }
 
 /// Send LOGIN7 response (LoginAck + EnvChange + Done).
+///
+/// When `login_routing` is configured, the response is an ENVCHANGE Routing
+/// token followed by Done — the login is not acknowledged, mirroring the
+/// Azure SQL Gateway redirect flow.
 async fn send_login_response<S: AsyncWrite + Unpin>(
     stream: &mut S,
     config: &MockServerConfig,
 ) -> Result<()> {
     let mut response = BytesMut::new();
+
+    if let Some((host, port)) = &config.login_routing {
+        encode_env_change_routing(&mut response, host, *port);
+        encode_done(&mut response, 0, false);
+        return write_packet(stream, PacketType::TabularResult, &response).await;
+    }
 
     // EnvChange: Database
     encode_env_change(&mut response, EnvChangeType::Database, &config.database, "");
@@ -825,6 +889,31 @@ fn encode_env_change(dst: &mut BytesMut, env_type: EnvChangeType, new_val: &str,
     for c in &old_utf16 {
         dst.put_u16_le(*c);
     }
+}
+
+/// Encode an ENVCHANGE Routing token (type 20) per MS-TDS 2.2.7.9.
+///
+/// Layout: token(1) + length(2) + env_type(1) +
+/// RoutingDataValue { length(2), protocol(1), port(2), server_len(2),
+/// server(UTF-16LE) } + zero-length OldValue(2).
+fn encode_env_change_routing(dst: &mut BytesMut, host: &str, port: u16) {
+    let host_utf16: Vec<u16> = host.encode_utf16().collect();
+    let routing_len = 1 + 2 + 2 + host_utf16.len() * 2;
+    let data_len = 1 + 2 + routing_len + 2;
+
+    dst.put_u8(TokenType::EnvChange as u8);
+    dst.put_u16_le(data_len as u16);
+    dst.put_u8(EnvChangeType::Routing as u8);
+
+    dst.put_u16_le(routing_len as u16);
+    dst.put_u8(0); // protocol: TCP
+    dst.put_u16_le(port);
+    dst.put_u16_le(host_utf16.len() as u16);
+    for c in &host_utf16 {
+        dst.put_u16_le(*c);
+    }
+
+    dst.put_u16_le(0); // OldValue: zero-length US_VARBYTE
 }
 
 /// Encode a LoginAck token.

--- a/crates/mssql-testing/tests/multi_subnet.rs
+++ b/crates/mssql-testing/tests/multi_subnet.rs
@@ -1,0 +1,110 @@
+//! Behavior tests for `MultiSubnetFailover` parallel TCP connect.
+//!
+//! The driver claims (README, CLAUDE.md) that `MultiSubnetFailover=true`
+//! races parallel TCP connects to *all* resolved addresses and uses the
+//! first to succeed. These tests prove the fan-out is real by binding mock
+//! servers on both loopback stacks (`127.0.0.1` and `[::1]`) under the same
+//! port and counting how many TCP connections each listener receives when
+//! the client connects to `localhost`.
+//!
+//! These run in normal CI; no live SQL Server required. They self-skip when
+//! `localhost` does not resolve dual-stack or IPv6 loopback is unavailable.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+use std::net::SocketAddr;
+use std::time::Duration;
+
+use mssql_client::{Client, Config};
+use mssql_testing::mock_server::MockTdsServer;
+
+/// Two mock servers on the same port: one on the IPv4 loopback, one on the
+/// IPv6 loopback. `None` when the environment cannot support the scenario.
+async fn dual_stack_mocks() -> Option<(MockTdsServer, MockTdsServer)> {
+    let addrs: Vec<SocketAddr> = tokio::net::lookup_host("localhost:1").await.ok()?.collect();
+    let has_v4 = addrs.iter().any(SocketAddr::is_ipv4);
+    let has_v6 = addrs.iter().any(SocketAddr::is_ipv6);
+    if !(has_v4 && has_v6) {
+        return None;
+    }
+
+    let v4 = MockTdsServer::builder().build().await.ok()?;
+    let port = v4.port();
+    let v6 = MockTdsServer::builder()
+        .with_bind_addr(format!("[::1]:{port}"))
+        .build()
+        .await
+        .ok()?;
+    Some((v4, v6))
+}
+
+fn localhost_config(port: u16, multi_subnet: bool) -> Config {
+    Config::from_connection_string(&format!(
+        "Server=localhost,{port};User Id=sa;Password=test;Encrypt=no_tls;\
+         ConnectRetryCount=0;MultiSubnetFailover={multi_subnet}"
+    ))
+    .expect("config parses")
+}
+
+/// `MultiSubnetFailover=true` must open a TCP connection to *every* resolved
+/// address (the race), not walk them sequentially.
+#[tokio::test]
+async fn test_multi_subnet_failover_races_all_resolved_addresses() {
+    let Some((v4, v6)) = dual_stack_mocks().await else {
+        eprintln!("skipping: localhost is not dual-stack in this environment");
+        return;
+    };
+
+    let client = Client::connect(localhost_config(v4.port(), true))
+        .await
+        .expect("parallel connect must succeed via the first winner");
+
+    // Both listeners must have seen a connection attempt. The losing socket
+    // is aborted by the client after the winner completes, but its TCP
+    // handshake already reached the listener.
+    let mut v4_total = 0;
+    let mut v6_total = 0;
+    for _ in 0..20 {
+        v4_total = v4.total_connection_count().await;
+        v6_total = v6.total_connection_count().await;
+        if v4_total + v6_total >= 2 {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    assert_eq!(
+        (v4_total, v6_total),
+        (1, 1),
+        "MultiSubnetFailover must race one TCP connect per resolved address"
+    );
+
+    let _ = client.close().await;
+    v4.stop();
+    v6.stop();
+}
+
+/// Without `MultiSubnetFailover`, the client connects to a single address —
+/// no speculative connections to the other stack.
+#[tokio::test]
+async fn test_sequential_connect_uses_single_address() {
+    let Some((v4, v6)) = dual_stack_mocks().await else {
+        eprintln!("skipping: localhost is not dual-stack in this environment");
+        return;
+    };
+
+    let client = Client::connect(localhost_config(v4.port(), false))
+        .await
+        .expect("sequential connect succeeds");
+
+    // Give any stray speculative connections time to land before counting.
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    let total = v4.total_connection_count().await + v6.total_connection_count().await;
+    assert_eq!(
+        total, 1,
+        "without MultiSubnetFailover exactly one address must be contacted"
+    );
+
+    let _ = client.close().await;
+    v4.stop();
+    v6.stop();
+}

--- a/crates/mssql-testing/tests/otel_metrics.rs
+++ b/crates/mssql-testing/tests/otel_metrics.rs
@@ -1,0 +1,102 @@
+//! Emission test for OpenTelemetry operation metrics.
+//!
+//! README claims "Query + pool lifecycle" metrics via the `otel` feature.
+//! This proves the query half actually emits **real values** — duration
+//! histogram, operations counter, errors counter — by capturing them with an
+//! in-memory exporter while a client runs queries against the mock server.
+//!
+//! Runs in normal CI (the test matrix uses `--all-features`); no live SQL
+//! Server required.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+use mssql_client::{Client, Config, metric_names};
+use mssql_testing::mock_server::{MockResponse, MockTdsServer};
+use opentelemetry::global;
+use opentelemetry_sdk::metrics::data::AggregatedMetrics;
+use opentelemetry_sdk::metrics::{InMemoryMetricExporter, PeriodicReader, SdkMeterProvider};
+
+#[tokio::test]
+async fn test_query_metrics_emit_real_values() {
+    let exporter = InMemoryMetricExporter::default();
+    let reader = PeriodicReader::builder(exporter.clone()).build();
+    let provider = SdkMeterProvider::builder().with_reader(reader).build();
+    // Must be installed before `Client::connect` — instruments bind to the
+    // global meter at connection setup.
+    global::set_meter_provider(provider.clone());
+
+    let server = MockTdsServer::builder()
+        .with_response("SELECT 7", MockResponse::scalar_int(7))
+        .with_response("SELECT boom", MockResponse::error(50000, "boom"))
+        .build()
+        .await
+        .expect("mock starts");
+
+    let config = Config::from_connection_string(&format!(
+        "Server=127.0.0.1,{};User Id=sa;Password=t;Encrypt=no_tls;ConnectRetryCount=0",
+        server.port()
+    ))
+    .expect("config parses");
+
+    let mut client = Client::connect(config).await.expect("connect");
+    for _ in 0..3 {
+        let rows = client.query("SELECT 7", &[]).await.expect("query");
+        assert_eq!(rows.into_iter().count(), 1);
+    }
+    assert!(
+        client.query("SELECT boom", &[]).await.is_err(),
+        "server error expected"
+    );
+
+    provider.force_flush().expect("flush");
+    let finished = exporter.get_finished_metrics().expect("finished metrics");
+
+    let mut operations_total = 0u64;
+    let mut errors_total = 0u64;
+    let mut duration_count = 0u64;
+    let mut duration_sum = 0.0f64;
+
+    for resource_metrics in &finished {
+        for scope in resource_metrics.scope_metrics() {
+            for metric in scope.metrics() {
+                use opentelemetry_sdk::metrics::data::MetricData;
+                match metric.data() {
+                    AggregatedMetrics::U64(MetricData::Sum(sum)) => {
+                        let total: u64 = sum.data_points().map(|dp| dp.value()).sum();
+                        if metric.name() == metric_names::DB_CLIENT_OPERATIONS_TOTAL {
+                            operations_total += total;
+                        } else if metric.name() == metric_names::DB_CLIENT_ERRORS_TOTAL {
+                            errors_total += total;
+                        }
+                    }
+                    AggregatedMetrics::F64(MetricData::Histogram(hist)) => {
+                        if metric.name() == metric_names::DB_CLIENT_OPERATION_DURATION {
+                            for dp in hist.data_points() {
+                                duration_count += dp.count();
+                                duration_sum += dp.sum();
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+
+    assert_eq!(
+        operations_total, 4,
+        "three successful queries plus one failed query must be counted"
+    );
+    assert_eq!(errors_total, 1, "the failed query must count as an error");
+    assert_eq!(
+        duration_count, 4,
+        "every operation must record a duration sample"
+    );
+    assert!(
+        duration_sum > 0.0,
+        "durations must carry real (non-zero) values"
+    );
+
+    let _ = client.close().await;
+    server.stop();
+}

--- a/crates/mssql-testing/tests/redirect.rs
+++ b/crates/mssql-testing/tests/redirect.rs
@@ -1,0 +1,128 @@
+//! Behavior tests for ENVCHANGE Routing (Azure SQL Gateway redirect) handling.
+//!
+//! The driver documents automatic redirect following (`ARCHITECTURE.md` §
+//! "Azure SQL Redirect Handling"). These tests prove the behavior against a
+//! mock TDS server that answers LOGIN7 with a spec-faithful Routing token —
+//! including the zero-length OldValue that real gateways send — so the whole
+//! chain (token parse → `Error::Routing` → reconnect loop → redirect cap) is
+//! exercised without an Azure subscription.
+//!
+//! These run in normal CI; no live SQL Server required.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+use mssql_client::{Client, Config, Error};
+use mssql_testing::mock_server::{MockResponse, MockTdsServer};
+
+fn mock_config(port: u16) -> Config {
+    // The mock is plaintext-only: NotSupported encryption keeps the entire
+    // exchange (including login) off TLS. Retries are disabled so connection
+    // counts below are deterministic.
+    Config::from_connection_string(&format!(
+        "Server=127.0.0.1,{port};User Id=sa;Password=test;Encrypt=no_tls;ConnectRetryCount=0"
+    ))
+    .expect("config parses")
+}
+
+/// A login-time routing token must be followed to the target server, and the
+/// session must end up on the target.
+#[tokio::test]
+async fn test_login_redirect_followed_to_target() {
+    let target = MockTdsServer::builder()
+        .with_server_name("RedirectTarget")
+        .with_response("SELECT 42", MockResponse::scalar_int(42))
+        .build()
+        .await
+        .expect("target starts");
+
+    let gateway = MockTdsServer::builder()
+        .with_server_name("Gateway")
+        .with_login_routing(target.host(), target.port())
+        .build()
+        .await
+        .expect("gateway starts");
+
+    let mut client = Client::connect(mock_config(gateway.port()))
+        .await
+        .expect("connect must follow the routing redirect to the target");
+
+    // The query must be served by the target, not the gateway.
+    let rows = client.query("SELECT 42", &[]).await.expect("query");
+    let row = rows.into_iter().next().expect("row").expect("row ok");
+    let value: i32 = row.get(0).expect("value");
+    assert_eq!(value, 42);
+
+    assert_eq!(
+        gateway.total_connection_count().await,
+        1,
+        "gateway sees exactly the initial login attempt"
+    );
+    assert_eq!(
+        target.total_connection_count().await,
+        1,
+        "target serves the redirected session"
+    );
+
+    let _ = client.close().await;
+    gateway.stop();
+    target.stop();
+}
+
+/// A routing loop must stop after `max_redirects` follows with
+/// `Error::TooManyRedirects` — exactly 1 + max_redirects connection attempts.
+#[tokio::test]
+async fn test_redirect_loop_stops_at_max_redirects() {
+    // Every login answers "go to me again".
+    let looper = MockTdsServer::builder()
+        .with_server_name("Looper")
+        .with_login_routing_to_self()
+        .build()
+        .await
+        .expect("looper starts");
+
+    let err = Client::connect(mock_config(looper.port()))
+        .await
+        .expect_err("a self-routing server must not be followed forever");
+
+    match err {
+        Error::TooManyRedirects { max } => assert_eq!(max, 2),
+        other => panic!("expected TooManyRedirects, got {other:?}"),
+    }
+
+    assert_eq!(
+        looper.total_connection_count().await,
+        3,
+        "default max_redirects=2 allows the original attempt plus exactly \
+         two followed redirects"
+    );
+
+    looper.stop();
+}
+
+/// With `follow_redirects = false` the routing token surfaces as
+/// `Error::Routing` instead of being followed.
+#[tokio::test]
+async fn test_redirect_surfaced_when_following_disabled() {
+    let gateway = MockTdsServer::builder()
+        .with_login_routing("compute.example.invalid", 11001)
+        .build()
+        .await
+        .expect("gateway starts");
+
+    let mut config = mock_config(gateway.port());
+    config.redirect.follow_redirects = false;
+
+    let err = Client::connect(config)
+        .await
+        .expect_err("routing must surface as an error when following is off");
+
+    match err {
+        Error::Routing { host, port } => {
+            assert_eq!(host, "compute.example.invalid");
+            assert_eq!(port, 11001);
+        }
+        other => panic!("expected Error::Routing, got {other:?}"),
+    }
+
+    gateway.stop();
+}

--- a/crates/tds-protocol/src/collation.rs
+++ b/crates/tds-protocol/src/collation.rs
@@ -310,14 +310,45 @@ pub fn encoding_name_for_lcid(lcid: u32) -> &'static str {
     }
 }
 
+/// Encode UTF-8 text into the given codepage, replacing unmappable
+/// characters with `?`.
+///
+/// `encoding_rs`'s convenience `Encoding::encode()` performs HTML-form
+/// substitution — unmappable characters become decimal numeric character
+/// references like `&#20320;`. That is never what a database client wants:
+/// one CJK character would silently expand into eight ASCII characters of
+/// markup. SQL Server itself and the other first-party drivers (ADO.NET,
+/// JDBC, ODBC) substitute `?`, so this drives the lower-level encoder by
+/// hand to match that convention.
+#[cfg(feature = "encoding")]
+fn encode_lossy_question_mark(value: &str, encoding: &'static encoding_rs::Encoding) -> Vec<u8> {
+    let mut encoder = encoding.new_encoder();
+    let mut out = Vec::with_capacity(value.len());
+    let mut buf = [0u8; 1024];
+    let mut input = value;
+    loop {
+        let (result, read, written) =
+            encoder.encode_from_utf8_without_replacement(input, &mut buf, true);
+        out.extend_from_slice(&buf[..written]);
+        input = &input[read..];
+        match result {
+            encoding_rs::EncoderResult::InputEmpty => break,
+            encoding_rs::EncoderResult::OutputFull => {}
+            encoding_rs::EncoderResult::Unmappable(_) => out.push(b'?'),
+        }
+    }
+    out
+}
+
 /// Transcode a Rust `&str` into single-byte VARCHAR bytes for the given collation.
 ///
 /// - UTF-8 collations (SQL Server 2019+) pass through as raw UTF-8 bytes.
 /// - Known non-UTF-8 LCIDs transcode via the matching `encoding_rs` codec.
 /// - Unknown or `None` collations fall back to Windows-1252 (Latin1_General_CI_AS).
 ///
-/// When the `encoding` feature is disabled, characters ≤ 0xFF pass through as
-/// Latin-1 bytes and everything else becomes `?`.
+/// Characters not representable in the target codepage are replaced with `?`,
+/// matching SQL Server's own conversion behavior and the other first-party
+/// drivers. (Regardless of whether the `encoding` feature is enabled.)
 pub fn encode_str_for_collation(
     value: &str,
     collation: Option<&crate::token::Collation>,
@@ -329,12 +360,10 @@ pub fn encode_str_for_collation(
                 return value.as_bytes().to_vec();
             }
             if let Some(encoding) = c.encoding() {
-                let (encoded, _, _) = encoding.encode(value);
-                return encoded.into_owned();
+                return encode_lossy_question_mark(value, encoding);
             }
         }
-        let (encoded, _, _) = encoding_rs::WINDOWS_1252.encode(value);
-        encoded.into_owned()
+        encode_lossy_question_mark(value, encoding_rs::WINDOWS_1252)
     }
     #[cfg(not(feature = "encoding"))]
     {
@@ -356,6 +385,31 @@ mod tests {
         // UTF-8 collation flag
         assert!(is_utf8_collation(0x0800_0409)); // English with UTF-8
         assert!(!is_utf8_collation(0x0409)); // English without UTF-8
+    }
+
+    /// Unmappable characters must become `?` (SQL Server / ADO.NET / JDBC
+    /// convention), NOT the decimal numeric character references
+    /// (`&#20320;`) that `encoding_rs::Encoding::encode()` produces for HTML
+    /// form submission. A regression here silently expands one CJK char into
+    /// eight ASCII chars of markup in the database.
+    #[test]
+    fn test_unmappable_chars_become_question_marks() {
+        // Windows-1252 fallback: Ω and 你 are unmappable, € maps to 0x80.
+        let encoded = encode_str_for_collation("aΩ€你b", None);
+        assert_eq!(encoded, b"a?\x80?b");
+        // No NCR entities anywhere.
+        let one_each = encode_str_for_collation("你好世界", None);
+        assert_eq!(one_each, b"????");
+
+        // Collation-specific path: GB18030 maps the CJK chars but not every
+        // codepoint; the mappable ones must round through the codec.
+        let chinese = crate::token::Collation {
+            lcid: 0x0804,
+            sort_id: 0,
+        };
+        let encoded = encode_str_for_collation("你好", Some(&chinese));
+        let (expected, _, _) = encoding_rs::GB18030.encode("你好");
+        assert_eq!(encoded, expected.into_owned());
     }
 
     #[test]

--- a/crates/tds-protocol/src/lib.rs
+++ b/crates/tds-protocol/src/lib.rs
@@ -132,7 +132,7 @@ pub use tvp::{
     TvpEncoder, TvpWireType, encode_tvp_bit, encode_tvp_date, encode_tvp_datetime2,
     encode_tvp_datetimeoffset, encode_tvp_decimal, encode_tvp_float, encode_tvp_guid,
     encode_tvp_int, encode_tvp_null, encode_tvp_nvarchar, encode_tvp_time, encode_tvp_varbinary,
-    encode_tvp_varchar,
+    encode_tvp_varchar, encode_tvp_varchar_with_collation,
 };
 pub use types::{ColumnFlags, TypeId, Updateable};
 pub use version::{SqlServerVersion, TdsVersion};

--- a/crates/tds-protocol/src/login7.rs
+++ b/crates/tds-protocol/src/login7.rs
@@ -679,6 +679,34 @@ mod tests {
         assert_eq!(tds_version, TdsVersion::V7_4.raw());
     }
 
+    /// `ApplicationIntent=ReadOnly` is wired to the LOGIN7 `READONLY_INTENT`
+    /// bit (TypeFlags bit 5, MS-TDS §2.2.6.4) — pin both the flag encoding
+    /// and its position in the encoded packet (byte 26: after Length,
+    /// TDSVersion, PacketSize, ClientProgVer, ClientPID, ConnectionID,
+    /// OptionFlags1, OptionFlags2).
+    #[test]
+    fn test_login7_read_only_intent_bit() {
+        let read_only = Login7::new()
+            .with_sql_auth("u", "p")
+            .with_read_only_intent(true);
+        assert_eq!(read_only.type_flags.to_byte() & 0x20, 0x20);
+        let encoded = read_only.encode();
+        assert_eq!(
+            encoded[26] & 0x20,
+            0x20,
+            "READONLY_INTENT must be set in the encoded TypeFlags byte"
+        );
+
+        let read_write = Login7::new().with_sql_auth("u", "p");
+        assert_eq!(read_write.type_flags.to_byte() & 0x20, 0);
+        let encoded = read_write.encode();
+        assert_eq!(
+            encoded[26] & 0x20,
+            0,
+            "READONLY_INTENT must be clear by default"
+        );
+    }
+
     #[test]
     fn test_password_obfuscation() {
         // Known test case: "a" should encode to specific bytes

--- a/crates/tds-protocol/src/rpc.rs
+++ b/crates/tds-protocol/src/rpc.rs
@@ -607,19 +607,7 @@ impl RpcParam {
     /// Encode a string as single-byte VARCHAR data using the default
     /// Windows-1252 encoding (or Latin-1 fallback without the `encoding` feature).
     fn encode_varchar_bytes(value: &str) -> Vec<u8> {
-        #[cfg(feature = "encoding")]
-        {
-            let (encoded, _, _) = encoding_rs::WINDOWS_1252.encode(value);
-            encoded.into_owned()
-        }
-        #[cfg(not(feature = "encoding"))]
-        {
-            // Latin-1 fallback: chars ≤ 0xFF pass through, others become '?'
-            value
-                .chars()
-                .map(|ch| if (ch as u32) <= 0xFF { ch as u8 } else { b'?' })
-                .collect()
-        }
+        crate::collation::encode_str_for_collation(value, None)
     }
 
     /// Create a VARCHAR parameter using the server's collation for encoding.

--- a/crates/tds-protocol/src/token.rs
+++ b/crates/tds-protocol/src/token.rs
@@ -1878,6 +1878,7 @@ impl EnvChange {
                 actual: src.remaining(),
             });
         }
+        let remaining_before = src.remaining();
 
         let env_type_byte = src.get_u8();
         let env_type = EnvChangeType::from_u8(env_type_byte)
@@ -1940,6 +1941,18 @@ impl EnvChange {
                 (new_value, old_value)
             }
         };
+
+        // The declared `length` frames the whole ENVCHANGE data. Value
+        // decoders may legitimately consume less than that — e.g. the
+        // Routing decoder reads only the NewValue, leaving the spec-mandated
+        // zero-length OldValue (two bytes) behind. Skip to the frame
+        // boundary so the leftover bytes are not misparsed as the next
+        // token. (Decoders that tolerantly read *past* an under-declared
+        // length are left as-is — see the transaction/collation branch.)
+        let consumed = remaining_before - src.remaining();
+        if consumed < length {
+            src.advance(length - consumed);
+        }
 
         Ok(Self {
             env_type,
@@ -2576,6 +2589,46 @@ mod tests {
         assert_eq!(EnvChangeType::from_u8(1), Some(EnvChangeType::Database));
         assert_eq!(EnvChangeType::from_u8(20), Some(EnvChangeType::Routing));
         assert_eq!(EnvChangeType::from_u8(100), None);
+    }
+
+    /// A spec-faithful Routing ENVCHANGE (MS-TDS 2.2.7.9) carries a
+    /// zero-length OldValue (two bytes) after the routing data. The decoder
+    /// reads only the NewValue, so it must skip to the declared frame
+    /// boundary — otherwise the leftover `00 00` is misparsed as the next
+    /// token type and the rest of the login response is garbage. Azure SQL
+    /// Gateway redirects send exactly this shape.
+    #[test]
+    fn test_env_change_routing_consumes_declared_length() {
+        let host = "redirect.example";
+        let host_utf16: Vec<u16> = host.encode_utf16().collect();
+
+        let mut data = BytesMut::new();
+        // RoutingDataValue: length + protocol + port + server_len + server
+        let routing_len = 1 + 2 + 2 + host_utf16.len() * 2;
+        // ENVCHANGE length: type byte + routing length prefix + routing data
+        // + zero-length OldValue
+        let env_len = 1 + 2 + routing_len + 2;
+        data.put_u16_le(env_len as u16);
+        data.put_u8(20); // Routing
+        data.put_u16_le(routing_len as u16);
+        data.put_u8(0); // protocol: TCP
+        data.put_u16_le(11000); // port
+        data.put_u16_le(host_utf16.len() as u16);
+        for c in &host_utf16 {
+            data.put_u16_le(*c);
+        }
+        data.put_u16_le(0); // OldValue: zero-length US_VARBYTE
+        // A trailing DONE token type byte that must remain for the next read.
+        data.put_u8(0xFD);
+
+        let mut buf: &[u8] = &data;
+        let env = EnvChange::decode(&mut buf).unwrap();
+        assert_eq!(env.routing_info(), Some((host, 11000)));
+        assert_eq!(
+            buf,
+            &[0xFD],
+            "decode must consume exactly the declared ENVCHANGE frame"
+        );
     }
 
     #[test]

--- a/crates/tds-protocol/src/tvp.rs
+++ b/crates/tds-protocol/src/tvp.rs
@@ -146,8 +146,29 @@ impl TvpWireType {
     }
 
     /// Encode the TYPE_INFO for this column type.
+    ///
+    /// String columns are declared with the default Latin1_General_CI_AS
+    /// collation; use [`encode_type_info_with_collation`](Self::encode_type_info_with_collation)
+    /// to declare the server's actual collation.
     pub fn encode_type_info(&self, buf: &mut BytesMut) {
+        self.encode_type_info_with_collation(buf, None);
+    }
+
+    /// Encode the TYPE_INFO for this column type, declaring `collation` for
+    /// string columns.
+    ///
+    /// The collation declared here tells the server which codepage VARCHAR
+    /// cell bytes are in. It must match the encoding used for the cell data
+    /// (see [`encode_tvp_varchar_with_collation`]). `None` falls back to
+    /// [`DEFAULT_COLLATION`] (Latin1_General_CI_AS / Windows-1252).
+    pub fn encode_type_info_with_collation(
+        &self,
+        buf: &mut BytesMut,
+        collation: Option<&crate::token::Collation>,
+    ) {
         buf.put_u8(self.type_id());
+
+        let collation_bytes = collation.map_or(DEFAULT_COLLATION, |c| c.to_bytes());
 
         match self {
             Self::Bit => {
@@ -163,11 +184,11 @@ impl TvpWireType {
             }
             Self::NVarChar { max_length } => {
                 buf.put_u16_le(*max_length);
-                buf.put_slice(&DEFAULT_COLLATION);
+                buf.put_slice(&collation_bytes);
             }
             Self::VarChar { max_length } => {
                 buf.put_u16_le(*max_length);
-                buf.put_slice(&DEFAULT_COLLATION);
+                buf.put_slice(&collation_bytes);
             }
             Self::VarBinary { max_length } => {
                 buf.put_u16_le(*max_length);
@@ -254,6 +275,15 @@ impl TvpColumnDef {
     ///
     /// Format: UserType (4) + Flags (2) + TYPE_INFO + ColName (B_VARCHAR, must be empty)
     pub fn encode(&self, buf: &mut BytesMut) {
+        self.encode_with_collation(buf, None);
+    }
+
+    /// Encode the column metadata, declaring `collation` for string columns.
+    pub fn encode_with_collation(
+        &self,
+        buf: &mut BytesMut,
+        collation: Option<&crate::token::Collation>,
+    ) {
         // UserType (always 0 for TVP columns)
         buf.put_u32_le(0);
 
@@ -261,7 +291,8 @@ impl TvpColumnDef {
         buf.put_u16_le(self.flags.to_bits());
 
         // TYPE_INFO
-        self.wire_type.encode_type_info(buf);
+        self.wire_type
+            .encode_type_info_with_collation(buf, collation);
 
         // ColName - MUST be zero-length per MS-TDS spec
         buf.put_u8(0);
@@ -302,7 +333,25 @@ impl<'a> TvpEncoder<'a> {
     ///
     /// After calling this, use [`Self::encode_row`] for each row, then
     /// [`Self::encode_end`] to finish.
+    ///
+    /// String columns are declared with the default Latin1_General_CI_AS
+    /// collation; use [`Self::encode_metadata_with_collation`] to declare the
+    /// server's actual collation.
     pub fn encode_metadata(&self, buf: &mut BytesMut) {
+        self.encode_metadata_with_collation(buf, None);
+    }
+
+    /// Encode the complete TVP type info and metadata, declaring `collation`
+    /// for string columns.
+    ///
+    /// Pass the collation captured from the login `ENVCHANGE` so VARCHAR cell
+    /// bytes (encoded with the same collation) are interpreted in the right
+    /// codepage by the server.
+    pub fn encode_metadata_with_collation(
+        &self,
+        buf: &mut BytesMut,
+        collation: Option<&crate::token::Collation>,
+    ) {
         // TVP type ID
         buf.put_u8(TVP_TYPE_ID);
 
@@ -334,7 +383,7 @@ impl<'a> TvpEncoder<'a> {
 
             // Encode each column
             for col in self.columns {
-                col.encode(buf);
+                col.encode_with_collation(buf, collation);
             }
         }
 
@@ -469,9 +518,26 @@ pub fn encode_tvp_nvarchar(value: &str, max_length: u16, buf: &mut BytesMut) {
 /// character: "abc" would be stored as "a\0b\0c\0".
 ///
 /// Encodes using Windows-1252 (Latin1_General_CI_AS), matching [`DEFAULT_COLLATION`]
-/// declared in TVP column metadata.
+/// declared in TVP column metadata. Use
+/// [`encode_tvp_varchar_with_collation`] to encode for the server's actual
+/// collation.
 pub fn encode_tvp_varchar(value: &str, max_length: u16, buf: &mut BytesMut) {
-    let encoded = crate::collation::encode_str_for_collation(value, None);
+    encode_tvp_varchar_with_collation(value, max_length, None, buf);
+}
+
+/// Encode a VARCHAR value for TVP using the codepage of `collation`.
+///
+/// The collation must match the one declared in the TVP column metadata
+/// (see [`TvpWireType::encode_type_info_with_collation`]) so the server
+/// interprets the cell bytes in the codepage they were encoded with.
+/// Characters not representable in the codepage are replaced with `?`.
+pub fn encode_tvp_varchar_with_collation(
+    value: &str,
+    max_length: u16,
+    collation: Option<&crate::token::Collation>,
+    buf: &mut BytesMut,
+) {
+    let encoded = crate::collation::encode_str_for_collation(value, collation);
     let byte_len = encoded.len();
 
     if max_length == 0xFFFF {
@@ -890,5 +956,39 @@ mod tests {
             &[0],
             "DATETIMEN NULL is a single length-zero byte"
         );
+    }
+
+    /// VARCHAR TVP columns must declare the provided collation in
+    /// TYPE_INFO instead of the hardcoded Latin1 default, and cell data
+    /// must be transcoded with that collation's codepage. Mismatched
+    /// declaration/encoding silently corrupts non-Latin1 data (the same
+    /// defect class as the v0.10 plain-param collation fix).
+    #[test]
+    #[cfg(feature = "encoding")]
+    fn test_tvp_varchar_with_collation_declares_and_encodes() {
+        let chinese = crate::token::Collation {
+            lcid: 0x0804, // Chinese_PRC → GB18030 / CP936
+            sort_id: 0,
+        };
+
+        // TYPE_INFO declares the caller's collation bytes.
+        let mut buf = BytesMut::new();
+        TvpWireType::VarChar { max_length: 100 }
+            .encode_type_info_with_collation(&mut buf, Some(&chinese));
+        assert_eq!(buf[0], 0xA7, "BIGVARCHARTYPE");
+        assert_eq!(&buf[1..3], &100u16.to_le_bytes());
+        assert_eq!(&buf[3..8], &chinese.to_bytes());
+
+        // Without a collation the default Latin1 bytes are declared.
+        let mut buf = BytesMut::new();
+        TvpWireType::VarChar { max_length: 100 }.encode_type_info(&mut buf);
+        assert_eq!(&buf[3..8], &DEFAULT_COLLATION);
+
+        // Cell data is transcoded with the declared collation's codepage.
+        let mut buf = BytesMut::new();
+        encode_tvp_varchar_with_collation("你好", 100, Some(&chinese), &mut buf);
+        let (expected, _, _) = encoding_rs::GB18030.encode("你好");
+        assert_eq!(&buf[..2], &(expected.len() as u16).to_le_bytes());
+        assert_eq!(&buf[2..], &expected[..]);
     }
 }


### PR DESCRIPTION
## Summary

Falsification-test sweep over the documented-capability-vs-reality defect class (continuing #136–#142): each claim was located, the implementation read, and behavior proven against the live SQL Server 2022 container or a spec-faithful mock — fixing what failed and pinning what passed. Five real defects found and fixed, several claims behavior-verified for the first time.

## Linked issues

Refs #136 #137 #138 #139 #140 #141 #142 (same defect-class campaign; no open issue tracks this sweep)

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation only (claims realigned with reality)
- [x] Test-only change (behavior pins for verified claims)

## What was found and fixed

| Claim | Reality found | Fix |
|---|---|---|
| `CancelHandle` leaves the connection usable | cancel-mid-read race: ack DONE surfaced as the query response, `cancelling` latched, next response eaten by a stale drain → `ConnectionClosed` | message-level cancel handling in the codec read path; new `CodecError::Cancelled` → `Error::Cancelled`; connection verified reusable |
| Automatic Azure redirect handling | spec-faithful Routing ENVCHANGE (with the OldValue real gateways send) under-consumed → stray bytes corrupt the login token stream; would have failed against a real gateway | ENVCHANGE now consumes its declared frame length |
| Unmappable VARCHAR chars become `?` (documented) | `encoding_rs::encode()` emitted HTML numeric refs: `你` stored as `&#20320;` (silent 8× expansion) | manual encoder loop emitting `?`, per ADO.NET/JDBC convention |
| TVP string cells "all types supported" | VARCHAR-declared TVP cells hardcoded Windows-1252 regardless of server collation → silent corruption on non-Latin servers (same class as the v0.10 param fix) | server collation threaded through TVP_COLMETADATA + cell encoding |
| OTel "Query + pool lifecycle" metrics | `db.client.operation.*` instruments built, named, publicly documented — never recorded from any query path | wired at the four span-instrumented data ops; in-memory-exporter test asserts real values |
| Change Tracking builders | `to_sql()` output never executable (missing required CHANGETABLE alias, err 22104); schema-qualified `enable_table_sql` broken (err 4902) | alias added; names bracketed part-by-part; live e2e on a CT-enabled DB |
| ADR-012 bulk API | phantom `send_stream()` API; example didn't match the real API; `batch_size` rustdoc claimed client-side batching/memory benefits (it is a ROWS_PER_BATCH hint) | docs realigned; incremental flush folds into the streaming work (item 6) |

Verified-and-pinned without code change: redirect loop cap is exactly 1 + `max_redirects` (suspected off-by-one refuted), `follow_redirects=false` surfaces `Error::Routing`, MultiSubnetFailover genuinely races one TCP connect per resolved address (dual-stack mock proof), LOGIN7 READONLY_INTENT bit at encoded offset 26, bulk PLP byte-exact at 16 MiB + 8 MB in one batch, server-side query termination via `sys.dm_exec_requests`.

New test infrastructure: mock-server login routing (`with_login_routing`, `with_login_routing_to_self`), configurable bind address, cumulative connection counter — redirect/failover claims are now CI-testable without Azure.

## Test plan

- [x] `cargo nextest run` — 807 unit tests pass
- [x] `cargo clippy --all-features --all-targets -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [x] `cargo test --doc --all-features`, `cargo machete`, `just doc-consistency` (25/25) pass
- [x] Live battery against SQL Server 2022 CU24: CI-equivalent `cargo nextest run --run-ignored ignored-only` (minus Azure/cert) — **238/238 pass**, including the new falsification tests (cancellation DMV proof, TVP Chinese-collation round-trip, CT end-to-end, 16 MiB PLP)
- [x] New mock-based suites (redirect, multi-subnet, otel_metrics) run in the normal matrix — 26/26

## Documentation updates

- [x] Rustdoc updated on changed public items (bulk options, TVP encoders, codec read path, cancel semantics)
- [x] CHANGELOG: entries derive from conventional commits via release-plz (no hand-edit per RELEASING.md)
- [x] README: FILESTREAM row marked Untested (matching the Kerberos precedent)
- [x] ARCHITECTURE.md: ADR-012 realigned; otel version blocks 0.31 → 0.32 (also CLAUDE.md)

## Security considerations

Touches SQL generation (Change Tracking builders — bracketing strengthened, no interpolation of untrusted input added), untrusted-input parsing (ENVCHANGE framing — strictly less data misinterpreted than before), and the codec read path (cancellation — drains are bounded by the same reader; no new allocation from untrusted lengths).

## Additional notes

- `InstrumentationContext` (otel feature) gains a private `Arc<DatabaseMetrics>` field. Two semver-visible effects: external struct-literal construction no longer compiles, and the struct loses its `UnwindSafe`/`RefUnwindSafe` auto-impls (the OTel instruments inside are not unwind-safe). Both internal-purpose; cargo-semver-checks in the release pipeline will classify the bump.
- Residual documented edge (pre-existing): Attention sent with no active request may never be acked; noted in the audit log, an attention timeout is the fix if it ever bites.
- Deferred with reasons (tracked in the sweep log): Kerberos live KDC validation, real-AG ApplicationIntent routing, .NET connection-string differential (no dotnet on the test host), zero-copy profiling, RowStream memory re-measure after item 6 (streaming), statement-cache wiring.
