### PR TITLE
fix: Tier-1 correctness fixes from the 2026-06 review (collation, UDT/XML, pool permits, datetimeoffset, FEDAUTH gate)

### DIFF
--- a/LIMITATIONS.md
+++ b/LIMITATIONS.md
@@ -18,7 +18,8 @@ For supported features, see [README.md](README.md).
 | Data Types | HIERARCHYID | Use `.ToString()` |
 | Data Types | CLR UDTs | Cast to VARBINARY |
 | Performance | Prepared statement cache (not wired) | `sp_executesql` server plan cache |
-| Auth | Kerberos untested against live KDC | SQL auth, NTLM, or Azure AD |
+| Auth | Azure AD / Entra and certificate auth (FEDAUTH not wired) | SQL auth or NTLM |
+| Auth | Kerberos untested against live KDC | SQL auth or NTLM |
 | Platforms | SQL Server 2005 and earlier | Upgrade to SQL Server 2008+ |
 | Platforms | 32-bit systems | Use 64-bit |
 | Runtime | Non-Tokio runtimes | Use Tokio |
@@ -110,6 +111,26 @@ Client-side handle caching is planned.
 
 ---
 
+### Azure AD / Entra and Certificate Authentication (FEDAUTH Not Wired)
+
+**Status:** Token acquisition implemented; login wiring not implemented
+
+The `mssql-auth` providers for Azure AD access tokens, Managed Identity,
+Service Principals, and client certificates can acquire tokens, but the
+LOGIN7 FEDAUTH feature extension is not yet implemented in `mssql-client`,
+so these credential types cannot complete a login. `Client::connect`
+rejects them with a clear configuration error instead of sending an
+empty-credential login (which the server would reject with an opaque
+error 18456).
+
+Full FEDAUTH support is tracked in
+[#155](https://github.com/praxiomlabs/rust-mssql-driver/issues/155).
+
+**Workaround:** SQL authentication or cross-platform NTLM. For Azure SQL,
+SQL authentication works on every tier.
+
+---
+
 ### Kerberos / Integrated Authentication (Untested Live)
 
 **Status:** Implemented but never validated against a live KDC
@@ -119,8 +140,8 @@ has unit tests, but no end-to-end authentication against a real KDC or
 domain-joined SQL Server has been performed. Treat it as experimental until
 live validation lands.
 
-**Workaround:** SQL authentication, cross-platform NTLM, or Azure AD are
-the validated paths.
+**Workaround:** SQL authentication and cross-platform NTLM are the
+validated paths.
 
 ---
 

--- a/crates/mssql-auth/src/azure_ad.rs
+++ b/crates/mssql-auth/src/azure_ad.rs
@@ -1,30 +1,38 @@
 //! Azure AD / Entra ID authentication implementation.
 //!
-//! This module provides Azure AD federated authentication for SQL Server,
+//! This module provides token handling for Azure AD federated authentication,
 //! supporting both pre-acquired tokens and (with feature flags) token acquisition.
 //!
-//! ## Authentication Flow
+//! ## ⚠️ Login wiring not yet implemented
+//!
+//! The token-acquisition side below works, but the LOGIN7 FEDAUTH feature
+//! extension is **not yet implemented** in `mssql-client`, so these
+//! credentials cannot complete a login end-to-end. `Client::connect` rejects
+//! them with a clear error. Tracked in
+//! [#155](https://github.com/praxiomlabs/rust-mssql-driver/issues/155).
+//!
+//! ## Authentication Flow (target design)
 //!
 //! Azure AD authentication uses the TDS FEDAUTH feature extension:
 //!
-//! 1. Client includes FEDAUTH feature in Login7 packet
+//! 1. Client includes FEDAUTH feature in Login7 packet *(not yet implemented)*
 //! 2. Server responds with FEDAUTHINFO containing STS URL and SPN
-//! 3. Client acquires token (or uses pre-acquired token)
-//! 4. Client sends FEDAUTH token packet
+//! 3. Client acquires token (or uses pre-acquired token) ✅ this module
+//! 4. Client sends FEDAUTH token packet *(not yet implemented)*
 //! 5. Server validates token and completes authentication
 //!
-//! ## Token Sources (Tier 1 - Core) ✅ Implemented
+//! ## Token Sources (Tier 1 - Core)
 //!
 //! - Pre-acquired access token (user provides token directly)
 //!
-//! ## Token Sources (Tier 2 - azure-identity feature) ✅ Implemented
+//! ## Token Sources (Tier 2 - azure-identity feature)
 //!
 //! These require the `azure-identity` feature flag:
 //!
 //! - `ManagedIdentityAuth` - Azure VM/Container identity
 //! - `ServicePrincipalAuth` - Client ID + Secret
 //!
-//! ## Token Sources (Tier 3 - cert-auth feature) ✅ Implemented
+//! ## Token Sources (Tier 3 - cert-auth feature)
 //!
 //! - `CertificateAuth` - X.509 client certificate
 

--- a/crates/mssql-auth/src/lib.rs
+++ b/crates/mssql-auth/src/lib.rs
@@ -10,23 +10,29 @@
 //! | Method | Feature Flag | Status | Description |
 //! |--------|--------------|--------|-------------|
 //! | SQL Authentication | default | ✅ Implemented | Username/password |
-//! | Azure AD Token | default | ✅ Implemented | Pre-obtained access token |
-//! | Azure Managed Identity | `azure-identity` | ✅ Implemented | VM/container identity |
-//! | Service Principal | `azure-identity` | ✅ Implemented | App credentials |
+//! | Azure AD Token | default | ⚠️ Token handling only¹ | Pre-obtained access token |
+//! | Azure Managed Identity | `azure-identity` | ⚠️ Token acquisition only¹ | VM/container identity |
+//! | Service Principal | `azure-identity` | ⚠️ Token acquisition only¹ | App credentials |
 //! | Integrated (Kerberos) | `integrated-auth` | ✅ Implemented | GSSAPI/Kerberos (Linux/macOS) |
 //! | Windows SSPI | `sspi-auth` | ✅ Implemented | Native Windows SSPI |
-//! | Certificate | `cert-auth` | ✅ Implemented | Client certificate (mTLS) |
+//! | Certificate | `cert-auth` | ⚠️ Token acquisition only¹ | Client certificate (mTLS) |
+//!
+//! ¹ These providers acquire tokens, but the LOGIN7 FEDAUTH feature
+//! extension is not yet implemented in `mssql-client`, so they cannot
+//! complete a login end-to-end. `Client::connect` rejects these credential
+//! types with a clear error. Tracked in
+//! [#155](https://github.com/praxiomlabs/rust-mssql-driver/issues/155).
 //!
 //! ## Authentication Tiers
 //!
 //! Per ARCHITECTURE.md, authentication is tiered:
 //!
-//! ### Tier 1 (Core - Pure Rust, Default) ✅ Implemented
+//! ### Tier 1 (Core - Pure Rust, Default)
 //!
-//! - [`SqlServerAuth`] - Username/password via Login7
-//! - [`AzureAdAuth`] - Pre-acquired access token
+//! - [`SqlServerAuth`] - Username/password via Login7 ✅ Implemented
+//! - [`AzureAdAuth`] - Pre-acquired access token ⚠️ FEDAUTH login wiring pending (#155)
 //!
-//! ### Tier 2 (Azure Native - `azure-identity` feature) ✅ Implemented
+//! ### Tier 2 (Azure Native - `azure-identity` feature) ⚠️ FEDAUTH login wiring pending (#155)
 //!
 //! - `ManagedIdentityAuth` - Azure VM/Container identity
 //! - `ServicePrincipalAuth` - Client ID + Secret
@@ -36,7 +42,7 @@
 //! - `IntegratedAuth` - Kerberos (Linux/macOS via GSSAPI)
 //! - `SspiAuth` - Windows SSPI (native Windows, cross-platform via sspi-rs)
 //!
-//! ### Tier 4 (Certificate - `cert-auth` feature) ✅ Implemented
+//! ### Tier 4 (Certificate - `cert-auth` feature) ⚠️ FEDAUTH login wiring pending (#155)
 //!
 //! - `CertificateAuth` - Client certificate authentication (mTLS)
 //!

--- a/crates/mssql-client/src/bulk.rs
+++ b/crates/mssql-client/src/bulk.rs
@@ -1079,9 +1079,11 @@ impl BulkInsert {
                 let time_len = time_byte_length(scale);
                 let total_len = time_len + 3 + 2;
                 buf.put_u8(total_len);
-                // Use mssql_types encode
-                encode_time_with_scale(dto.time(), scale, buf);
-                mssql_types::encode::encode_date(dto.date_naive(), buf);
+                // The wire date/time portion is UTC per MS-TDS §2.2.5.5.1.9,
+                // not the local wall-clock.
+                let utc = dto.naive_utc();
+                encode_time_with_scale(utc.time(), scale, buf);
+                mssql_types::encode::encode_date(utc.date(), buf);
                 // Timezone offset in minutes
                 use chrono::Offset;
                 let offset_minutes = (dto.offset().fix().local_minus_utc() / 60) as i16;

--- a/crates/mssql-client/src/client/connect.rs
+++ b/crates/mssql-client/src/client/connect.rs
@@ -44,6 +44,31 @@ impl Client<Disconnected> {
     /// # }
     /// ```
     pub async fn connect(config: Config) -> Result<Client<Ready>> {
+        // FEDAUTH-based credentials (Azure AD / Entra and client certificate)
+        // are not yet wired into the login sequence: providers can acquire
+        // tokens, but LOGIN7 carries no FEDAUTH feature extension, so the
+        // server would receive an empty-credential login and reject it with
+        // an opaque error 18456. Fail fast with an actionable error instead.
+        // Full FEDAUTH support is tracked in issue #155.
+        match &config.credentials {
+            mssql_auth::Credentials::SqlServer { .. } => {}
+            #[cfg(any(feature = "integrated-auth", feature = "sspi-auth"))]
+            mssql_auth::Credentials::Integrated => {}
+            // Every other credential type (Azure access token, managed
+            // identity, service principal, client certificate) is
+            // FEDAUTH-based and rejected here.
+            _ => {
+                return Err(Error::Config(
+                    "Azure AD / Entra and client certificate (FEDAUTH) authentication \
+                     are not yet supported: the LOGIN7 FEDAUTH feature extension is not \
+                     implemented (tracked in \
+                     https://github.com/praxiomlabs/rust-mssql-driver/issues/155). \
+                     Use SQL Server or integrated authentication."
+                        .into(),
+                ));
+            }
+        }
+
         let retry = config.retry.clone();
         let max_redirects = config.redirect.max_redirects;
         let follow_redirects = config.redirect.follow_redirects;

--- a/crates/mssql-client/src/client/params.rs
+++ b/crates/mssql-client/src/client/params.rs
@@ -510,14 +510,17 @@ impl<S: ConnectionState> Client<S> {
             #[cfg(feature = "chrono")]
             SqlValue::DateTimeOffset(dto) => {
                 use chrono::{Offset, Timelike};
+                // The wire date/time portion is UTC per MS-TDS §2.2.5.5.1.9,
+                // not the local wall-clock.
+                let utc = dto.naive_utc();
                 // Time component (in 100-nanosecond intervals)
-                let nanos = dto.time().num_seconds_from_midnight() as u64 * 1_000_000_000
-                    + dto.time().nanosecond() as u64;
+                let nanos = utc.time().num_seconds_from_midnight() as u64 * 1_000_000_000
+                    + utc.time().nanosecond() as u64;
                 let intervals = nanos / 100;
                 // Date component (days since 0001-01-01)
                 let base =
                     chrono::NaiveDate::from_ymd_opt(1, 1, 1).expect("epoch 0001-01-01 is valid");
-                let days = dto.date_naive().signed_duration_since(base).num_days() as u32;
+                let days = utc.date().signed_duration_since(base).num_days() as u32;
                 // Timezone offset in minutes
                 let offset_minutes = (dto.offset().fix().local_minus_utc() / 60) as i16;
                 let scale = match wire_type {

--- a/crates/mssql-client/src/column_parser.rs
+++ b/crates/mssql-client/src/column_parser.rs
@@ -713,10 +713,9 @@ pub fn parse_column_value(buf: &mut &[u8], col: &ColumnData) -> Result<SqlValue>
                         .unwrap_or_else(|| {
                             chrono::FixedOffset::east_opt(0).expect("UTC offset 0 is valid")
                         });
-                    let datetime = offset
-                        .from_local_datetime(&date.and_time(time))
-                        .single()
-                        .unwrap_or_else(|| offset.from_utc_datetime(&date.and_time(time)));
+                    // The wire date/time portion is UTC per MS-TDS §2.2.5.5.1.9;
+                    // attach the offset without shifting the instant.
+                    let datetime = offset.from_utc_datetime(&date.and_time(time));
                     SqlValue::DateTimeOffset(datetime)
                 }
                 #[cfg(not(feature = "chrono"))]
@@ -1454,10 +1453,9 @@ fn parse_sql_variant(buf: &mut &[u8]) -> Result<SqlValue> {
                     .unwrap_or_else(|| {
                         chrono::FixedOffset::east_opt(0).expect("UTC offset 0 is valid")
                     });
-                let datetime = offset
-                    .from_local_datetime(&date.and_time(time))
-                    .single()
-                    .unwrap_or_else(|| offset.from_utc_datetime(&date.and_time(time)));
+                // The wire date/time portion is UTC per MS-TDS §2.2.5.5.1.9;
+                // attach the offset without shifting the instant.
+                let datetime = offset.from_utc_datetime(&date.and_time(time));
                 Ok(SqlValue::DateTimeOffset(datetime))
             }
             #[cfg(not(feature = "chrono"))]

--- a/crates/mssql-client/src/row.rs
+++ b/crates/mssql-client/src/row.rs
@@ -156,7 +156,8 @@ impl Column {
     /// Check if this column uses UTF-8 encoding.
     ///
     /// Returns `true` if the column has a SQL Server 2019+ UTF-8 collation,
-    /// which is indicated by bit 27 (0x0800_0000) being set in the LCID.
+    /// which is indicated by fUTF8 (bit 26, 0x0400_0000) being set in the
+    /// collation info field.
     #[must_use]
     pub fn is_utf8_collation(&self) -> bool {
         #[cfg(feature = "encoding")]

--- a/crates/mssql-client/tests/config.rs
+++ b/crates/mssql-client/tests/config.rs
@@ -325,3 +325,35 @@ fn test_repeated_keys_last_wins() {
 
     assert_eq!(config.host, "third");
 }
+
+// ============================================================================
+// FEDAUTH Credential Gate (issue #159)
+// ============================================================================
+
+/// Azure AD credentials are not yet wired into the login sequence (no LOGIN7
+/// FEDAUTH feature extension — see #155). connect() must fail fast with an
+/// actionable configuration error instead of sending an empty-credential
+/// login that the server rejects with an opaque 18456.
+#[tokio::test]
+async fn test_azure_credentials_fail_fast_before_io() {
+    let config = Config::new()
+        .host("host-that-must-never-be-contacted.invalid")
+        .credentials(mssql_client::Credentials::AzureAccessToken {
+            token: "test-token".into(),
+        });
+
+    let err = mssql_client::Client::connect(config)
+        .await
+        .expect_err("Azure credentials must be rejected at connect time");
+
+    match err {
+        mssql_client::Error::Config(msg) => {
+            assert!(msg.contains("FEDAUTH"), "error should name FEDAUTH: {msg}");
+            assert!(
+                msg.contains("155"),
+                "error should link tracking issue: {msg}"
+            );
+        }
+        other => panic!("expected Error::Config, got {other:?}"),
+    }
+}

--- a/crates/mssql-client/tests/config.rs
+++ b/crates/mssql-client/tests/config.rs
@@ -346,14 +346,14 @@ async fn test_azure_credentials_fail_fast_before_io() {
         .await
         .expect_err("Azure credentials must be rejected at connect time");
 
-    match err {
-        mssql_client::Error::Config(msg) => {
-            assert!(msg.contains("FEDAUTH"), "error should name FEDAUTH: {msg}");
-            assert!(
-                msg.contains("155"),
-                "error should link tracking issue: {msg}"
-            );
-        }
-        other => panic!("expected Error::Config, got {other:?}"),
-    }
+    let msg = err.to_string();
+    assert!(
+        matches!(err, mssql_client::Error::Config(_)),
+        "expected Error::Config, got: {msg}"
+    );
+    assert!(msg.contains("FEDAUTH"), "error should name FEDAUTH: {msg}");
+    assert!(
+        msg.contains("155"),
+        "error should link tracking issue: {msg}"
+    );
 }

--- a/crates/mssql-pool/src/pool.rs
+++ b/crates/mssql-pool/src/pool.rs
@@ -423,10 +423,11 @@ impl Pool {
                 }
                 inner.record_pool_status();
 
-                // Release semaphore permits for closed connections
-                inner
-                    .semaphore
-                    .add_permits((expired_lifetime + expired_idle) as usize);
+                // Deliberately no semaphore.add_permits here: idle connections
+                // hold no permits (permits are owned by checkouts and released
+                // on checkin; warm-up drops its permit after pushing to idle),
+                // so evicting idle entries frees nothing. Adding permits here
+                // inflated capacity past max_connections on every reap (#151).
             } else {
                 inner.metrics.lock().reaper_runs += 1;
             }

--- a/crates/mssql-pool/tests/integration.rs
+++ b/crates/mssql-pool/tests/integration.rs
@@ -1204,3 +1204,62 @@ async fn test_cancel_safety_pool_discards_inflight_connection() {
 
     pool.close().await;
 }
+
+// =============================================================================
+// Permit Accounting (issue #151)
+// =============================================================================
+
+/// Regression test for #151: the reaper called `add_permits` when evicting
+/// idle connections, but idle connections hold no permits (permits are owned
+/// by checkouts and released on checkin), so every reap permanently inflated
+/// capacity past `max_connections`.
+#[tokio::test]
+#[ignore = "Requires SQL Server"]
+async fn test_reaper_does_not_inflate_max_connections() {
+    let client_config = get_test_config().expect("SQL Server config required");
+
+    let pool_config = mssql_driver_pool::PoolConfig::new()
+        .min_connections(0)
+        .max_connections(2)
+        .connection_timeout(Duration::from_millis(500))
+        .idle_timeout(Duration::from_millis(100))
+        .test_on_checkout(false)
+        .health_check_interval(Duration::from_millis(200)); // reaper tick
+
+    let pool = Pool::builder()
+        .client_config(client_config)
+        .pool_config(pool_config)
+        .build()
+        .await
+        .expect("Failed to create pool");
+
+    // Fill the pool, then return both connections to idle.
+    let c1 = pool.get().await.expect("checkout 1");
+    let c2 = pool.get().await.expect("checkout 2");
+    drop(c1);
+    drop(c2);
+
+    // Let the reaper evict both idle connections (idle_timeout 100ms,
+    // reaper tick 200ms; generous margin for slow CI).
+    tokio::time::sleep(Duration::from_millis(800)).await;
+    let metrics = pool.metrics();
+    assert!(
+        metrics.connections_idle_expired >= 2,
+        "reaper should have evicted the idle connections (evicted: {})",
+        metrics.connections_idle_expired
+    );
+
+    // Capacity must still be max_connections: two checkouts succeed...
+    let _h1 = pool.get().await.expect("checkout after reap 1");
+    let _h2 = pool.get().await.expect("checkout after reap 2");
+    // ...and a third must fail on the acquire timeout rather than exceed the
+    // cap. Before the fix the reap had added two phantom permits, so this
+    // third checkout incorrectly succeeded.
+    let third = pool.get().await;
+    assert!(
+        third.is_err(),
+        "third concurrent checkout must fail with max_connections=2"
+    );
+
+    pool.close().await;
+}

--- a/crates/mssql-types/src/decode.rs
+++ b/crates/mssql-types/src/decode.rs
@@ -862,10 +862,9 @@ fn decode_datetimeoffset(buf: &mut Bytes, type_info: &TypeInfo) -> Result<SqlVal
     let offset = chrono::FixedOffset::east_opt((offset_minutes as i32) * 60)
         .ok_or_else(|| TypeError::InvalidDateTime(format!("invalid offset: {offset_minutes}")))?;
 
-    let datetime = offset
-        .from_local_datetime(&date.and_time(time))
-        .single()
-        .ok_or_else(|| TypeError::InvalidDateTime("ambiguous datetime".to_string()))?;
+    // The wire date/time portion is UTC per MS-TDS §2.2.5.5.1.9; attach the
+    // offset without shifting the instant.
+    let datetime = offset.from_utc_datetime(&date.and_time(time));
 
     Ok(SqlValue::DateTimeOffset(datetime))
 }
@@ -1089,6 +1088,58 @@ mod tests {
         data.extend_from_slice(&0u32.to_le_bytes());
         let mut buf = Bytes::from(data);
         assert!(decode_datetime(&mut buf).is_err());
+    }
+
+    /// Issue #152 regression: the DATETIMEOFFSET wire date/time portion is
+    /// the UTC instant per MS-TDS §2.2.5.5.1.9; decoding must attach the
+    /// offset without shifting it. Wire 10:00 UTC with +02:00 → 12:00+02:00.
+    /// The previous from_local_datetime decode produced 10:00+02:00 (a
+    /// different instant), which round-tripped only against our own equally
+    /// inverted encoder.
+    #[cfg(feature = "chrono")]
+    #[test]
+    fn test_datetimeoffset_decodes_wire_as_utc() {
+        use chrono::TimeZone;
+
+        let mut data = Vec::new();
+        data.push(10u8); // BYTELEN: 5 time + 3 date + 2 offset
+        let intervals: u64 = 10 * 3600 * 10_000_000; // 10:00:00 UTC, scale 7
+        for i in 0..5 {
+            data.push(((intervals >> (8 * i)) & 0xFF) as u8);
+        }
+        let base = chrono::NaiveDate::from_ymd_opt(1, 1, 1).unwrap();
+        let days = (chrono::NaiveDate::from_ymd_opt(2024, 3, 15).unwrap() - base).num_days() as u32;
+        data.push((days & 0xFF) as u8);
+        data.push(((days >> 8) & 0xFF) as u8);
+        data.push(((days >> 16) & 0xFF) as u8);
+        data.extend_from_slice(&120i16.to_le_bytes()); // +02:00
+
+        let type_info = TypeInfo {
+            type_id: 0x2B,
+            length: None,
+            scale: Some(7),
+            precision: None,
+            collation: None,
+        };
+        let mut buf = Bytes::from(data);
+        let value = decode_datetimeoffset(&mut buf, &type_info).unwrap();
+
+        let offset = chrono::FixedOffset::east_opt(2 * 3600).unwrap();
+        let expected = offset.with_ymd_and_hms(2024, 3, 15, 12, 0, 0).unwrap();
+        match value {
+            SqlValue::DateTimeOffset(dt) => {
+                assert_eq!(dt, expected);
+                assert_eq!(dt.offset().local_minus_utc(), 7200);
+                assert_eq!(
+                    dt.naive_utc(),
+                    chrono::NaiveDate::from_ymd_opt(2024, 3, 15)
+                        .unwrap()
+                        .and_hms_opt(10, 0, 0)
+                        .unwrap()
+                );
+            }
+            other => panic!("expected DateTimeOffset, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/mssql-types/src/decode.rs
+++ b/crates/mssql-types/src/decode.rs
@@ -44,10 +44,11 @@ pub struct Collation {
 impl Collation {
     /// Check if this collation uses UTF-8 encoding (SQL Server 2019+).
     ///
-    /// UTF-8 collations have bit 27 (0x0800_0000) set in the LCID.
+    /// UTF-8 collations have fUTF8, bit 26 (0x0400_0000), set in the
+    /// collation info field (bit 27 is FRESERVEDBIT per MS-TDS).
     #[must_use]
     pub fn is_utf8(&self) -> bool {
-        (self.lcid & 0x0800_0000) != 0
+        (self.lcid & 0x0400_0000) != 0
     }
 
     /// Get the encoding for this collation.
@@ -61,9 +62,10 @@ impl Collation {
     }
 }
 
-/// UTF-8 collation flag bit (bit 27).
+/// UTF-8 collation flag bit — fUTF8, bit 26 per the MS-TDS Collation Rule
+/// Definition (bit 27 is FRESERVEDBIT).
 #[cfg(feature = "encoding")]
-const UTF8_COLLATION_FLAG: u32 = 0x0800_0000;
+const UTF8_COLLATION_FLAG: u32 = 0x0400_0000;
 
 /// Get the encoding for an LCID value.
 #[cfg(feature = "encoding")]

--- a/crates/mssql-types/src/encode.rs
+++ b/crates/mssql-types/src/encode.rs
@@ -431,14 +431,17 @@ pub fn encode_datetime2(datetime: chrono::NaiveDateTime, buf: &mut BytesMut) {
 
 /// Encode a DATETIMEOFFSET value.
 ///
-/// DATETIMEOFFSET is encoded as TIME + DATE + offset (in minutes).
+/// DATETIMEOFFSET is encoded as TIME + DATE + offset (in minutes). Per
+/// MS-TDS §2.2.5.5.1.9 the date/time portion is the **UTC** instant, not the
+/// local wall-clock; the offset is carried separately.
 #[cfg(feature = "chrono")]
 pub fn encode_datetimeoffset(datetime: chrono::DateTime<chrono::FixedOffset>, buf: &mut BytesMut) {
     use chrono::Offset;
 
-    // Encode time and date components
-    encode_time(datetime.time(), buf);
-    encode_date(datetime.date_naive(), buf);
+    // Encode the UTC date/time components
+    let utc = datetime.naive_utc();
+    encode_time(utc.time(), buf);
+    encode_date(utc.date(), buf);
 
     // Encode timezone offset in minutes (signed 16-bit)
     let offset_seconds = datetime.offset().fix().local_minus_utc();
@@ -450,6 +453,41 @@ pub fn encode_datetimeoffset(datetime: chrono::DateTime<chrono::FixedOffset>, bu
 #[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
+
+    /// Issue #152 regression: the DATETIMEOFFSET wire date/time portion is
+    /// the UTC instant per MS-TDS §2.2.5.5.1.9. 12:00 at +02:00 must encode
+    /// a 10:00 time portion. The previous encoder wrote the local wall-clock,
+    /// shifting every non-zero-offset value when read by other drivers or
+    /// compared server-side.
+    #[cfg(feature = "chrono")]
+    #[test]
+    fn test_datetimeoffset_encodes_utc_instant() {
+        use chrono::TimeZone;
+
+        let offset = chrono::FixedOffset::east_opt(2 * 3600).unwrap();
+        let dto = offset.with_ymd_and_hms(2024, 3, 15, 12, 0, 0).unwrap();
+
+        let mut buf = BytesMut::new();
+        encode_datetimeoffset(dto, &mut buf);
+        assert_eq!(buf.len(), 10); // 5 time + 3 date + 2 offset
+
+        // Time portion: 100ns intervals since midnight of the UTC instant.
+        let mut intervals: u64 = 0;
+        for i in 0..5 {
+            intervals |= u64::from(buf[i]) << (8 * i);
+        }
+        assert_eq!(intervals, 10 * 3600 * 10_000_000, "time must be 10:00 UTC");
+
+        // Date portion: days since 0001-01-01 of the UTC date.
+        let days = u32::from(buf[5]) | (u32::from(buf[6]) << 8) | (u32::from(buf[7]) << 16);
+        let base = chrono::NaiveDate::from_ymd_opt(1, 1, 1).unwrap();
+        let expected_days =
+            (chrono::NaiveDate::from_ymd_opt(2024, 3, 15).unwrap() - base).num_days() as u32;
+        assert_eq!(days, expected_days);
+
+        // Offset: +120 minutes, unchanged.
+        assert_eq!(i16::from_le_bytes([buf[8], buf[9]]), 120);
+    }
 
     #[test]
     fn test_encode_int() {

--- a/crates/tds-protocol/src/collation.rs
+++ b/crates/tds-protocol/src/collation.rs
@@ -43,8 +43,10 @@ use encoding_rs::Encoding;
 use crate::prelude::*;
 
 /// Flag bit indicating UTF-8 collation (SQL Server 2019+).
-/// This is bit 27 (0x0800_0000) in the collation info field.
-pub const COLLATION_FLAG_UTF8: u32 = 0x0800_0000;
+/// This is fUTF8, bit 26 (0x0400_0000) in the collation info field per the
+/// MS-TDS Collation Rule Definition (bit 27 is FRESERVEDBIT). Matches
+/// mssql-jdbc's `UTF8_IN_TDSCOLLATION = 0x4000000`.
+pub const COLLATION_FLAG_UTF8: u32 = 0x0400_0000;
 
 /// Mask to extract the primary LCID from the collation info.
 /// The LCID is stored in the lower 20 bits.
@@ -56,7 +58,7 @@ pub const PRIMARY_LANGUAGE_MASK: u32 = 0x0000_FFFF;
 /// Returns whether the collation uses UTF-8 encoding.
 ///
 /// SQL Server 2019+ supports UTF-8 collations with the `_UTF8` suffix.
-/// These collations set bit 27 in the collation info field.
+/// These collations set fUTF8 (bit 26) in the collation info field.
 #[inline]
 pub fn is_utf8_collation(lcid: u32) -> bool {
     lcid & COLLATION_FLAG_UTF8 != 0
@@ -382,9 +384,14 @@ mod tests {
 
     #[test]
     fn test_utf8_detection() {
-        // UTF-8 collation flag
-        assert!(is_utf8_collation(0x0800_0409)); // English with UTF-8
+        // UTF-8 collation flag: fUTF8 is bit 26 (0x0400_0000), matching
+        // mssql-jdbc's UTF8_IN_TDSCOLLATION. A real Latin1_General_100_*_UTF8
+        // collation info field has this bit set.
+        assert!(is_utf8_collation(0x0400_0409)); // English with UTF-8
         assert!(!is_utf8_collation(0x0409)); // English without UTF-8
+        // Regression: bit 27 is FRESERVEDBIT, not fUTF8. Treating it as UTF-8
+        // made is_utf8() always false for real _UTF8 collations (issue #153).
+        assert!(!is_utf8_collation(0x0800_0409));
     }
 
     /// Unmappable characters must become `?` (SQL Server / ADO.NET / JDBC
@@ -558,7 +565,7 @@ mod tests {
     fn test_encoding_name() {
         assert_eq!(encoding_name_for_lcid(0x0411), "Shift_JIS");
         assert_eq!(encoding_name_for_lcid(0x0419), "windows-1251");
-        assert_eq!(encoding_name_for_lcid(0x0800_0409), "UTF-8");
+        assert_eq!(encoding_name_for_lcid(0x0400_0409), "UTF-8");
         assert_eq!(encoding_name_for_lcid(0x9999), "windows-1252"); // fallback
     }
 

--- a/crates/tds-protocol/src/token.rs
+++ b/crates/tds-protocol/src/token.rs
@@ -766,9 +766,11 @@ pub(crate) fn decode_type_info(
             let schema_present = src.get_u8();
 
             if schema_present != 0 {
-                // Read schema info (3 us_varchar strings)
-                let _ = read_us_varchar(src).ok_or(ProtocolError::UnexpectedEof)?; // db name
-                let _ = read_us_varchar(src).ok_or(ProtocolError::UnexpectedEof)?; // owning schema
+                // XML_INFO per MS-TDS §2.2.5.5.3: DBNAME and OWNING_SCHEMA are
+                // B_VARCHAR (1-byte length); only XML_SCHEMA_COLLECTION is
+                // US_VARCHAR (2-byte length).
+                let _ = read_b_varchar(src).ok_or(ProtocolError::UnexpectedEof)?; // db name
+                let _ = read_b_varchar(src).ok_or(ProtocolError::UnexpectedEof)?; // owning schema
                 let _ = read_us_varchar(src).ok_or(ProtocolError::UnexpectedEof)?; // xml schema collection
             }
 
@@ -783,10 +785,12 @@ pub(crate) fn decode_type_info(
             }
             let max_length = src.get_u16_le() as u32;
 
-            // UDT metadata: db name, schema name, type name, assembly qualified name
-            let _ = read_us_varchar(src).ok_or(ProtocolError::UnexpectedEof)?; // db name
-            let _ = read_us_varchar(src).ok_or(ProtocolError::UnexpectedEof)?; // schema name
-            let _ = read_us_varchar(src).ok_or(ProtocolError::UnexpectedEof)?; // type name
+            // UDT_INFO per MS-TDS: DB_NAME, SCHEMA_NAME, and TYPE_NAME are
+            // B_VARCHAR (1-byte length); only ASSEMBLY_QUALIFIED_NAME is
+            // US_VARCHAR (2-byte length).
+            let _ = read_b_varchar(src).ok_or(ProtocolError::UnexpectedEof)?; // db name
+            let _ = read_b_varchar(src).ok_or(ProtocolError::UnexpectedEof)?; // schema name
+            let _ = read_b_varchar(src).ok_or(ProtocolError::UnexpectedEof)?; // type name
             let _ = read_us_varchar(src).ok_or(ProtocolError::UnexpectedEof)?; // assembly qualified name
 
             Ok(TypeInfo {
@@ -2628,6 +2632,73 @@ mod tests {
             buf,
             &[0xFD],
             "decode must consume exactly the declared ENVCHANGE frame"
+        );
+    }
+
+    fn put_b_varchar(buf: &mut BytesMut, s: &str) {
+        let utf16: Vec<u16> = s.encode_utf16().collect();
+        buf.put_u8(utf16.len() as u8);
+        for c in utf16 {
+            buf.put_u16_le(c);
+        }
+    }
+
+    fn put_us_varchar(buf: &mut BytesMut, s: &str) {
+        let utf16: Vec<u16> = s.encode_utf16().collect();
+        buf.put_u16_le(utf16.len() as u16);
+        for c in utf16 {
+            buf.put_u16_le(c);
+        }
+    }
+
+    /// UDT_INFO regression (issue #154): per MS-TDS, DB_NAME, SCHEMA_NAME,
+    /// and TYPE_NAME are B_VARCHAR (1-byte length); only
+    /// ASSEMBLY_QUALIFIED_NAME is US_VARCHAR. Reading all four as US_VARCHAR
+    /// misaligned the stream, so every query selecting a UDT column
+    /// (geography, geometry, hierarchyid, CLR UDTs) failed with
+    /// UnexpectedEof.
+    #[test]
+    fn test_udt_info_metadata_uses_b_varchar_names() {
+        let mut data = BytesMut::new();
+        data.put_u16_le(0xFFFF); // MAX_BYTE_SIZE
+        put_b_varchar(&mut data, "master");
+        put_b_varchar(&mut data, "dbo");
+        put_b_varchar(&mut data, "hierarchyid");
+        put_us_varchar(
+            &mut data,
+            "Microsoft.SqlServer.Types.SqlHierarchyId, Microsoft.SqlServer.Types",
+        );
+        // A trailing token type byte that must remain for the next read.
+        data.put_u8(0xFD);
+
+        let mut buf: &[u8] = &data;
+        let info = decode_type_info(&mut buf, TypeId::Udt, TypeId::Udt as u8).unwrap();
+        assert_eq!(info.max_length, Some(0xFFFF));
+        assert_eq!(
+            buf,
+            &[0xFD],
+            "decode must consume exactly the UDT_INFO frame"
+        );
+    }
+
+    /// XML_INFO regression (issue #154): per MS-TDS §2.2.5.5.3, DBNAME and
+    /// OWNING_SCHEMA are B_VARCHAR; only XML_SCHEMA_COLLECTION is US_VARCHAR.
+    /// Schema-bound xml columns (SCHEMA_PRESENT=1) previously misparsed.
+    #[test]
+    fn test_xml_info_schema_bound_uses_b_varchar_names() {
+        let mut data = BytesMut::new();
+        data.put_u8(1); // SCHEMA_PRESENT
+        put_b_varchar(&mut data, "master");
+        put_b_varchar(&mut data, "dbo");
+        put_us_varchar(&mut data, "MyXmlSchemaCollection");
+        data.put_u8(0xFD);
+
+        let mut buf: &[u8] = &data;
+        decode_type_info(&mut buf, TypeId::Xml, TypeId::Xml as u8).unwrap();
+        assert_eq!(
+            buf,
+            &[0xFD],
+            "decode must consume exactly the XML_INFO frame"
         );
     }
 

--- a/crates/tds-protocol/src/token.rs
+++ b/crates/tds-protocol/src/token.rs
@@ -228,7 +228,7 @@ pub struct Collation {
     /// contain the primary language ID, and bits 16-19 contain the sort ID
     /// for some collations.
     ///
-    /// For UTF-8 collations (SQL Server 2019+), bit 27 (0x0800_0000) is set.
+    /// For UTF-8 collations (SQL Server 2019+), fUTF8 (bit 26, 0x0400_0000) is set.
     pub lcid: u32,
     /// Sort ID.
     ///


### PR DESCRIPTION
## Summary

Fixes the five Tier-1 correctness findings from the 2026-06-11 full-project review: the UTF-8 collation flag bit, UDT/schema-bound-XML metadata parsing, pool semaphore permit inflation, DATETIMEOFFSET UTC/local inversion, and a fail-fast gate for unwired FEDAUTH (Azure AD / certificate) credentials. One commit per issue.

## Linked issues

Closes #151
Closes #152
Closes #153
Closes #154
Closes #159

Refs #155 (full FEDAUTH implementation — the #159 commit adds the stopgap gate and corrects the docs that claimed Azure AD was implemented).

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Test plan

- [x] `cargo nextest run --workspace` — 814 passed, 0 failed (247 live-gated skipped)
- [x] `cargo test --workspace --doc` passes
- [x] `cargo clippy --workspace --all-targets` clean (default features; CI covers `--all-features` on Linux)
- [x] `cargo fmt --all --check` clean
- [x] New or updated tests cover each change:
  - collation: corrected the two tests that asserted the wrong bit + regression assertion that FRESERVEDBIT (bit 27) is not treated as UTF-8
  - UDT/XML: wire-layout tests asserting exact frame consumption for `UDT_INFO` and schema-bound `XML_INFO`
  - pool: live-gated test that a third concurrent checkout still fails with `max_connections=2` after a reap cycle (runs in the CI integration job)
  - datetimeoffset: asymmetric known-wire-bytes tests (12:00+02:00 ⇄ 10:00 UTC time portion) that a symmetric inversion cannot pass
  - FEDAUTH gate: non-live test asserting `connect()` rejects Azure credentials with `Error::Config` naming FEDAUTH and #155
- [ ] Live SQL Server run: not run locally; the CI integration job exercises the pool regression test and the existing 238 live tests. The datetimeoffset and UTF-8 collation fixes would benefit from live round-trip tests against `_UTF8` collation and `datetimeoffset` columns — proposed as follow-ups in #153/#152 if not added here.

## Documentation updates

- [x] Updated rustdoc comments on changed items (collation constants, encode_datetimeoffset, mssql-auth status tables, azure_ad module doc)
- [ ] CHANGELOG.md: intentionally not hand-edited — all commits are conventional `fix:` commits that release-plz picks up; hand-editing [Unreleased] would duplicate them (per RELEASING.md, changelog entries belong to release-plz)
- [x] LIMITATIONS.md: added the FEDAUTH limitation with workarounds; corrected the two rows that listed Azure AD as a validated alternative
- [ ] README.md: no installation/feature/quick-start impact
- [ ] ARCHITECTURE.md: no new architectural decision (ADR-002's `Authentication=` keyword claim is tracked separately in #166)

## Notes for review

- The pool fix (`add_permits` removal) is the one to scrutinize: the invariant is that permits are owned exclusively by checkouts (`PooledConnection._permit`, dropped on checkin; warm-up explicitly drops its permit after pushing to idle; the expired-on-checkout path already declined to add permits). If you can find any path where an idle entry holds a permit, the fix is wrong — I could not.
- The FEDAUTH gate also covers `cert-auth` credentials: `cert_auth.rs` produces `AuthData::FedAuth` like the Azure providers, and nothing in mssql-client consumes `AuthData` at all (issue #159 describes the Azure variants; the certificate variant fails the same way for the same reason).
- DATETIMEOFFSET was fixed in all four sites (live column parser ×2 incl. sql_variant, mssql-types decode/encode, TVP cell encoder) so the driver stays self-consistent while becoming interop-correct.