### PR TITLE
ci(release): auto-sync README dep-version snippets on the Release PR

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -115,3 +115,35 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+      # release-plz bumps Cargo.toml + CHANGELOG but not the README install
+      # snippets (`mssql-client = "X.Y"`), so the doc-consistency gate fails on
+      # every Release PR until they are hand-bumped. Sync them automatically on
+      # the Release PR branch. Pushing to that branch (never main) re-runs CI
+      # but does not re-trigger this workflow, and self-heals on the next main
+      # push because this step runs again.
+      - name: Sync README dep-version snippets on the Release PR
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          # The Release PR branch is always named release-plz-*.
+          pr_branch=$(gh pr list --state open --json headRefName \
+            --jq '[.[] | select(.headRefName | startswith("release-plz-"))][0].headRefName' \
+            2>/dev/null || true)
+          if [ -z "$pr_branch" ]; then
+            echo "No open Release PR; nothing to sync."
+            exit 0
+          fi
+          remote="https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git fetch "$remote" "$pr_branch"
+          git checkout -B "$pr_branch" FETCH_HEAD
+          bash scripts/sync-readme-version.sh
+          if git diff --quiet; then
+            echo "Dep-version snippets already in sync."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit -am "docs: sync first-party dep version snippets to the release version"
+          git push "$remote" "HEAD:$pr_branch"
+          echo "Synced dep-version snippets on $pr_branch."

--- a/scripts/sync-readme-version.sh
+++ b/scripts/sync-readme-version.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+#
+# Sync first-party crate dependency snippets in the docs to the workspace
+# version (major.minor). release-plz bumps Cargo.toml and the CHANGELOG when it
+# opens a Release PR, but it does NOT touch install snippets like
+# `mssql-client = "0.12"` in README.md — so the doc-consistency gate
+# (scripts/check-doc-consistency.sh, "Doc dependency snippets" check) fails on
+# every Release PR until the snippet is hand-bumped.
+#
+# This script performs that bump deterministically. It is run by the
+# release-plz workflow against the open Release PR branch, and can also be run
+# locally. It mirrors the file list and crate list of the doc-consistency
+# check so the two never disagree.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+WORKSPACE_VERSION=$(grep -m1 '^version = ' Cargo.toml | sed 's/version = "\(.*\)".*/\1/')
+EXPECTED_MINOR=${WORKSPACE_VERSION%.*}
+
+# Keep in sync with scripts/check-doc-consistency.sh.
+SNIPPET_CRATES='tds-protocol|mssql-client|mssql-auth|mssql-tls|mssql-codec|mssql-types|mssql-derive|mssql-driver-pool'
+
+shopt -s nullglob
+files=(README.md docs/*.md crates/*/README.md)
+
+changed=0
+for f in "${files[@]}"; do
+    [ -f "$f" ] || continue
+    before=$(cat "$f")
+    # Rewrite the quoted version of any first-party dep line to major.minor.
+    # Group 1 captures `<indent><crate> = "`; the version and closing quote are
+    # replaced. Both `"X.Y"` and `"X.Y.Z"` forms are handled.
+    sed -i -E \
+        "s/^([[:space:]]*(${SNIPPET_CRATES}) = \")[0-9]+\.[0-9]+(\.[0-9]+)?\"/\1${EXPECTED_MINOR}\"/" \
+        "$f"
+    if [ "$before" != "$(cat "$f")" ]; then
+        echo "synced $f → ${EXPECTED_MINOR}"
+        changed=1
+    fi
+done
+
+if [ "$changed" = "0" ]; then
+    echo "all first-party dep snippets already at ${EXPECTED_MINOR}"
+fi


### PR DESCRIPTION
## Summary

Stops the recurring doc-consistency failure on every release-plz Release PR. release-plz bumps `Cargo.toml` + `CHANGELOG` but never touches the README install snippet (`mssql-client = "X.Y"`), which the doc-consistency gate requires to match the workspace major.minor — so the gate failed on every Release PR until someone hand-bumped it, and any commit landing on main before the Release PR merged regenerated the branch and reverted the manual fix.

## Type of change

- [x] Build / CI / tooling

## What changed

- **`scripts/sync-readme-version.sh`** (new): rewrites every first-party dep snippet in `README.md`, `docs/*.md`, and `crates/*/README.md` to the workspace major.minor. It mirrors the file list and crate list of `scripts/check-doc-consistency.sh` so the two can't disagree. Idempotent (no-op when already in sync).
- **`.github/workflows/release-plz.yml`**: a new step in the `release-plz-pr` job runs the script against the open `release-plz-*` branch and commits the result back to that branch.

## Why it's safe / self-healing

- The push targets the `release-plz-*` branch, **never main**, so it re-runs `ci.yml` (the gate goes green) but does **not** re-trigger `release-plz.yml` (which is `on: push: branches: [main]`) — no loop.
- If a later main push regenerates the Release PR branch (reverting the README), this step runs again on that same workflow run and re-syncs — so it self-heals.
- No empty commits (`git diff --quiet` guard); commits authored as `github-actions[bot]`.

## Test plan

- [x] `bash -n` + `shellcheck` clean on the script
- [x] Script tested locally both ways: no-op when workspace==README version; rewrites `mssql-client = "0.12"` → `"0.13"` when the workspace is bumped to 0.13.0
- [x] `python3 -c "yaml.safe_load(...)"` validates the workflow
- [x] `typos` clean; `scripts/check-doc-consistency.sh` still passes on main
- [ ] End-to-end exercise of the workflow step itself can only happen when release-plz next runs (it needs an open Release PR + the app token); the script and branch logic are verified independently

## Notes

The current v0.13.0 Release PR (#169) was unblocked separately by a one-time manual README bump on its branch; this change prevents the recurrence from v0.14.0 onward (and will re-sync #169 automatically the next time release-plz runs after this merges).