### PR TITLE
chore: fix typos recipe and document the full pre-push CI gate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -331,8 +331,22 @@ When making changes here, remember:
 
 4. **Respect the release rules** documented in RELEASING.md (irreversibility, never cancel a publish mid-run, recovery is re-run). They exist because of specific past incidents. Don't work around them — if you find them inconvenient, propose a process change via an issue.
 
-5. **Trunk-based development.** Work happens on short-lived feature branches merged into `main` via PRs (no squash-merging — history stays linked). CI runs on every push and PR; cross-platform issues surface immediately, not at release time.
+5. **Trunk-based development.** Work happens on short-lived feature branches merged into `main` via PRs (no squash-merging — history stays linked). CI (`ci.yml`) triggers on pushes to `main` and on PRs whose base is `main` — not on feature-branch pushes that lack an open PR to `main`. Cross-platform issues surface at PR time, not at release time.
 
 6. **Update CLAUDE.md when you add new infrastructure.** This document is the entry point for future AI assistants working on the repo. Adding a new tool, workflow, or policy without updating CLAUDE.md leaves future sessions flying blind. The Process and Governance section above should reference all the discoverable infrastructure.
 
 7. **Use issue/PR templates.** They ask the right questions. If you're opening an issue or PR, fill out the template completely — it helps the human reviewer and it helps future AI sessions parse the intent.
+
+8. **Run the full local CI mirror before every push; never trust a subset.** `cargo check` and unit tests do not catch the `-D warnings`-class failures CI rejects. This repo's gate is reproduced by `just ci-all` (fmt + clippy `--all-features --all-targets -D warnings` + nextest all-features + `cargo doc -D warnings` + examples). `ci-all` does NOT compose two gates CI enforces, so the real pre-push command is:
+
+   ```bash
+   just ci-all && just typos && \
+     MSSQL_HOST=localhost MSSQL_PORT=1433 MSSQL_USER=sa MSSQL_PASSWORD='YourStrong@Passw0rd' \
+       cargo nextest run --all-features --run-ignored ignored-only --no-fail-fast \
+       -E 'not (binary(azure_sql) or test(azure_identity_auth) or test(cert_auth))'
+   ```
+
+   - `just typos` runs the same bare `typos` (whole-tree, `typos.toml`-aware) the CI Hygiene job runs. It needs the tool installed at an MSRV-1.88-compatible version: `cargo install typos-cli --version 1.42.3 --locked` (newer requires rustc 1.91). The recipe still prints a WARN and passes if typos is absent, so confirm it is actually installed — a silent skip is how a spell-check failure reaches CI.
+   - The ignored-only suite needs a local SQL Server 2022 container (`just sql-server-start`). `ci-all` and unit tests will NOT catch live-only failures (e.g. bulk temporal, decimal high-scale).
+   - **Never open a PR stacked on another feature branch.** CI only triggers on PRs based on `main` (see convention 5), so a stacked PR gets zero CI until it is retargeted to `main`.
+   - **Branch protection requires up-to-date-with-`main`.** Merge each green PR before opening the next to minimize the `update-branch` + CI-re-run churn that comes from keeping many PRs in flight at once.

--- a/Justfile
+++ b/Justfile
@@ -1344,7 +1344,11 @@ typos:
         printf '{{yellow}}[WARN]{{reset}} typos not installed (cargo install typos-cli)\n'
         exit 0
     fi
-    typos crates/ docs/ README.md CHANGELOG.md RELEASING.md ARCHITECTURE.md
+    # Scan the whole tree (respecting typos.toml), matching the bare `typos`
+    # invocation in the CI Hygiene job. The previous hand-picked path list
+    # included a `docs/` directory that no longer exists, so the recipe
+    # failed (exit 64) and also diverged from what CI actually checks.
+    typos
     printf '{{green}}[OK]{{reset}}   Typos check passed\n'
 
 [group('lint')]


### PR DESCRIPTION
## Summary

Two changes from a session retrospective on CI-only failures:

1. **Fix the `just typos` recipe.** It ran `typos crates/ docs/ README.md …`, but `docs/` no longer exists, so the recipe failed with exit 64 — and it also diverged from CI, which runs a bare whole-tree `typos` (respecting `typos.toml`, per `ci.yml:394`). Changed to bare `typos` so the recipe both works and matches CI.

2. **Document the full pre-push gate (CLAUDE.md convention 8)** and **correct convention 5.** `just ci-all` reproduces most of CI but omits two enforced gates (`just typos` and the ignored-only live suite); convention 8 records the exact one-shot command. Convention 5 previously claimed CI "runs on every push and PR" — the `ci.yml` trigger is pushes to `main` and PRs based on `main` only.

## Type of change

- [x] Build / CI / tooling
- [x] Documentation

## Test plan

- [x] Validated the recorded pre-push command end-to-end before documenting it: `just ci-all` clean, `just typos` clean (after the recipe fix), and the ignored-only live suite **241/241** against a local SQL Server 2022 container
- [x] `scripts/check-doc-consistency.sh` — all 25 checks pass

## Why

In a prior session, four CI-only failures (clippy `unexpected_cfgs`, clippy `panic`, rustdoc private-intra-doc-links, and a `typos` hit) each cost a CI round-trip because local verification used `cargo check` / a hand-picked subset rather than the repo's own `just ci-all` mirror — which would have caught three of the four. The fourth (`typos`) would still have slipped because the recipe was broken. This PR fixes the recipe and writes the complete gate down so it isn't re-derived.