### PR TITLE
docs: correct false streaming/low-memory claims for query results (#161)

### DIFF
--- a/LIMITATIONS.md
+++ b/LIMITATIONS.md
@@ -13,6 +13,7 @@ For supported features, see [README.md](README.md).
 | Protocol | MARS | Use connection pooling |
 | Protocol | Named Pipes / Shared Memory | Use TCP/IP |
 | Protocol | True LOB Streaming | Chunked reads via SQL |
+| Protocol | Incremental result streaming (whole response is buffered) | Page with OFFSET/FETCH |
 | Protocol | Server-Side Cursors | Use OFFSET/FETCH pagination |
 | Data Types | NUMERIC/DECIMAL beyond 28-29 significant digits | CAST to narrower NUMERIC, FLOAT, or VARCHAR |
 | Collations | OEM code pages CP437 / CP850 (legacy SQL collations) | Use a CP125x or UTF-8 collation, or CAST to NVARCHAR |
@@ -63,11 +64,32 @@ let (result1, result2) = tokio::join!(
 
 ---
 
+### Result Set Buffering (No Incremental Streaming)
+
+**Status:** The full server response is buffered in memory; rows decode lazily
+
+`query()` reads the entire server response into one buffer before returning.
+The returned result set then *decodes* each row lazily as you iterate, so
+peak memory tracks the raw response size (not the response plus a fully
+typed `Vec<Row>`) — but it does **not** bound memory to a single row the way
+true incremental network streaming would. A multi-GB result set means
+multi-GB resident memory. There is currently no maximum-response-size guard.
+
+**Workaround:** Page the query with `OFFSET`/`FETCH` so each fetch is
+bounded:
+
+```sql
+SELECT ... FROM t ORDER BY id OFFSET @skip ROWS FETCH NEXT @take ROWS ONLY
+```
+
+---
+
 ### Large Object (LOB) Streaming
 
 **Status:** Buffered only (no true streaming)
 
-Large objects (VARCHAR(MAX), NVARCHAR(MAX), VARBINARY(MAX)) are fully buffered in memory.
+Large objects (VARCHAR(MAX), NVARCHAR(MAX), VARBINARY(MAX)) are fully buffered in memory
+(this is a specific case of the whole-response buffering described above).
 
 **Workaround:** For objects over 100MB, chunk via SQL:
 
@@ -307,7 +329,9 @@ Windows-only protocols with limited use in modern deployments.
 
 ### Server-Side Cursors
 
-Result set streaming is efficient; cursors add complexity without significant benefit.
+Not implemented. Bound large reads by paging in SQL rather than holding a
+server-side cursor; see "Result Set Buffering" above for why paging (not the
+result set type) is what limits client memory.
 
 **Alternative:** Use `OFFSET`/`FETCH` for pagination.
 

--- a/crates/mssql-client/src/client.rs
+++ b/crates/mssql-client/src/client.rs
@@ -685,10 +685,13 @@ impl Client<Ready> {
         self.needs_reset
     }
 
-    /// Execute a query and return a streaming result set.
+    /// Execute a query and return a result set with lazy per-row decoding.
     ///
-    /// Per ADR-007, results are streamed by default for memory efficiency.
-    /// Use `.collect_all()` on the stream if you need all rows in memory.
+    /// Per ADR-007 the full response is buffered in memory and each row is
+    /// *decoded* on demand as you iterate — this is not incremental network
+    /// streaming, so peak memory tracks the response size. Use
+    /// `.collect_all()` if you want all rows materialized into a `Vec` up
+    /// front.
     ///
     /// # Example
     ///

--- a/crates/mssql-client/src/stream.rs
+++ b/crates/mssql-client/src/stream.rs
@@ -1,7 +1,8 @@
-//! Streaming query result support.
+//! Query result sets with lazy per-row decoding.
 //!
-//! This module provides streaming result sets for memory-efficient
-//! processing of large query results.
+//! The full server response is buffered in memory first; rows are then
+//! *decoded* lazily as callers pull them. This is not incremental
+//! network streaming — see the next section for what that means for memory.
 //!
 //! ## Buffered vs True Streaming
 //!
@@ -55,10 +56,14 @@ pub(crate) enum PendingRow {
     Nbc(NbcRow),
 }
 
-/// A streaming result set from a query.
+/// A result set from a query, yielding rows one at a time.
 ///
-/// This stream yields rows one at a time, allowing processing of
-/// large result sets without loading everything into memory.
+/// The complete server response is already buffered in memory by the time
+/// this is returned; each [`Row`] is *decoded* lazily as it is pulled, not
+/// fetched incrementally from the network. Peak memory is therefore roughly
+/// the size of the raw response payload regardless of how you iterate. For
+/// genuinely large result sets, page with `OFFSET`/`FETCH` in SQL rather
+/// than relying on this type to bound memory.
 ///
 /// # Example
 ///


### PR DESCRIPTION
## Summary

Tier-2 review fix #161 (docs-only). `query()` buffers the whole response then decodes rows lazily — it is not incremental streaming. The rustdoc claimed results could be processed "without loading everything into memory" and were "streamed by default for memory efficiency", which misleads users into thinking memory is bounded for large result sets. Corrected, and the whole-response buffering is now disclosed in LIMITATIONS.md.

## Linked issues

Closes #161

## Type of change

- [x] Documentation only

## Test plan

- [x] `cargo clippy --all-features --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features --workspace` clean
- [x] `typos` clean
- [x] mssql-client doctests pass (63)
- [x] `scripts/check-doc-consistency.sh` — all 25 checks pass

## Changes

- `stream.rs`: reworded the module summary and the `QueryStream` struct doc to state the buffer-then-lazy-decode model and that peak memory tracks the response size. The existing "Buffered vs True Streaming" section was already accurate — left as-is.
- `client.rs`: `Client::query` doc no longer says "streamed by default for memory efficiency"; explains lazy decode vs. incremental streaming.
- `LIMITATIONS.md`: new "Result Set Buffering (No Incremental Streaming)" section + quick-reference row, with an `OFFSET`/`FETCH` paging workaround; generalized the LOB section to reference it; corrected the Server-Side Cursors non-goal which implied result streaming already bounds memory.

## Notes

- README was already honest ("Rows decode lazily, but the response is buffered in memory") — no change needed there.
- A configurable max-response-size guard (mentioned in the issue) is deliberately **not** included here — that's a code/behavior change for separate review; this PR only makes the docs match today's behavior. Flagged for #167 triage.