### PR TITLE
docs: correct MIGRATION/STABILITY/ARCHITECTURE/CLAUDE drift (#166)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Architectural Reference: Rust MS SQL Driver
 
-**Version:** 1.6.0
+**Version:** 1.8.0
 **Status:** Design Complete
 **Target Protocol:** MS-TDS 7.3 – 8.0 (SQL Server 2008 – 2025)
 **Toolchain Standard:** Rust 2024 Edition (v1.85+, released February 20, 2025)
@@ -354,7 +354,7 @@ Server=tcp:hostname,port;Database=dbname;User Id=user;Password=pass;Encrypt=stri
 | `Password` | `PWD` | SQL authentication password |
 | `Encrypt` | | `true`, `false`, `strict`, `no_tls` |
 | `TrustServerCertificate` | | Skip certificate validation |
-| `Authentication` | | `SqlPassword`, `ActiveDirectoryPassword`, `ActiveDirectoryManagedIdentity`, `ActiveDirectoryServicePrincipal` |
+| `Authentication` (recognized, **not yet supported** — FEDAUTH login wiring pending, see #155) | | `SqlPassword`, `ActiveDirectoryPassword`, `ActiveDirectoryManagedIdentity`, `ActiveDirectoryServicePrincipal` |
 | `Application Name` | | Application identifier |
 | `Connect Timeout` | | Connection timeout in seconds |
 | `Command Timeout` | | Default command timeout |
@@ -868,7 +868,7 @@ alongside the response-streaming work.
 
 **Status:** Implemented
 
-**Decision:** Always Encrypted client-side encryption is fully implemented with production-ready key providers.
+**Decision:** Always Encrypted client-side decryption (the read path) is fully implemented with production-ready key providers. The encrypt-before-send write path is not yet implemented (only `NULL` can be written to encrypted columns); see LIMITATIONS.md.
 
 **Implemented (v0.2.0):**
 - AEAD_AES_256_CBC_HMAC_SHA256 encryption/decryption
@@ -2005,7 +2005,7 @@ Features are defined on `mssql-client` and forwarded to internal crates as neede
 | `azure-identity` | No | mssql-auth | All | `azure_identity` (pulls OpenSSL transitively) |
 | `integrated-auth` | No | mssql-auth | Linux/macOS | `gssapi`, `libkrb5-dev` |
 | `sspi-auth` | No | mssql-auth | Windows | `sspi-rs` |
-| `cert-auth` | No | mssql-auth | All | None (uses rustls) |
+| `cert-auth` | No | mssql-auth | All | `azure_identity/client_certificate` (pulls OpenSSL transitively) |
 
 Features on `mssql-auth` only (not exposed via `mssql-client`):
 
@@ -2049,6 +2049,7 @@ quick-reference cheat sheet.
 | 1.5.0 | 2026-01-01 | Updated for v0.5.0 release: Collation-aware VARCHAR decoding, encoding feature, Column marked non_exhaustive |
 | 1.6.0 | 2026-04-07 | Updated for v0.7.0 release: MSRV bumped to 1.88, SSPI integrated auth wired into client login, RUSTSEC advisories resolved, 33 public enums marked non_exhaustive for semver safety, deprecated APIs removed before 1.0 |
 | 1.7.0 | 2026-04-13 | Updated for v0.8.0 release: Stored procedure support (§4.7), SQL Browser instance resolution, pool test_on_checkin, Azure SDK 0.34, mock TLS cross-platform fix |
+| 1.8.0 | 2026-06-11 | Doc-accuracy corrections (#166): header version aligned with history; ADR-002 marks `Authentication` keyword as recognized-but-not-yet-supported (FEDAUTH pending, #155); ADR-013 clarifies Always Encrypted is read-path only (write path NULL-only); §8.3 corrects `cert-auth` dependency (pulls OpenSSL via azure_identity, not pure-rustls) |
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ A high-performance MS SQL Server driver for Rust that aims to surpass `prisma/ti
 
 ## Key Architecture Decisions
 
-Refer to `ARCHITECTURE.md` (v1.2.0) for complete details. Critical decisions:
+Refer to `ARCHITECTURE.md` (v1.8.0) for complete details. Critical decisions:
 
 | Decision | Choice | Rationale |
 |----------|--------|-----------|

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -68,8 +68,10 @@ let value: i32 = row[0].get(0).unwrap();
 
 **rust-mssql-driver:**
 ```rust
-let mut stream = client.query("SELECT 1 AS value", &[]).await?;
-let row = stream.next().await.unwrap()?;
+let stream = client.query("SELECT 1 AS value", &[]).await?;
+// The result set is iterated synchronously (the response is already
+// buffered; rows decode lazily). Each item is a `Result<Row, Error>`.
+let row = stream.into_iter().next().expect("one row")?;
 let value: i32 = row.get(0)?;
 ```
 
@@ -88,12 +90,12 @@ let name: &str = row.get(1).unwrap();
 
 **rust-mssql-driver:**
 ```rust
-let mut stream = client.query(
+let stream = client.query(
     "SELECT * FROM users WHERE id = @p1",
     &[&1i32]
 ).await?;
 
-let row = stream.next().await.unwrap()?;
+let row = stream.into_iter().next().expect("one row")?;
 let name: String = row.get(1)?;
 ```
 
@@ -143,21 +145,27 @@ for row in rows {
 
 **rust-mssql-driver:**
 ```rust
-let mut stream = client.query("SELECT * FROM users", &[]).await?;
+let stream = client.query("SELECT * FROM users", &[]).await?;
 
-while let Some(row) = stream.next().await {
+// Synchronous iteration: the response is already buffered, and each row
+// decodes lazily as it is yielded. Each item is a `Result<Row, Error>`.
+for row in stream {
     let row = row?;
     let id: i32 = row.get(0)?;
     let name: String = row.get(1)?;
 }
+```
 
-// Or collect all rows
+To buffer all rows up front instead:
+```rust
+let stream = client.query("SELECT * FROM users", &[]).await?;
 let rows: Vec<Row> = stream.collect_all().await?;
 ```
 
 **Key changes:**
-- Async iteration with `stream.next().await`
-- Explicit error handling per row
+- Synchronous `for row in stream` iteration (the result set implements
+  `Iterator`, not async `Stream`-style `.next().await`)
+- Explicit error handling per row (`Result<Row, Error>`)
 - `collect_all()` for buffered results
 
 ### Column Access by Name
@@ -561,4 +569,4 @@ let client = tx.commit().await?;  // Capture the returned client
 | `execute("BEGIN TRANSACTION")` | `begin_transaction()` |
 | `execute("COMMIT")` | `commit()` → returns client |
 | Manual Azure redirect | Automatic |
-| No statement caching | Automatic LRU cache |
+| `sp_executesql` plan reuse | `sp_executesql` plan reuse (client-side handle cache not yet wired) |

--- a/STABILITY.md
+++ b/STABILITY.md
@@ -49,9 +49,9 @@ The following APIs are considered stable and covered by semver guarantees:
 | `Config::new()` + `with_*` builders | Stable |
 | `Row::get()` | Stable |
 | `Row::try_get()` | Stable |
-| `Transaction::commit()` | Stable |
-| `Transaction::rollback()` | Stable |
-| `Transaction::save_point()` | Stable |
+| `Client<InTransaction>::commit()` | Stable |
+| `Client<InTransaction>::rollback()` | Stable |
+| `Client::save_point()` | Stable |
 | `Client::call_procedure()` | Stable |
 | `Client::procedure()` | Stable |
 | `ProcedureBuilder::input()` | Stable |


### PR DESCRIPTION
## Summary

Tier-2 review fix #166 (docs-only). Corrects the user-impacting documentation drift: MIGRATION.md examples that don't compile + a false cache claim, STABILITY.md promising stability for methods that don't exist, and several ARCHITECTURE.md inaccuracies including an internally-inconsistent version.

## Linked issues

Closes #166

## Type of change

- [x] Documentation only

## Test plan

- [x] `typos` clean
- [x] `scripts/check-doc-consistency.sh` — all 25 checks pass (incl. the bumped ARCHITECTURE version)
- [x] Workspace doctests pass
- [x] Corrected MIGRATION examples verified against the real API: `QueryStream` implements `Iterator` (confirmed `impl Iterator for QueryStream` in stream.rs), so `for row in stream` / `stream.into_iter().next()` are correct and `stream.next().await` was a type error

## What changed

**MIGRATION.md** (highest user impact — broken copy-paste):
- All three result-set examples used `stream.next().await`, which doesn't compile (`QueryStream` is an `Iterator`, not an async `Stream` you `.next().await`). Replaced with synchronous `for row in stream` / `into_iter().next()` matching README and ADR-006.
- Quick-reference "Automatic LRU cache" → corrected (statement cache is unwired; it's `sp_executesql` plan reuse).

**STABILITY.md:**
- Stable-API table named `Transaction::{commit,rollback,save_point}` — methods on the exported-but-vestigial `Transaction` stub. Pointed at the real `Client<InTransaction>::{commit,rollback}` and `Client::save_point`.

**ARCHITECTURE.md:**
- Header `1.6.0` trailed its own Document History (`1.7.0`) → bumped to `1.8.0` + history entry.
- ADR-002: `Authentication` keyword marked recognized-but-not-yet-supported (FEDAUTH pending #155).
- ADR-013: Always Encrypted clarified as read-path only (write path NULL-only).
- §8.3: `cert-auth` dependency corrected (pulls OpenSSL via azure_identity, not pure-rustls).

**CLAUDE.md:** ARCHITECTURE.md version reference `1.2.0` → `1.8.0`.

## Scope note

This targets the confirmed user-facing errors (non-compiling examples, false claims, broken stability promises). Lower-impact design-doc internals the review also flagged — ADR-008/§4.1 showing illustrative `Client::new(...)`-style APIs that predate the type-state design, the stale ADR-010 Cargo.toml snapshot, and the `ToSql` vs `ToParams` naming — are deferred to #167 triage rather than expanding this PR; they don't misinform a user following the guides. Adding MIGRATION.md to the compile-checked doc-tests crate (so these can't regress) is also noted there, as it requires restructuring each example with a doctest harness.