### PR TITLE
fix: cancel queries on timeout via ATTENTION and enforce command_timeout

### DIFF
--- a/crates/mssql-client/src/client.rs
+++ b/crates/mssql-client/src/client.rs
@@ -35,7 +35,6 @@ use tds_protocol::packet::PacketType;
 use tds_protocol::rpc::RpcRequest;
 use tds_protocol::token::{EnvChange, EnvChangeType};
 use tokio::net::TcpStream;
-use tokio::time::timeout;
 
 use crate::config::Config;
 use crate::error::{Error, Result};
@@ -45,6 +44,39 @@ use crate::state::{ConnectionState, InTransaction, Ready};
 use crate::statement_cache::StatementCache;
 use crate::stream::{MultiResultStream, QueryStream};
 use crate::transaction::SavePoint;
+
+/// Run a network future under an optional command deadline.
+///
+/// On timeout this sends an Attention packet via `canceller` and then awaits
+/// the future so its own read loop drains the server's DONE_ATTN
+/// acknowledgement, leaving the connection clean before returning
+/// [`Error::CommandTimeout`]. This is the cancel-safe alternative to dropping
+/// the future (e.g. via `tokio::time::timeout`), which would leave unconsumed
+/// TDS data in the connection buffer and desync the next request.
+async fn run_with_deadline<F, T>(
+    fut: F,
+    deadline: Option<std::time::Duration>,
+    canceller: crate::cancel::CancelHandle,
+) -> Result<T>
+where
+    F: std::future::Future<Output = Result<T>>,
+{
+    let Some(d) = deadline else {
+        return fut.await;
+    };
+    tokio::pin!(fut);
+    tokio::select! {
+        biased;
+        res = &mut fut => res,
+        () = tokio::time::sleep(d) => {
+            // Signal cancellation, then let the in-flight read consume the
+            // server's attention acknowledgement so the connection stays usable.
+            let _ = canceller.cancel().await;
+            let _ = fut.await;
+            Err(Error::CommandTimeout)
+        }
+    }
+}
 
 /// SQL Server client with type-state connection management.
 ///
@@ -105,6 +137,15 @@ enum ConnectionHandle {
 
 // Private helper methods available to all connection states
 impl<S: ConnectionState> Client<S> {
+    /// The default per-command deadline from `command_timeout`.
+    ///
+    /// Returns `None` when `command_timeout` is zero, which means "no limit"
+    /// (matching ADO.NET's `SqlCommand.CommandTimeout = 0`).
+    fn command_deadline(&self) -> Option<std::time::Duration> {
+        let t = self.config.command_timeout;
+        if t.is_zero() { None } else { Some(t) }
+    }
+
     /// Process transaction-related EnvChange tokens.
     ///
     /// This handles BeginTransaction, CommitTransaction, and RollbackTransaction
@@ -677,6 +718,17 @@ impl Client<Ready> {
         sql: &str,
         params: &[&(dyn crate::ToSql + Sync)],
     ) -> Result<QueryStream<'a>> {
+        let deadline = self.command_deadline();
+        self.query_inner(sql, params, deadline).await
+    }
+
+    /// Shared query implementation with an explicit command deadline.
+    async fn query_inner<'a>(
+        &'a mut self,
+        sql: &str,
+        params: &[&(dyn crate::ToSql + Sync)],
+        deadline: Option<std::time::Duration>,
+    ) -> Result<QueryStream<'a>> {
         tracing::debug!(sql = sql, params_count = params.len(), "executing query");
 
         #[cfg(feature = "otel")]
@@ -688,21 +740,26 @@ impl Client<Ready> {
             crate::instrumentation::extract_operation(sql),
         );
 
-        let result = async {
-            if params.is_empty() {
-                // Simple query without parameters - use SQL batch
-                self.send_sql_batch(sql).await?;
-            } else {
-                // Parameterized query - use sp_executesql via RPC
-                let rpc_params =
-                    Self::convert_params(params, self.send_unicode(), self.server_collation())?;
-                let rpc = RpcRequest::execute_sql(sql, rpc_params);
-                self.send_rpc(&rpc).await?;
-            }
+        let canceller = self.cancel_handle();
+        let result = run_with_deadline(
+            async {
+                if params.is_empty() {
+                    // Simple query without parameters - use SQL batch
+                    self.send_sql_batch(sql).await?;
+                } else {
+                    // Parameterized query - use sp_executesql via RPC
+                    let rpc_params =
+                        Self::convert_params(params, self.send_unicode(), self.server_collation())?;
+                    let rpc = RpcRequest::execute_sql(sql, rpc_params);
+                    self.send_rpc(&rpc).await?;
+                }
 
-            // Read complete response including columns and rows
-            self.read_query_response().await
-        }
+                // Read complete response including columns and rows
+                self.read_query_response().await
+            },
+            deadline,
+            canceller,
+        )
         .await;
 
         #[cfg(feature = "otel")]
@@ -741,7 +798,9 @@ impl Client<Ready> {
     ///
     /// This overrides the default `command_timeout` from the connection configuration
     /// for this specific query. If the query does not complete within the specified
-    /// duration, an error is returned.
+    /// duration, the driver sends an Attention packet to cancel it server-side,
+    /// drains the acknowledgement, and returns [`Error::CommandTimeout`] with the
+    /// connection left usable for the next request.
     ///
     /// # Arguments
     ///
@@ -773,9 +832,7 @@ impl Client<Ready> {
         params: &[&(dyn crate::ToSql + Sync)],
         timeout_duration: std::time::Duration,
     ) -> Result<QueryStream<'a>> {
-        timeout(timeout_duration, self.query(sql, params))
-            .await
-            .map_err(|_| Error::CommandTimeout)?
+        self.query_inner(sql, params, Some(timeout_duration)).await
     }
 
     /// Execute a batch that may return multiple result sets.
@@ -842,6 +899,17 @@ impl Client<Ready> {
         sql: &str,
         params: &[&(dyn crate::ToSql + Sync)],
     ) -> Result<u64> {
+        let deadline = self.command_deadline();
+        self.execute_inner(sql, params, deadline).await
+    }
+
+    /// Shared execute implementation with an explicit command deadline.
+    async fn execute_inner(
+        &mut self,
+        sql: &str,
+        params: &[&(dyn crate::ToSql + Sync)],
+        deadline: Option<std::time::Duration>,
+    ) -> Result<u64> {
         tracing::debug!(
             sql = sql,
             params_count = params.len(),
@@ -857,21 +925,26 @@ impl Client<Ready> {
             crate::instrumentation::extract_operation(sql),
         );
 
-        let result = async {
-            if params.is_empty() {
-                // Simple statement without parameters - use SQL batch
-                self.send_sql_batch(sql).await?;
-            } else {
-                // Parameterized statement - use sp_executesql via RPC
-                let rpc_params =
-                    Self::convert_params(params, self.send_unicode(), self.server_collation())?;
-                let rpc = RpcRequest::execute_sql(sql, rpc_params);
-                self.send_rpc(&rpc).await?;
-            }
+        let canceller = self.cancel_handle();
+        let result = run_with_deadline(
+            async {
+                if params.is_empty() {
+                    // Simple statement without parameters - use SQL batch
+                    self.send_sql_batch(sql).await?;
+                } else {
+                    // Parameterized statement - use sp_executesql via RPC
+                    let rpc_params =
+                        Self::convert_params(params, self.send_unicode(), self.server_collation())?;
+                    let rpc = RpcRequest::execute_sql(sql, rpc_params);
+                    self.send_rpc(&rpc).await?;
+                }
 
-            // Read response and get row count
-            self.read_execute_result().await
-        }
+                // Read response and get row count
+                self.read_execute_result().await
+            },
+            deadline,
+            canceller,
+        )
         .await;
 
         #[cfg(feature = "otel")]
@@ -893,7 +966,9 @@ impl Client<Ready> {
     ///
     /// This overrides the default `command_timeout` from the connection configuration
     /// for this specific statement. If the statement does not complete within the
-    /// specified duration, an error is returned.
+    /// specified duration, the driver sends an Attention packet to cancel it
+    /// server-side, drains the acknowledgement, and returns
+    /// [`Error::CommandTimeout`] with the connection left usable.
     ///
     /// # Arguments
     ///
@@ -925,9 +1000,8 @@ impl Client<Ready> {
         params: &[&(dyn crate::ToSql + Sync)],
         timeout_duration: std::time::Duration,
     ) -> Result<u64> {
-        timeout(timeout_duration, self.execute(sql, params))
+        self.execute_inner(sql, params, Some(timeout_duration))
             .await
-            .map_err(|_| Error::CommandTimeout)?
     }
 
     /// Begin a transaction.
@@ -1233,6 +1307,17 @@ impl Client<InTransaction> {
         sql: &str,
         params: &[&(dyn crate::ToSql + Sync)],
     ) -> Result<QueryStream<'a>> {
+        let deadline = self.command_deadline();
+        self.query_inner(sql, params, deadline).await
+    }
+
+    /// Shared query implementation with an explicit command deadline.
+    async fn query_inner<'a>(
+        &'a mut self,
+        sql: &str,
+        params: &[&(dyn crate::ToSql + Sync)],
+        deadline: Option<std::time::Duration>,
+    ) -> Result<QueryStream<'a>> {
         tracing::debug!(
             sql = sql,
             params_count = params.len(),
@@ -1248,21 +1333,26 @@ impl Client<InTransaction> {
             crate::instrumentation::extract_operation(sql),
         );
 
-        let result = async {
-            if params.is_empty() {
-                // Simple query without parameters - use SQL batch
-                self.send_sql_batch(sql).await?;
-            } else {
-                // Parameterized query - use sp_executesql via RPC
-                let rpc_params =
-                    Self::convert_params(params, self.send_unicode(), self.server_collation())?;
-                let rpc = RpcRequest::execute_sql(sql, rpc_params);
-                self.send_rpc(&rpc).await?;
-            }
+        let canceller = self.cancel_handle();
+        let result = run_with_deadline(
+            async {
+                if params.is_empty() {
+                    // Simple query without parameters - use SQL batch
+                    self.send_sql_batch(sql).await?;
+                } else {
+                    // Parameterized query - use sp_executesql via RPC
+                    let rpc_params =
+                        Self::convert_params(params, self.send_unicode(), self.server_collation())?;
+                    let rpc = RpcRequest::execute_sql(sql, rpc_params);
+                    self.send_rpc(&rpc).await?;
+                }
 
-            // Read complete response including columns and rows
-            self.read_query_response().await
-        }
+                // Read complete response including columns and rows
+                self.read_query_response().await
+            },
+            deadline,
+            canceller,
+        )
         .await;
 
         #[cfg(feature = "otel")]
@@ -1305,6 +1395,17 @@ impl Client<InTransaction> {
         sql: &str,
         params: &[&(dyn crate::ToSql + Sync)],
     ) -> Result<u64> {
+        let deadline = self.command_deadline();
+        self.execute_inner(sql, params, deadline).await
+    }
+
+    /// Shared execute implementation with an explicit command deadline.
+    async fn execute_inner(
+        &mut self,
+        sql: &str,
+        params: &[&(dyn crate::ToSql + Sync)],
+        deadline: Option<std::time::Duration>,
+    ) -> Result<u64> {
         tracing::debug!(
             sql = sql,
             params_count = params.len(),
@@ -1320,21 +1421,26 @@ impl Client<InTransaction> {
             crate::instrumentation::extract_operation(sql),
         );
 
-        let result = async {
-            if params.is_empty() {
-                // Simple statement without parameters - use SQL batch
-                self.send_sql_batch(sql).await?;
-            } else {
-                // Parameterized statement - use sp_executesql via RPC
-                let rpc_params =
-                    Self::convert_params(params, self.send_unicode(), self.server_collation())?;
-                let rpc = RpcRequest::execute_sql(sql, rpc_params);
-                self.send_rpc(&rpc).await?;
-            }
+        let canceller = self.cancel_handle();
+        let result = run_with_deadline(
+            async {
+                if params.is_empty() {
+                    // Simple statement without parameters - use SQL batch
+                    self.send_sql_batch(sql).await?;
+                } else {
+                    // Parameterized statement - use sp_executesql via RPC
+                    let rpc_params =
+                        Self::convert_params(params, self.send_unicode(), self.server_collation())?;
+                    let rpc = RpcRequest::execute_sql(sql, rpc_params);
+                    self.send_rpc(&rpc).await?;
+                }
 
-            // Read response and get row count
-            self.read_execute_result().await
-        }
+                // Read response and get row count
+                self.read_execute_result().await
+            },
+            deadline,
+            canceller,
+        )
         .await;
 
         #[cfg(feature = "otel")]
@@ -1361,9 +1467,7 @@ impl Client<InTransaction> {
         params: &[&(dyn crate::ToSql + Sync)],
         timeout_duration: std::time::Duration,
     ) -> Result<QueryStream<'a>> {
-        timeout(timeout_duration, self.query(sql, params))
-            .await
-            .map_err(|_| Error::CommandTimeout)?
+        self.query_inner(sql, params, Some(timeout_duration)).await
     }
 
     /// Execute a statement within the transaction with a specific timeout.
@@ -1375,9 +1479,8 @@ impl Client<InTransaction> {
         params: &[&(dyn crate::ToSql + Sync)],
         timeout_duration: std::time::Duration,
     ) -> Result<u64> {
-        timeout(timeout_duration, self.execute(sql, params))
+        self.execute_inner(sql, params, Some(timeout_duration))
             .await
-            .map_err(|_| Error::CommandTimeout)?
     }
 
     /// Open a FILESTREAM BLOB for async reading and/or writing.

--- a/crates/mssql-client/src/config/types.rs
+++ b/crates/mssql-client/src/config/types.rs
@@ -87,6 +87,13 @@ pub struct TimeoutConfig {
     /// Time to complete login sequence (default: 30s).
     pub login_timeout: Duration,
     /// Default timeout for command execution (default: 30s).
+    ///
+    /// Applied to every `query`/`execute` call: if the server does not return
+    /// a complete response within this duration, the driver sends an Attention
+    /// packet to cancel the command, drains the acknowledgement, and returns
+    /// [`Error::CommandTimeout`](crate::Error::CommandTimeout) with the
+    /// connection left usable. Set to `Duration::ZERO` for no limit (matching
+    /// ADO.NET's `CommandTimeout = 0`).
     pub command_timeout: Duration,
     /// Time before idle connection is closed (default: 300s).
     pub idle_timeout: Duration,

--- a/crates/mssql-client/tests/resilience.rs
+++ b/crates/mssql-client/tests/resilience.rs
@@ -445,6 +445,81 @@ async fn test_long_running_query() {
     client.close().await.expect("Failed to close");
 }
 
+/// Issue #156 regression: `query_with_timeout` must cancel via Attention and
+/// leave the connection usable, not desync it by dropping the read future.
+#[tokio::test]
+#[ignore = "Requires SQL Server"]
+async fn test_query_with_timeout_leaves_connection_usable() {
+    let config = get_test_config().expect("SQL Server config required");
+    let mut client = Client::connect(config).await.expect("Failed to connect");
+
+    // A 10s server-side delay against a 1s command timeout must fail fast...
+    let start = std::time::Instant::now();
+    let result = client
+        .query_with_timeout(
+            "WAITFOR DELAY '00:00:10'; SELECT 1 AS n",
+            &[],
+            Duration::from_secs(1),
+        )
+        .await;
+    let elapsed = start.elapsed();
+    match result {
+        Err(mssql_client::Error::CommandTimeout) => {}
+        Err(other) => panic!("expected CommandTimeout, got {other:?}"),
+        Ok(_) => panic!("expected CommandTimeout, query unexpectedly succeeded"),
+    }
+    assert!(
+        elapsed < Duration::from_secs(5),
+        "timeout must fire near 1s, not wait out the 10s query; took {elapsed:?}"
+    );
+
+    // ...and the very next query on the SAME client must succeed with the
+    // correct result — proving the connection was not left desynced.
+    let rows = client
+        .query("SELECT 42 AS answer", &[])
+        .await
+        .expect("connection must be usable after a command timeout");
+    let data: Vec<_> = rows.filter_map(|r| r.ok()).collect();
+    assert_eq!(data.len(), 1);
+    let answer: i32 = data[0].get(0).expect("must read the fresh result");
+    assert_eq!(answer, 42, "stale response would yield wrong data");
+
+    client.close().await.expect("Failed to close");
+}
+
+/// Issue #156 regression: the default `command_timeout` is enforced on a
+/// plain `query()` (no explicit timeout), and the connection stays usable.
+#[tokio::test]
+#[ignore = "Requires SQL Server"]
+async fn test_default_command_timeout_enforced() {
+    let mut config = get_test_config().expect("SQL Server config required");
+    config.command_timeout = Duration::from_secs(1);
+    let mut client = Client::connect(config).await.expect("Failed to connect");
+
+    let start = std::time::Instant::now();
+    let result = client.query("WAITFOR DELAY '00:00:10'", &[]).await;
+    let elapsed = start.elapsed();
+    match result {
+        Err(mssql_client::Error::CommandTimeout) => {}
+        Err(other) => panic!("default command_timeout must cancel; got {other:?}"),
+        Ok(_) => panic!("default command_timeout must cancel; query succeeded"),
+    }
+    assert!(
+        elapsed < Duration::from_secs(5),
+        "default timeout must fire near 1s; took {elapsed:?}"
+    );
+
+    let rows = client
+        .query("SELECT 7 AS n", &[])
+        .await
+        .expect("connection must be usable after a default-timeout cancel");
+    let data: Vec<_> = rows.filter_map(|r| r.ok()).collect();
+    let n: i32 = data[0].get(0).expect("must read fresh result");
+    assert_eq!(n, 7);
+
+    client.close().await.expect("Failed to close");
+}
+
 /// Test that short timeout interrupts long-running query.
 #[tokio::test]
 #[ignore = "Requires SQL Server"]


### PR DESCRIPTION
## Summary

Tier-2 review fix #156. The `*_with_timeout` methods dropped the read future on expiry (no ATTENTION sent, connection left desynced — the crate's own `cancel.rs` warns against exactly this), and `command_timeout` was parsed/defaulted/documented but never enforced. Both are fixed via a shared cancel-race helper.

## Linked issues

Closes #156

## Type of change

- [x] Bug fix
- [ ] API breaking change — **no** (method signatures unchanged); but see the behavior change below

## Test plan

- [x] `cargo clippy --all-features --all-targets -- -D warnings` clean (exit verified)
- [x] `cargo fmt --all -- --check` clean
- [x] `typos` clean
- [x] `cargo nextest run --workspace --all-features` — 843 passed
- [x] All-features doctests pass
- [x] Full ignored-only integration suite against local SQL Server 2022 — **241/241** (239 prior + 2 new); confirms the new default 30s timeout broke none of the existing live tests
- [x] Two new live regression tests:
  - `test_query_with_timeout_leaves_connection_usable`: a 1s explicit timeout on a 10s `WAITFOR` returns `CommandTimeout` in <5s, and the **next query on the same client** returns the correct fresh result (a desynced connection would return stale data or error)
  - `test_default_command_timeout_enforced`: with `command_timeout = 1s`, a plain `query()` of a 10s `WAITFOR` is cancelled, and the connection stays usable

## Behavior change (important)

This is **not** an API break — `query`/`execute`/`*_with_timeout` signatures are unchanged, so cargo-semver-checks is clean. But runtime behavior changes: **every `query`/`execute` now enforces `command_timeout` (default 30s)**. Queries that previously ran unbounded will be cancelled after 30s unless the caller sets `Command Timeout=0` (which means "no limit", matching ADO.NET `SqlCommand.CommandTimeout = 0`). This is the documented-but-previously-ignored semantics finally taking effect. Per maintainer decision (this session), shipping the ADO.NET-parity default rather than opt-in.

## Implementation notes

- `run_with_deadline(fut, deadline, canceller)` (free fn): `tokio::select!` between the network future and a sleep; on timeout it `canceller.cancel().await` (sends ATTENTION via the already-cloned write half) then `fut.await` so the in-flight read drains the server's DONE_ATTN. The connection is clean on return. `deadline = None` (i.e. `command_timeout = 0`) skips the race entirely.
- The four base methods (`query`/`execute` × Ready/InTransaction) became thin wrappers over private `*_inner(.., deadline)` carrying the otel instrumentation; the public `*_with_timeout` methods pass an explicit deadline to the same inner. No duplication of the cancel logic.
- `command_deadline()` lives on the generic `impl<S: ConnectionState>` so both states share it.
- The OTel span/timer still wrap the deadline, so a `CommandTimeout` is recorded as an error on the span.