### PR TITLE
fix!: error on conversion/decode failures instead of substituting NULL or lossy values

### DIFF
--- a/LIMITATIONS.md
+++ b/LIMITATIONS.md
@@ -14,6 +14,7 @@ For supported features, see [README.md](README.md).
 | Protocol | Named Pipes / Shared Memory | Use TCP/IP |
 | Protocol | True LOB Streaming | Chunked reads via SQL |
 | Protocol | Server-Side Cursors | Use OFFSET/FETCH pagination |
+| Data Types | NUMERIC/DECIMAL beyond 28-29 significant digits | CAST to narrower NUMERIC, FLOAT, or VARCHAR |
 | Data Types | GEOMETRY, GEOGRAPHY | Use `STAsText()` or `STAsGeoJSON()` |
 | Data Types | HIERARCHYID | Use `.ToString()` |
 | Data Types | CLR UDTs | Cast to VARBINARY |
@@ -142,6 +143,25 @@ live validation lands.
 
 **Workaround:** SQL authentication and cross-platform NTLM are the
 validated paths.
+
+---
+
+### NUMERIC/DECIMAL Precision Beyond 28-29 Significant Digits
+
+**Status:** Reads error with a descriptive message
+
+SQL Server `NUMERIC`/`DECIMAL` supports up to 38 significant digits;
+[`rust_decimal`] (the `decimal` feature's backing type) holds a 96-bit
+mantissa with scale ≤ 28. Reading a value that exceeds that range returns a
+`TypeError` naming the limitation. It is deliberately **not** a silent
+fallback to `f64` (~15-16 significant digits), which would corrupt values
+read, written back, or compared downstream.
+
+[`rust_decimal`]: https://docs.rs/rust_decimal
+
+**Workaround:** `CAST` the column in the query — to a `NUMERIC` precision
+within range, to `FLOAT` if approximate semantics are acceptable, or to
+`VARCHAR` to receive the exact digits as text.
 
 ---
 

--- a/crates/mssql-client/examples/azure_sql.rs
+++ b/crates/mssql-client/examples/azure_sql.rs
@@ -174,8 +174,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     for result in rows {
         let row = result?;
-        let tier: Option<String> = row.try_get(0);
-        let edition: Option<String> = row.try_get(1);
+        let tier: Option<String> = row.try_get(0).expect("tier should decode");
+        let edition: Option<String> = row.try_get(1).expect("edition should decode");
         println!("  Service Tier: {tier:?}");
         println!("  Edition: {edition:?}");
     }

--- a/crates/mssql-client/src/client/params.rs
+++ b/crates/mssql-client/src/client/params.rs
@@ -270,14 +270,25 @@ impl<S: ConnectionState> Client<S> {
         // Encode metadata
         encoder.encode_metadata_with_collation(&mut buf, collation);
 
-        // Encode each row
+        // Encode each row. encode_row takes an infallible closure, so capture
+        // the first cell error and abort the whole conversion — the partially
+        // written buffer is discarded with it.
+        let mut cell_error: Option<Error> = None;
         for row in &tvp_data.rows {
             encoder.encode_row(&mut buf, |row_buf| {
                 for (col_idx, value) in row.iter().enumerate() {
                     let wire_type = &wire_columns[col_idx].wire_type;
-                    Self::encode_tvp_value(value, wire_type, collation, row_buf);
+                    if let Err(e) = Self::encode_tvp_value(value, wire_type, collation, row_buf) {
+                        if cell_error.is_none() {
+                            cell_error = Some(e);
+                        }
+                        break;
+                    }
                 }
             });
+            if let Some(e) = cell_error.take() {
+                return Err(e);
+            }
         }
 
         // Encode end marker
@@ -352,12 +363,21 @@ impl<S: ConnectionState> Client<S> {
     }
 
     /// Encode a single TVP column value.
+    /// Encode one TVP cell.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for values the wire type cannot represent
+    /// (out-of-range MONEY/SMALLMONEY/SMALLDATETIME) and for unsupported
+    /// variants (nested TVPs) — the cell must NOT be silently written as
+    /// NULL: the server cannot tell a substituted NULL from an intentional
+    /// one, so the row would insert wrong data (issue #157).
     fn encode_tvp_value(
         value: &mssql_types::SqlValue,
         wire_type: &TvpWireType,
         collation: Option<&tds_protocol::token::Collation>,
         buf: &mut BytesMut,
-    ) {
+    ) -> Result<()> {
         use mssql_types::SqlValue;
 
         match value {
@@ -413,27 +433,11 @@ impl<S: ConnectionState> Client<S> {
                 // authoritative dispatch key.
                 match wire_type {
                     TvpWireType::Money => {
-                        let scaled = match mssql_types::encode::decimal_to_money_cents_i64(*d) {
-                            Ok(v) => v,
-                            Err(_) => {
-                                // Out-of-range values write NULL so the row
-                                // structure stays intact; the caller can
-                                // pre-validate to reject.
-                                encode_tvp_null(wire_type, buf);
-                                return;
-                            }
-                        };
+                        let scaled = mssql_types::encode::decimal_to_money_cents_i64(*d)?;
                         encode_tvp_money(scaled, buf);
                     }
                     TvpWireType::SmallMoney => {
-                        let scaled = match mssql_types::encode::decimal_to_smallmoney_cents_i32(*d)
-                        {
-                            Ok(v) => v,
-                            Err(_) => {
-                                encode_tvp_null(wire_type, buf);
-                                return;
-                            }
-                        };
+                        let scaled = mssql_types::encode::decimal_to_smallmoney_cents_i32(*d)?;
                         encode_tvp_smallmoney(scaled, buf);
                     }
                     _ => {
@@ -480,14 +484,9 @@ impl<S: ConnectionState> Client<S> {
                         encode_tvp_datetime(days, ticks, buf);
                     }
                     TvpWireType::SmallDateTime => {
-                        match mssql_types::encode::datetime_to_smalldatetime_days_minutes(*dt) {
-                            Ok((days, minutes)) => {
-                                encode_tvp_smalldatetime(days, minutes, buf);
-                            }
-                            Err(_) => {
-                                encode_tvp_null(wire_type, buf);
-                            }
-                        }
+                        let (days, minutes) =
+                            mssql_types::encode::datetime_to_smalldatetime_days_minutes(*dt)?;
+                        encode_tvp_smalldatetime(days, minutes, buf);
                     }
                     _ => {
                         use chrono::Timelike;
@@ -545,13 +544,75 @@ impl<S: ConnectionState> Client<S> {
                 encode_tvp_nvarchar(s, 0xFFFF, buf);
             }
             SqlValue::Tvp(_) => {
-                // Nested TVPs are not supported
-                encode_tvp_null(wire_type, buf);
+                return Err(mssql_types::TypeError::UnsupportedConversion {
+                    from: "TVP".to_string(),
+                    to: "TVP cell (nested TVPs are not supported)",
+                }
+                .into());
             }
-            // Handle future SqlValue variants as NULL
-            _ => {
-                encode_tvp_null(wire_type, buf);
+            // Future SqlValue variants must error, not silently become NULL.
+            other => {
+                return Err(mssql_types::TypeError::UnsupportedConversion {
+                    from: other.type_name().to_string(),
+                    to: "TVP cell",
+                }
+                .into());
             }
         }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use crate::state::Ready;
+    use mssql_types::SqlValue;
+    use tds_protocol::tvp::TvpWireType;
+
+    /// Issue #157 regression: TVP cells whose value the wire type cannot
+    /// represent must error — previously they were silently written as NULL,
+    /// inserting wrong data the server cannot distinguish from intentional
+    /// NULLs.
+    #[cfg(feature = "decimal")]
+    #[test]
+    fn tvp_out_of_range_money_cell_errors_instead_of_null() {
+        let mut buf = BytesMut::new();
+        let err = Client::<Ready>::encode_tvp_value(
+            &SqlValue::Money(rust_decimal::Decimal::MAX),
+            &TvpWireType::Money,
+            None,
+            &mut buf,
+        )
+        .expect_err("out-of-range MONEY must error");
+        assert!(
+            !err.to_string().is_empty(),
+            "error must be descriptive: {err}"
+        );
+
+        let mut buf = BytesMut::new();
+        Client::<Ready>::encode_tvp_value(
+            &SqlValue::SmallMoney(rust_decimal::Decimal::MAX),
+            &TvpWireType::SmallMoney,
+            None,
+            &mut buf,
+        )
+        .expect_err("out-of-range SMALLMONEY must error");
+    }
+
+    /// Issue #157 regression: unsupported variants (nested TVPs) must error,
+    /// not silently encode NULL.
+    #[test]
+    fn tvp_nested_tvp_cell_errors_instead_of_null() {
+        let nested = mssql_types::TvpData::new("dbo", "Inner");
+        let mut buf = BytesMut::new();
+        Client::<Ready>::encode_tvp_value(
+            &SqlValue::Tvp(Box::new(nested)),
+            &TvpWireType::Int { size: 4 },
+            None,
+            &mut buf,
+        )
+        .expect_err("nested TVP cell must error");
     }
 }

--- a/crates/mssql-client/src/column_parser.rs
+++ b/crates/mssql-client/src/column_parser.rs
@@ -436,9 +436,11 @@ pub fn parse_column_value(buf: &mut &[u8], col: &ColumnData) -> Result<SqlValue>
                 {
                     use rust_decimal::Decimal;
                     // rust_decimal holds 96-bit mantissas with scale <= 28;
-                    // SQL Server NUMERIC goes to 38 digits, so wire values
-                    // (legitimate or hostile) can exceed both limits. Fall
-                    // back to f64 rather than panic.
+                    // SQL Server NUMERIC goes to 38 digits, so legitimate
+                    // wire values can exceed it. That must be an error, not
+                    // a silent fall back to f64 (~15-16 significant digits):
+                    // a lossy value read, written back, or compared
+                    // downstream corrupts data (issue #157).
                     let decimal = i128::try_from(mantissa)
                         .ok()
                         .and_then(|m| Decimal::try_from_i128_with_scale(m, scale).ok());
@@ -450,10 +452,12 @@ pub fn parse_column_value(buf: &mut &[u8], col: &ColumnData) -> Result<SqlValue>
                             SqlValue::Decimal(decimal)
                         }
                         None => {
-                            let divisor = 10f64.powi(scale as i32);
-                            let value = (mantissa as f64) / divisor;
-                            let value = if sign == 0 { -value } else { value };
-                            SqlValue::Double(value)
+                            return Err(mssql_types::TypeError::InvalidDecimal(format!(
+                                "NUMERIC value (mantissa {mantissa}, scale {scale}) exceeds \
+                                 rust_decimal's 96-bit/scale-28 range; CAST the column to a \
+                                 narrower NUMERIC, FLOAT, or VARCHAR in the query"
+                            ))
+                            .into());
                         }
                     }
                 }
@@ -1291,12 +1295,12 @@ fn parse_sql_variant(buf: &mut &[u8]) -> Result<SqlValue> {
                         }
                         Ok(SqlValue::Decimal(decimal))
                     }
-                    None => {
-                        let divisor = 10f64.powi(scale as i32);
-                        let value = (mantissa as f64) / divisor;
-                        let value = if sign == 0 { -value } else { value };
-                        Ok(SqlValue::Double(value))
-                    }
+                    None => Err(mssql_types::TypeError::InvalidDecimal(format!(
+                        "NUMERIC value in sql_variant (mantissa {mantissa}, scale {scale}) \
+                         exceeds rust_decimal's 96-bit/scale-28 range; CAST the column to a \
+                         narrower NUMERIC, FLOAT, or VARCHAR in the query"
+                    ))
+                    .into()),
                 }
             }
             #[cfg(not(feature = "decimal"))]
@@ -1903,10 +1907,12 @@ mod tests {
 
     #[cfg(feature = "decimal")]
     #[test]
-    fn hostile_variant_decimal_over_96bit_is_not_panic() {
+    fn hostile_variant_decimal_over_96bit_is_error_not_panic() {
         // SQL_VARIANT DECIMALN (0x6A) with a 16-byte mantissa above 2^96.
-        // rust_decimal cannot hold it; must fall back to f64, never panic
-        // (a legitimate 38-digit NUMERIC inside a variant reaches this too).
+        // rust_decimal cannot hold it; this must be a descriptive error,
+        // never a panic — and never a silent f64 fallback, which corrupted
+        // legitimate 38-digit NUMERIC values down to ~15-16 significant
+        // digits (issue #157).
         // total_len=21: base_type + prop_count + precision + scale + sign(1)
         // + mantissa(16) = 2 + 2 + 17.
         let mantissa = 1u128 << 100;
@@ -1919,9 +1925,11 @@ mod tests {
         data.push(0x01); // sign (positive)
         data.extend_from_slice(&mantissa.to_le_bytes());
         let mut buf: &[u8] = &data;
-        // Must not panic; an oversized mantissa decodes to a Double fallback.
-        let value = parse_sql_variant(&mut buf).expect("must not error");
-        assert!(matches!(value, SqlValue::Double(_)));
+        let err = parse_sql_variant(&mut buf).expect_err("oversized NUMERIC must error");
+        assert!(
+            err.to_string().contains("rust_decimal"),
+            "error should explain the range limitation: {err}"
+        );
     }
 
     #[cfg(feature = "chrono")]

--- a/crates/mssql-client/src/procedure.rs
+++ b/crates/mssql-client/src/procedure.rs
@@ -50,7 +50,7 @@
 use tds_protocol::rpc::{RpcParam, RpcRequest, TypeInfo as RpcTypeInfo};
 
 use crate::client::Client;
-use crate::error::Result;
+use crate::error::{Error, Result};
 use crate::state::ConnectionState;
 use crate::stream::ProcedureResult;
 
@@ -80,6 +80,9 @@ pub struct ProcedureBuilder<'a, S: ConnectionState> {
     client: &'a mut Client<S>,
     proc_name: String,
     params: Vec<RpcParam>,
+    /// First parameter-conversion failure, surfaced by `execute()`. Kept as
+    /// a field so `input()` stays chainable.
+    deferred_error: Option<Error>,
 }
 
 impl<'a, S: ConnectionState> ProcedureBuilder<'a, S> {
@@ -91,6 +94,7 @@ impl<'a, S: ConnectionState> ProcedureBuilder<'a, S> {
             client,
             proc_name: proc_name.to_string(),
             params: Vec::new(),
+            deferred_error: None,
         }
     }
 
@@ -112,7 +116,10 @@ impl<'a, S: ConnectionState> ProcedureBuilder<'a, S> {
     /// ```
     pub fn input(&mut self, name: &str, value: &(dyn crate::ToSql + Sync)) -> &mut Self {
         // Use the shared conversion logic from params.rs.
-        // If conversion fails, the error is deferred to execute().
+        // If conversion fails, the error is deferred to execute() — the call
+        // must NOT proceed with a substituted value: the server cannot tell
+        // a placeholder apart from an intentional NULL, so the procedure
+        // would silently run with wrong data (issue #157).
         match Client::<S>::convert_single_param(
             name,
             value,
@@ -122,10 +129,9 @@ impl<'a, S: ConnectionState> ProcedureBuilder<'a, S> {
             Ok(param) => self.params.push(param),
             Err(e) => {
                 tracing::warn!(name = name, error = %e, "failed to convert input parameter");
-                // Store a null placeholder so parameter ordering is preserved.
-                // The error will surface if the server rejects the call.
-                self.params
-                    .push(RpcParam::null(name, RpcTypeInfo::nvarchar(1)));
+                if self.deferred_error.is_none() {
+                    self.deferred_error = Some(e);
+                }
             }
         }
         self
@@ -218,7 +224,16 @@ impl<'a, S: ConnectionState> ProcedureBuilder<'a, S> {
     /// Sends an RPC request to SQL Server with the accumulated parameters
     /// and reads the complete response including result sets, output
     /// parameters, and the procedure return value.
+    ///
+    /// # Errors
+    ///
+    /// Returns the first parameter-conversion error from [`input`](Self::input)
+    /// before anything is sent — the procedure is never called with a
+    /// substituted value.
     pub async fn execute(&mut self) -> Result<ProcedureResult> {
+        if let Some(e) = self.deferred_error.take() {
+            return Err(e);
+        }
         let mut rpc = RpcRequest::named(&self.proc_name);
         for param in self.params.drain(..) {
             rpc = rpc.param(param);

--- a/crates/mssql-client/src/row.rs
+++ b/crates/mssql-client/src/row.rs
@@ -570,28 +570,52 @@ impl Row {
         self.get(index)
     }
 
-    /// Try to get a value by column index, returning None if NULL or not found.
-    pub fn try_get<T: FromSql>(&self, index: usize) -> Option<T> {
+    /// Try to get a value by column index.
+    ///
+    /// Returns `Ok(None)` when the column is NULL or the index is out of
+    /// bounds. Decode and conversion failures are errors — they were
+    /// previously swallowed as `None`, which made a type mismatch on a
+    /// nullable column silently read as NULL (issue #157).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TypeError`] if the column value cannot be decoded or
+    /// converted to `T`.
+    pub fn try_get<T: FromSql>(&self, index: usize) -> Result<Option<T>, TypeError> {
         // If we have cached values, use them
         if let Some(ref values) = self.values {
-            return values
-                .get(index)
-                .and_then(|v| T::from_sql_nullable(v).ok().flatten());
+            return match values.get(index) {
+                Some(v) => T::from_sql_nullable(v),
+                None => Ok(None),
+            };
         }
 
         // Otherwise check the slice
-        let slice = self.slices.get(index)?;
+        let Some(slice) = self.slices.get(index) else {
+            return Ok(None);
+        };
         if slice.is_null {
-            return None;
+            return Ok(None);
         }
 
-        self.get(index).ok()
+        self.get(index).map(Some)
     }
 
-    /// Try to get a value by column name, returning None if NULL or not found.
-    pub fn try_get_by_name<T: FromSql>(&self, name: &str) -> Option<T> {
-        let index = self.metadata.find_by_name(name)?;
-        self.try_get(index)
+    /// Try to get a value by column name.
+    ///
+    /// Returns `Ok(None)` when the column is NULL or no column with this
+    /// name exists. Decode and conversion failures are errors — see
+    /// [`try_get`](Self::try_get).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TypeError`] if the column value cannot be decoded or
+    /// converted to `T`.
+    pub fn try_get_by_name<T: FromSql>(&self, name: &str) -> Result<Option<T>, TypeError> {
+        match self.metadata.find_by_name(name) {
+            Some(index) => self.try_get(index),
+            None => Ok(None),
+        }
     }
 
     // ========================================================================
@@ -758,7 +782,7 @@ impl<'a> IntoIterator for &'a Row {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 
@@ -866,6 +890,38 @@ mod tests {
         assert_eq!(row.columns().len(), 1);
         assert_eq!(row.columns()[0].name, "col1");
         assert_eq!(row.metadata().len(), 1);
+    }
+
+    /// Issue #157 regression: `try_get` must distinguish SQL NULL (Ok(None))
+    /// from a decode/conversion failure (Err). Previously both collapsed to
+    /// `None`, so a type mismatch on a nullable column silently read as NULL.
+    #[test]
+    fn test_try_get_distinguishes_null_from_conversion_error() {
+        let columns = vec![Column::new("a", 0, "NVARCHAR"), Column::new("b", 1, "INT")];
+        let row = Row::from_values(
+            columns,
+            vec![SqlValue::String("not a number".into()), SqlValue::Null],
+        );
+
+        // NULL → Ok(None)
+        let b: Option<i32> = row.try_get(1).expect("NULL must be Ok(None)");
+        assert!(b.is_none());
+
+        // Missing column/index → Ok(None) (lenient lookup is unchanged)
+        let missing: Option<i32> = row.try_get(9).expect("missing index must be Ok(None)");
+        assert!(missing.is_none());
+        let missing: Option<i32> = row
+            .try_get_by_name("no_such_column")
+            .expect("missing name must be Ok(None)");
+        assert!(missing.is_none());
+
+        // Conversion failure → Err, NOT Ok(None)
+        assert!(row.try_get::<i32>(0).is_err());
+        assert!(row.try_get_by_name::<i32>("a").is_err());
+
+        // The successful typed read still works
+        let a: Option<String> = row.try_get(0).expect("string read must succeed");
+        assert_eq!(a.as_deref(), Some("not a number"));
     }
 
     #[test]

--- a/crates/mssql-client/tests/bulk_insert.rs
+++ b/crates/mssql-client/tests/bulk_insert.rs
@@ -285,7 +285,13 @@ async fn test_bulk_insert_null_values() {
 
     let data: Vec<(i32, Option<String>, Option<i32>)> = rows
         .filter_map(|r| r.ok())
-        .map(|row| (row.get(0).unwrap(), row.try_get(1), row.try_get(2)))
+        .map(|row| {
+            (
+                row.get(0).unwrap(),
+                row.try_get(1).unwrap(),
+                row.try_get(2).unwrap(),
+            )
+        })
         .collect();
 
     assert_eq!(data.len(), 4);

--- a/crates/mssql-client/tests/integration.rs
+++ b/crates/mssql-client/tests/integration.rs
@@ -2809,7 +2809,7 @@ async fn test_data_type_date() {
 
     for result in rows {
         let row = result.expect("Row should be valid");
-        let date: Option<NaiveDate> = row.try_get(0);
+        let date: Option<NaiveDate> = row.try_get(0).expect("date should decode");
         assert!(date.is_none(), "Should be NULL");
     }
 
@@ -2846,7 +2846,7 @@ async fn test_data_type_xml() {
 
     for result in rows {
         let row = result.expect("Row should be valid");
-        let xml: Option<String> = row.try_get(0);
+        let xml: Option<String> = row.try_get(0).expect("xml should decode");
         assert!(xml.is_none(), "Should be NULL");
     }
 
@@ -2962,28 +2962,46 @@ async fn test_data_type_decimal_high_scale() {
     let config = get_test_config().expect("SQL Server config required");
     let mut client = Client::connect(config).await.expect("Failed to connect");
 
-    // Test high-scale DECIMAL - was causing hang before fix
-    // rust_decimal supports max scale of 28, so scale 30+ falls back to f64
-    let rows = client
+    // High-scale DECIMAL — originally caused a hang; then silently degraded
+    // to f64. Since #157, values beyond rust_decimal's 96-bit/scale-28 range
+    // must surface a descriptive error rather than lose precision silently.
+    // The error may surface at query() or at row decode depending on where
+    // the response is parsed — accept either, but never a silent value.
+    let mut saw_range_error = false;
+    match client
         .query(
             "SELECT CAST(123456.123456789012345678901234567890 AS DECIMAL(38,30)) AS high_scale",
             &[],
         )
         .await
-        .expect("High-scale DECIMAL query failed - driver may have hung");
-
-    for result in rows {
-        let row = result.expect("Row should be valid");
-        // With scale > 28, we fall back to f64
-        let value: f64 = row.get(0).expect("Should get high-scale decimal as f64");
-        // Check approximate value (f64 won't have full precision)
-        assert!(
-            (value - 123456.123456789).abs() < 0.001,
-            "Value should be approximately correct: {value}"
-        );
+    {
+        Err(e) => {
+            assert!(
+                e.to_string().contains("rust_decimal"),
+                "error should explain the range limitation: {e}"
+            );
+            saw_range_error = true;
+        }
+        Ok(rows) => {
+            for result in rows {
+                let err = result.expect_err(
+                    "DECIMAL(38,30) beyond rust_decimal range must error, not decode silently",
+                );
+                assert!(
+                    err.to_string().contains("rust_decimal"),
+                    "error should explain the range limitation: {err}"
+                );
+                saw_range_error = true;
+            }
+        }
     }
+    assert!(
+        saw_range_error,
+        "the out-of-range DECIMAL must produce an error somewhere"
+    );
 
-    // Test normal scale DECIMAL still works with rust_decimal
+    // Normal scale DECIMAL still works — this also proves the connection
+    // remains usable after the decode error above.
     let rows = client
         .query(
             "SELECT CAST(123.456789 AS DECIMAL(18,6)) AS normal_scale",
@@ -3205,7 +3223,7 @@ async fn test_data_type_sql_variant() {
 
     for result in rows {
         let row = result.expect("Row should be valid");
-        let value: Option<i32> = row.try_get(0);
+        let value: Option<i32> = row.try_get(0).expect("value should decode");
         assert!(value.is_none(), "Should be NULL");
     }
 

--- a/crates/mssql-derive/src/from_row.rs
+++ b/crates/mssql-derive/src/from_row.rs
@@ -61,21 +61,26 @@ pub(crate) fn impl_from_row(input: &DeriveInput) -> syn::Result<TokenStream2> {
         });
 
         if config.default {
-            // Use try_get_by_name which returns Option, fallback to Default
+            // try_get_by_name returns Ok(None) for NULL/missing columns
+            // (fallback to Default) but propagates decode/conversion errors —
+            // a type mismatch must not silently become the default value.
             if is_option_type(field_type) {
                 field_extractions.push(quote! {
                     #field_name: row.try_get_by_name(#column_name)
+                        .map_err(mssql_client::Error::from)?
                 });
             } else {
                 field_extractions.push(quote! {
                     #field_name: row.try_get_by_name(#column_name)
+                        .map_err(mssql_client::Error::from)?
                         .unwrap_or_else(::std::default::Default::default)
                 });
             }
         } else if is_option_type(field_type) {
-            // Option types use try_get which handles NULL gracefully
+            // Option types map NULL to None but propagate decode errors
             field_extractions.push(quote! {
                 #field_name: row.try_get_by_name(#column_name)
+                    .map_err(mssql_client::Error::from)?
             });
         } else {
             // Required fields use get_by_name which returns Result

--- a/crates/tds-protocol/src/crypto.rs
+++ b/crates/tds-protocol/src/crypto.rs
@@ -331,9 +331,11 @@ impl CryptoMetadata {
         let base_user_type = src.get_u32_le();
         let base_col_type = src.get_u8();
 
-        // Parse base type info using the shared decoder from token.rs
-        let base_type_id =
-            crate::types::TypeId::from_u8(base_col_type).unwrap_or(crate::types::TypeId::Null);
+        // Parse base type info using the shared decoder from token.rs. An
+        // unknown base type byte must be a hard error: defaulting to Null
+        // (zero-length) misaligns the rest of the metadata (issue #157).
+        let base_type_id = crate::types::TypeId::from_u8(base_col_type)
+            .ok_or(ProtocolError::InvalidDataType(base_col_type))?;
         let base_type_info = crate::token::decode_type_info(src, base_type_id, base_col_type)?;
 
         // algorithm_id (1) + encryption_type (1) + normalization_version (1) = 3

--- a/crates/tds-protocol/src/token.rs
+++ b/crates/tds-protocol/src/token.rs
@@ -864,7 +864,10 @@ impl ColMetaData {
         let flags = src.get_u16_le();
         let col_type = src.get_u8();
 
-        let type_id = TypeId::from_u8(col_type).unwrap_or(TypeId::Null); // Default to Null for unknown types
+        // An unknown type byte must be a hard error: treating it as Null (a
+        // zero-length column) misaligns every subsequent column and row,
+        // producing plausible garbage values (issue #157).
+        let type_id = TypeId::from_u8(col_type).ok_or(ProtocolError::InvalidDataType(col_type))?;
 
         // Parse type-specific metadata
         let type_info = decode_type_info(src, type_id, col_type)?;
@@ -937,7 +940,7 @@ impl ColMetaData {
         let flags = src.get_u16_le();
         let col_type = src.get_u8();
 
-        let type_id = TypeId::from_u8(col_type).unwrap_or(TypeId::Null);
+        let type_id = TypeId::from_u8(col_type).ok_or(ProtocolError::InvalidDataType(col_type))?;
 
         // Parse type-specific metadata (for encrypted columns, this is the transport type)
         let type_info = decode_type_info(src, type_id, col_type)?;
@@ -1477,7 +1480,7 @@ impl ReturnValue {
         let flags = src.get_u16_le();
         let col_type = src.get_u8();
 
-        let type_id = TypeId::from_u8(col_type).unwrap_or(TypeId::Null);
+        let type_id = TypeId::from_u8(col_type).ok_or(ProtocolError::InvalidDataType(col_type))?;
 
         // Parse type info
         let type_info = decode_type_info(src, type_id, col_type)?;


### PR DESCRIPTION
## Summary

Closes the silent-NULL-substitution cluster from the 2026-06 review (#157): five paths that replaced failed conversions/decodes with NULL, None, or lossy f64 values now surface errors. A database driver must never send or report a value the caller didn't produce.

## Linked issues

Closes #157

## Type of change

- [x] Bug fix
- [x] Breaking change (see below)

## Test plan

- [x] `cargo clippy --all-features --all-targets -- -D warnings` clean (exit code verified, not piped)
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo nextest run --workspace --all-features` — 837 passed
- [x] All-features doctests pass
- [x] Exact CI integration invocation against local `mssql/server:2022-latest` — **239/239 passed**
- [x] New/updated tests:
  - `try_get` matrix test: NULL→Ok(None), missing column→Ok(None), type mismatch→Err
  - TVP out-of-range MONEY/SMALLMONEY and nested-TVP cells → Err
  - sql_variant oversized NUMERIC: was asserting the f64 fallback, now asserts a descriptive error
  - live `test_data_type_decimal_high_scale`: rewritten — DECIMAL(38,30) must error (it pinned the silent-f64 behavior), and the connection stays usable afterward

## Documentation updates

- [x] Rustdoc: `# Errors` sections on `try_get`/`try_get_by_name`/`execute`/`encode_tvp_value`
- [x] LIMITATIONS.md: new NUMERIC/DECIMAL precision section + quick-reference row (the gap was undisclosed)
- [ ] CHANGELOG: via release-plz from the `fix(client)!:` commit

## Breaking changes

### What breaks

1. `Row::try_get` / `Row::try_get_by_name` return `Result<Option<T>, TypeError>` instead of `Option<T>`. NULL and missing columns are `Ok(None)` (so `#[mssql(default)]` semantics are preserved); decode/conversion failures are now `Err`.
2. Reading NUMERIC/DECIMAL beyond rust_decimal's 96-bit/scale-28 range errors instead of silently degrading to f64.
3. `ProcedureBuilder::execute()` now fails (before sending) if any `input()` conversion failed, instead of calling the procedure with NULL.
4. TVP encoding fails on out-of-range cells instead of writing NULL.

### Migration guide

```rust
// Before (0.12.x):
let v: Option<i32> = row.try_get(0);

// After:
let v: Option<i32> = row.try_get(0)?;   // decode failures now visible
```
For NUMERIC > 28-29 digits: `CAST` the column to a narrower NUMERIC, FLOAT, or VARCHAR in the query (see LIMITATIONS.md).

## Notes for review

- `#[derive(FromRow)]` codegen updated: `Option<T>` and `#[mssql(default)]` fields propagate decode errors via `?` instead of mapping them to None/default. Missing-column leniency is intact.
- Unknown type bytes in COLMETADATA/RETURNVALUE/crypto metadata now return `ProtocolError::InvalidDataType(byte)` — combined with #160 (terminal classification, PR #170) these are hard errors, not retry storms.
- Observed but left alone per scope: the money decode path at `column_parser.rs:250` has an analogous Decimal→f64 fallback for out-of-range cents (exact for |cents| < 2^53, lossy above); flagging for a follow-up rather than bundling it here — it can be folded into #167 triage.