### PR TITLE
fix(ci): run release-plz on the stable toolchain, not the MSRV pin

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -59,6 +59,15 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
       - name: Install Kerberos headers
         run: sudo apt-get update && sudo apt-get install -y libkrb5-dev
+      # rust-toolchain.toml pins the repo to the MSRV toolchain, which is too
+      # old for cargo-semver-checks (0.47 needs rustc >= 1.91; the sspi dep
+      # needs >= 1.89). release-plz silently treats a cargo-semver-checks
+      # error as "API compatible changes" (release-plz#2294), which produced
+      # a patch-bump Release PR (v0.11.1) for an API-breaking main. Force the
+      # stable toolchain for release-plz's cargo invocations; CI already
+      # builds and tests every commit on stable in the test matrix.
+      - name: Use stable toolchain despite the MSRV pin
+        run: echo "RUSTUP_TOOLCHAIN=stable" >> "$GITHUB_ENV"
       - name: Run release-plz
         uses: release-plz/action@v0.5.129
         with:
@@ -90,6 +99,15 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
       - name: Install Kerberos headers
         run: sudo apt-get update && sudo apt-get install -y libkrb5-dev
+      # rust-toolchain.toml pins the repo to the MSRV toolchain, which is too
+      # old for cargo-semver-checks (0.47 needs rustc >= 1.91; the sspi dep
+      # needs >= 1.89). release-plz silently treats a cargo-semver-checks
+      # error as "API compatible changes" (release-plz#2294), which produced
+      # a patch-bump Release PR (v0.11.1) for an API-breaking main. Force the
+      # stable toolchain for release-plz's cargo invocations; CI already
+      # builds and tests every commit on stable in the test matrix.
+      - name: Use stable toolchain despite the MSRV pin
+        run: echo "RUSTUP_TOOLCHAIN=stable" >> "$GITHUB_ENV"
       - name: Run release-plz
         uses: release-plz/action@v0.5.129
         with:


### PR DESCRIPTION
## Summary

The Release PR regenerated after #143 merged came out as **v0.11.1 (patch)** despite main carrying API-breaking changes vs v0.11.0 (#142's statement-cache unexport, #143's `InstrumentationContext` changes). A breaking 0.11.1 would silently break every `^0.11` consumer on `cargo update`, so the version must be 0.12.0.

Root cause (reproduced locally, step by step): `rust-toolchain.toml` resolves release-plz's cargo invocations to the MSRV toolchain (1.88). cargo-semver-checks cannot run there — 0.47 requires rustc ≥ 1.91 outright, and the all-features rustdoc build needs ≥ 1.89 for the `sspi` dependency. release-plz silently reports any cargo-semver-checks error as "(✓ API compatible changes)" ([release-plz#2294](https://github.com/release-plz/release-plz/issues/2294)), so versioning fell back to commit types only → patch.

Fix: set `RUSTUP_TOOLCHAIN=stable` (highest precedence in rustup's resolution order) for the release-plz steps in both jobs. CI already builds and tests every commit on stable in the test matrix, and the publish path is feature-identical.

## Verification

Simulated the fixed job locally (`release-plz update` with stable + cargo-semver-checks 0.47 on PATH):

```
mssql-client: next version is 0.12.0 (⚠️ API breaking changes)
(all lockstep crates follow to 0.12.0)
```

vs. the current behavior (MSRV toolchain): every crate reported "✓ API compatible changes" → 0.11.1.

## Type of change

- [x] Bug fix (CI/release tooling — wrong release versioning)

## Test plan

- [x] YAML validated; workflow-only change, no code touched
- [x] Local `release-plz update` simulation proves 0.12.0 with breaking-change detection

## Additional notes

After this merges, the next push to main makes release-plz regenerate the open Release PR (#119) as v0.12.0. Related repo finding to be tracked separately: the `sspi-auth` feature cannot build under the declared MSRV 1.88 with the locked sspi 0.18.9 (needs 1.89) — end users are shielded by cargo's MSRV-aware resolver, but the repo lockfile/MSRV combination is inconsistent and needs a decision (bump MSRV to 1.89 vs pin sspi).