### PR TITLE
fix(codec): one EOM packet for empty payloads + codec error-path tests (#165)

### DIFF
--- a/crates/mssql-codec/src/connection.rs
+++ b/crates/mssql-codec/src/connection.rs
@@ -210,7 +210,15 @@ where
         reset_connection: bool,
     ) -> Result<(), CodecError> {
         let max_payload = max_packet_size - PACKET_HEADER_SIZE;
-        let chunks: Vec<_> = payload.chunks(max_payload).collect();
+        // An empty payload must still produce one header-only EOM packet:
+        // `[]chunks()` yields zero chunks, which would send nothing at all and
+        // leave the caller waiting for a response that never comes (issue
+        // #165). A zero-length-payload message is valid TDS framing.
+        let chunks: Vec<&[u8]> = if payload.is_empty() {
+            vec![&[]]
+        } else {
+            payload.chunks(max_payload).collect()
+        };
         let total_chunks = chunks.len();
 
         let mut writer = self.writer.lock().await;
@@ -431,6 +439,88 @@ where
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
+
+    /// Issue #165: sending a message with an empty payload must still emit
+    /// exactly one header-only EOM packet. Previously `chunks()` on an empty
+    /// payload yielded zero chunks, so nothing was sent and the caller would
+    /// hang waiting for a response.
+    #[tokio::test]
+    async fn test_send_empty_payload_emits_one_eom_packet() {
+        use tokio::io::AsyncReadExt;
+
+        let (client_io, mut server_io) = tokio::io::duplex(4096);
+        let mut conn = Connection::new(client_io);
+
+        conn.send_message(PacketType::SqlBatch, Bytes::new(), 4096)
+            .await
+            .expect("empty message should send");
+
+        // Exactly one header-only packet (8 bytes) must arrive.
+        let mut header = [0u8; PACKET_HEADER_SIZE];
+        server_io
+            .read_exact(&mut header)
+            .await
+            .expect("one header-only packet must be sent");
+        assert_eq!(header[0], PacketType::SqlBatch as u8);
+        assert!(
+            PacketStatus::from_bits_truncate(header[1]).contains(PacketStatus::END_OF_MESSAGE),
+            "the single packet must be flagged END_OF_MESSAGE"
+        );
+        let length = u16::from_be_bytes([header[2], header[3]]);
+        assert_eq!(
+            length as usize, PACKET_HEADER_SIZE,
+            "length must be header-only (no payload)"
+        );
+
+        // And nothing more.
+        drop(conn);
+        let mut rest = Vec::new();
+        server_io.read_to_end(&mut rest).await.expect("read rest");
+        assert!(rest.is_empty(), "no second packet may follow");
+    }
+
+    /// Issue #165: across a multi-packet send, RESET_CONNECTION must be set on
+    /// the first packet only (per MS-TDS), and END_OF_MESSAGE on the last only.
+    #[tokio::test]
+    async fn test_reset_flag_on_first_packet_only_across_multi_packet_send() {
+        use tokio::io::AsyncReadExt;
+
+        let (client_io, mut server_io) = tokio::io::duplex(4096);
+        let mut conn = Connection::new(client_io);
+
+        // max_packet_size 16 → max_payload 8; a 12-byte payload spans 2 packets.
+        let payload = Bytes::from(vec![0xABu8; 12]);
+        conn.send_message_with_reset(PacketType::SqlBatch, payload, 16, true)
+            .await
+            .expect("multi-packet send should succeed");
+        drop(conn);
+
+        let mut all = Vec::new();
+        server_io.read_to_end(&mut all).await.expect("read packets");
+
+        // Packet 1: header(8) + payload(8) = 16 bytes.
+        let s0 = PacketStatus::from_bits_truncate(all[1]);
+        assert!(
+            s0.contains(PacketStatus::RESET_CONNECTION),
+            "first packet must carry RESET_CONNECTION"
+        );
+        assert!(
+            !s0.contains(PacketStatus::END_OF_MESSAGE),
+            "first packet of two must not be END_OF_MESSAGE"
+        );
+
+        // Packet 2 starts at offset 16: header(8) + payload(4).
+        let s1 = PacketStatus::from_bits_truncate(all[16 + 1]);
+        assert!(
+            !s1.contains(PacketStatus::RESET_CONNECTION),
+            "RESET_CONNECTION must not repeat on later packets"
+        );
+        assert!(
+            s1.contains(PacketStatus::END_OF_MESSAGE),
+            "last packet must be END_OF_MESSAGE"
+        );
+        assert_eq!(all.len(), 16 + 8 + 4, "exactly two packets must be sent");
+    }
 
     #[test]
     fn test_attention_packet_header() {

--- a/crates/mssql-codec/src/framed.rs
+++ b/crates/mssql-codec/src/framed.rs
@@ -299,3 +299,58 @@ where
             .finish()
     }
 }
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::*;
+    use futures_util::{SinkExt, StreamExt};
+    use tds_protocol::packet::{PacketHeader, PacketStatus, PacketType};
+
+    /// Issue #165: `PacketStream` (Sink + Stream over `TdsCodec`) must
+    /// round-trip a packet through a transport — the framing adapter that had
+    /// no direct tests.
+    #[tokio::test]
+    async fn test_packet_stream_round_trip() {
+        let (a, b) = tokio::io::duplex(4096);
+        let mut writer = PacketStream::new(a);
+        let mut reader = PacketStream::new(b);
+
+        let header = PacketHeader::new(PacketType::SqlBatch, PacketStatus::END_OF_MESSAGE, 0);
+        let sent = Packet::new(header, BytesMut::from(&b"hello"[..]));
+
+        writer.send(sent).await.expect("send packet");
+
+        let got = reader
+            .next()
+            .await
+            .expect("a packet must arrive")
+            .expect("decode must succeed");
+        assert_eq!(got.header.packet_type, PacketType::SqlBatch);
+        assert!(got.header.is_end_of_message());
+        assert_eq!(&got.payload[..], b"hello");
+    }
+
+    /// Issue #165: the split `PacketWriter` → `PacketReader` halves used for
+    /// cancellation-safe I/O (ADR-005) must also round-trip.
+    #[tokio::test]
+    async fn test_split_reader_writer_round_trip() {
+        let (a, b) = tokio::io::duplex(4096);
+        let mut writer = PacketWriter::new(a);
+        let mut reader = PacketReader::new(b);
+
+        let header = PacketHeader::new(PacketType::Rpc, PacketStatus::END_OF_MESSAGE, 0);
+        writer
+            .send(Packet::new(header, BytesMut::from(&b"world"[..])))
+            .await
+            .expect("send packet");
+
+        let got = reader
+            .next()
+            .await
+            .expect("a packet must arrive")
+            .expect("decode must succeed");
+        assert_eq!(got.header.packet_type, PacketType::Rpc);
+        assert_eq!(&got.payload[..], b"world");
+    }
+}

--- a/crates/mssql-codec/src/packet_codec.rs
+++ b/crates/mssql-codec/src/packet_codec.rs
@@ -176,7 +176,7 @@ impl Encoder<Packet> for TdsCodec {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 mod tests {
     use super::*;
     use tds_protocol::packet::{PacketStatus, PacketType};
@@ -232,5 +232,135 @@ mod tests {
 
         let result = codec.decode(&mut data).unwrap();
         assert!(result.is_none()); // Should return None for incomplete
+    }
+
+    /// Build an 8-byte TDS header with an arbitrary length field (which may be
+    /// intentionally invalid for testing).
+    fn header_with_length(len: u16) -> BytesMut {
+        let mut data = BytesMut::new();
+        data.put_u8(PacketType::SqlBatch as u8);
+        data.put_u8(PacketStatus::END_OF_MESSAGE.bits());
+        data.put_u16(len);
+        data.put_u16(0); // spid
+        data.put_u8(1); // packet_id
+        data.put_u8(0); // window
+        data
+    }
+
+    /// Issue #165: a length field smaller than the 8-byte header is malformed
+    /// and must be rejected, not silently accepted or panicked on.
+    #[test]
+    fn test_decode_rejects_length_below_header_size() {
+        let mut codec = TdsCodec::new();
+        let mut data = header_with_length(4); // < PACKET_HEADER_SIZE (8)
+        assert!(matches!(
+            codec.decode(&mut data),
+            Err(CodecError::InvalidHeader)
+        ));
+    }
+
+    /// Issue #165: a declared length above the negotiated maximum must be
+    /// rejected before any allocation/read of the claimed size.
+    #[test]
+    fn test_decode_rejects_packet_too_large() {
+        let mut codec = TdsCodec::new().with_max_packet_size(16);
+        // Header claims 20 bytes; only the 8-byte header is present, but the
+        // size check must fire before the completeness check.
+        let mut data = header_with_length(20);
+        match codec.decode(&mut data) {
+            Err(CodecError::PacketTooLarge { size, max }) => {
+                assert_eq!(size, 20);
+                assert_eq!(max, 16);
+            }
+            other => panic!("expected PacketTooLarge, got {other:?}"),
+        }
+    }
+
+    /// Issue #165: encoding a packet whose total length exceeds the maximum
+    /// must error rather than emit a truncated/overflowing length field.
+    #[test]
+    fn test_encode_rejects_packet_too_large() {
+        let mut codec = TdsCodec::new().with_max_packet_size(16);
+        let header = PacketHeader::new(PacketType::SqlBatch, PacketStatus::END_OF_MESSAGE, 0);
+        // 8-byte header + 16-byte payload = 24 > 16.
+        let payload = BytesMut::from(&[0u8; 16][..]);
+        let mut dst = BytesMut::new();
+        match codec.encode(Packet::new(header, payload), &mut dst) {
+            Err(CodecError::PacketTooLarge { size, max }) => {
+                assert_eq!(size, 24);
+                assert_eq!(max, 16);
+            }
+            other => panic!("expected PacketTooLarge, got {other:?}"),
+        }
+    }
+
+    /// Issue #165: the packet-id counter wraps 255 → 1, skipping 0 (TDS
+    /// packet IDs are 1-based; a 0 would be misread by the server).
+    #[test]
+    fn test_packet_id_wraps_past_zero() {
+        let mut codec = TdsCodec::new();
+        let mut saw_zero = false;
+        let mut saw_wrap_to_one = false;
+        let mut prev = codec.next_packet_id(); // first id (1)
+        for _ in 0..600 {
+            let id = codec.next_packet_id();
+            if id == 0 {
+                saw_zero = true;
+            }
+            if prev == 255 {
+                assert_eq!(id, 1, "after 255 the id must skip 0 and become 1");
+                saw_wrap_to_one = true;
+            }
+            prev = id;
+        }
+        assert!(!saw_zero, "packet id 0 must never be emitted");
+        assert!(saw_wrap_to_one, "the test must exercise the 255→1 wrap");
+    }
+
+    /// Issue #165: two complete packets concatenated in one buffer must both
+    /// decode, with the buffer fully consumed.
+    #[test]
+    fn test_decode_two_packets_from_one_buffer() {
+        let mut codec = TdsCodec::new();
+        let mut data = BytesMut::new();
+        for tag in [b"aaaa", b"bbbb"] {
+            data.put_u8(PacketType::SqlBatch as u8);
+            data.put_u8(PacketStatus::END_OF_MESSAGE.bits());
+            data.put_u16(12);
+            data.put_u16(0);
+            data.put_u8(1);
+            data.put_u8(0);
+            data.put_slice(tag);
+        }
+
+        let p1 = codec.decode(&mut data).unwrap().expect("first packet");
+        assert_eq!(&p1.payload[..], b"aaaa");
+        let p2 = codec.decode(&mut data).unwrap().expect("second packet");
+        assert_eq!(&p2.payload[..], b"bbbb");
+        assert!(data.is_empty(), "buffer must be fully consumed");
+        assert!(codec.decode(&mut data).unwrap().is_none());
+    }
+
+    /// Issue #165: a packet arriving in two reads (partial header, then the
+    /// rest) must decode once the full packet is present.
+    #[test]
+    fn test_decode_incremental_feed() {
+        let mut codec = TdsCodec::new();
+        let mut full = header_with_length(12);
+        full.put_slice(b"test");
+
+        // Feed only the first 5 bytes (partial header).
+        let mut data = BytesMut::new();
+        data.put_slice(&full[..5]);
+        assert!(codec.decode(&mut data).unwrap().is_none());
+
+        // Feed the remaining bytes; now it decodes.
+        data.put_slice(&full[5..]);
+        let p = codec
+            .decode(&mut data)
+            .unwrap()
+            .expect("packet after full feed");
+        assert_eq!(&p.payload[..], b"test");
+        assert!(data.is_empty());
     }
 }


### PR DESCRIPTION
## Summary

Tier-2 verification fix #165. Adds the codec error-path and framing tests the crate was missing (11 test attrs for ~1.5k LOC), and fixes a latent bug found while writing them: `send_message` of an empty payload sent **zero packets** (caller hangs).

## Linked issues

Closes #165

## Type of change

- [x] Bug fix (empty-payload framing)
- [x] Test coverage

## Test plan

- [x] `cargo clippy --all-features --all-targets -- -D warnings` clean (exit verified)
- [x] `cargo fmt --all -- --check` clean
- [x] `typos` clean
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features --workspace` clean
- [x] `cargo nextest run --workspace --all-features` — 855 passed; mssql-codec now 21 tests (was 11)
- [x] Full ignored-only integration suite against local SQL Server 2022 — **241/241** (the send-path change is exercised by every real query)

## The bug

`send_message_with_reset` built packets via `payload.chunks(max_payload)`. On an empty `Bytes`, `chunks()` yields zero elements, so the send loop never ran and **nothing was written** — the caller would then await a response that never comes. Fixed: an empty payload now frames as a single header-only `END_OF_MESSAGE` packet (valid TDS). No real path sends empty payloads today, so no behavior change for existing callers; this closes the latent hang and is pinned by a test.

## Tests added

- `packet_codec`: `InvalidHeader` (length < 8), `PacketTooLarge` on decode and encode, packet-id wrap 255→1 (never 0), two-packets-from-one-buffer, incremental cross-read feed
- `connection`: empty-payload emits exactly one EOM packet; `RESET_CONNECTION` on first packet only / `END_OF_MESSAGE` on last only across a multi-packet send
- `framed`: `PacketStream` and split `PacketReader`/`PacketWriter` round-trips (this file had no tests)

## Notes

- The review's #165 referenced "framed.rs (the TLS-inside-TDS prelogin framing)". That framing actually lives in `mssql-tls::TlsPreloginWrapper`; `mssql-codec::framed` is the `Stream`/`Sink` adapter over `TdsCodec`, now covered by round-trip tests. The oversized-handshake-flush concern noted in the review belongs to the mssql-tls wrapper and is out of scope here — flagged for #167 triage.