### PR TITLE
fix: Tier-3 remediation — SortId 201, ChangeTrackingQuery bracketing, bounded timeout drain + full deadline coverage

### DIFF
--- a/crates/mssql-client/src/change_tracking.rs
+++ b/crates/mssql-client/src/change_tracking.rs
@@ -316,7 +316,11 @@ impl ChangeTrackingQuery {
 
     /// Generate the SQL query string.
     ///
-    /// This returns a query that can be executed directly.
+    /// This returns a query that can be executed directly. The table name is
+    /// bracket-quoted part by part (`dbo.Items` → `[dbo].[Items]`) and the
+    /// alias, primary key, and column names are bracket-quoted as single
+    /// identifiers; pass all of them unbracketed — pre-bracketed input is
+    /// treated as literal characters of the name.
     #[must_use]
     pub fn to_sql(&self) -> String {
         let force_seek = if self.force_seek { ", FORCESEEK" } else { "" };
@@ -328,7 +332,11 @@ impl ChangeTrackingQuery {
         // the CHANGETABLE function must be aliased.", error 22104).
         format!(
             "SELECT {} FROM CHANGETABLE(CHANGES {}, {}{}) AS {}",
-            select_cols, self.table_name, self.last_sync_version, force_seek, self.alias
+            select_cols,
+            ChangeTracking::bracket_table_name(&self.table_name),
+            self.last_sync_version,
+            force_seek,
+            bracket_identifier(&self.alias)
         )
     }
 
@@ -354,7 +362,7 @@ impl ChangeTrackingQuery {
     #[must_use]
     pub fn to_sql_with_data(&self, data_columns: &[&str]) -> String {
         let force_seek = if self.force_seek { ", FORCESEEK" } else { "" };
-        let alias = &self.alias;
+        let alias = bracket_identifier(&self.alias);
 
         // Build change tracking columns
         let ct_cols = format!(
@@ -365,7 +373,7 @@ impl ChangeTrackingQuery {
         // Build data columns (prefixed with table alias)
         let data_cols: String = data_columns
             .iter()
-            .map(|c| format!("T.{c}"))
+            .map(|c| format!("T.{}", bracket_identifier(c)))
             .collect::<Vec<_>>()
             .join(", ");
 
@@ -375,7 +383,7 @@ impl ChangeTrackingQuery {
             .as_ref()
             .map(|pks| {
                 pks.iter()
-                    .map(|pk| format!("{alias}.{pk}"))
+                    .map(|pk| format!("{alias}.{}", bracket_identifier(pk)))
                     .collect::<Vec<_>>()
                     .join(", ")
             })
@@ -387,7 +395,10 @@ impl ChangeTrackingQuery {
             .as_ref()
             .map(|pks| {
                 pks.iter()
-                    .map(|pk| format!("{alias}.{pk} = T.{pk}"))
+                    .map(|pk| {
+                        let pk = bracket_identifier(pk);
+                        format!("{alias}.{pk} = T.{pk}")
+                    })
                     .collect::<Vec<_>>()
                     .join(" AND ")
             })
@@ -403,13 +414,13 @@ impl ChangeTrackingQuery {
             "SELECT {select_cols} \
              FROM CHANGETABLE(CHANGES {table}, {version}{force_seek}) AS {alias} \
              LEFT OUTER JOIN {table} AS T ON {join_condition}",
-            table = self.table_name,
+            table = ChangeTracking::bracket_table_name(&self.table_name),
             version = self.last_sync_version,
         )
     }
 
     fn build_select_columns(&self) -> String {
-        let alias = &self.alias;
+        let alias = bracket_identifier(&self.alias);
 
         // Always include change tracking system columns
         let mut cols = vec![
@@ -423,14 +434,14 @@ impl ChangeTrackingQuery {
         // Add primary key columns if specified
         if let Some(ref pks) = self.primary_keys {
             for pk in pks {
-                cols.push(format!("{alias}.{pk}"));
+                cols.push(format!("{alias}.{}", bracket_identifier(pk)));
             }
         }
 
         // Add data columns if specified
         if let Some(ref data_cols) = self.columns {
             for col in data_cols {
-                cols.push(format!("{alias}.{col}"));
+                cols.push(format!("{alias}.{}", bracket_identifier(col)));
             }
         }
 
@@ -621,6 +632,15 @@ fn escape_nvarchar_literal(s: &str) -> String {
     s.replace('\'', "''")
 }
 
+/// Bracket a single identifier (alias, column, or primary-key name) with
+/// interior `]` doubled (the T-SQL QUOTENAME rule), so hostile input stays
+/// one quoted identifier instead of escaping into the surrounding statement.
+/// Pass names unbracketed; pre-bracketed input is treated as literal
+/// characters of the name.
+fn bracket_identifier(name: &str) -> String {
+    format!("[{}]", name.replace(']', "]]"))
+}
+
 /// Result of checking if a sync version is still valid.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
@@ -742,14 +762,14 @@ mod tests {
         let query = ChangeTrackingQuery::changes("Products", 42);
         let sql = query.to_sql();
 
-        assert!(sql.contains("CHANGETABLE(CHANGES Products, 42)"));
+        assert!(sql.contains("CHANGETABLE(CHANGES [Products], 42)"));
         assert!(sql.contains("SYS_CHANGE_VERSION"));
         assert!(sql.contains("SYS_CHANGE_OPERATION"));
         // SQL Server rejects CHANGETABLE without an alias (error 22104) —
         // the substring above matches the broken pre-alias SQL too, so pin
         // the alias explicitly.
         assert!(
-            sql.contains(") AS CT"),
+            sql.contains(") AS [CT]"),
             "CHANGETABLE must be aliased or the query is not executable: {sql}"
         );
     }
@@ -759,8 +779,8 @@ mod tests {
         let query = ChangeTrackingQuery::changes("Products", 42).with_columns(&["Name", "Price"]);
         let sql = query.to_sql();
 
-        assert!(sql.contains("CT.Name"));
-        assert!(sql.contains("CT.Price"));
+        assert!(sql.contains("[CT].[Name]"));
+        assert!(sql.contains("[CT].[Price]"));
     }
 
     #[test]
@@ -768,7 +788,7 @@ mod tests {
         let query = ChangeTrackingQuery::changes("Products", 42).with_primary_keys(&["ProductId"]);
         let sql = query.to_sql();
 
-        assert!(sql.contains("CT.ProductId"));
+        assert!(sql.contains("[CT].[ProductId]"));
     }
 
     #[test]
@@ -784,10 +804,48 @@ mod tests {
         let query = ChangeTrackingQuery::changes("Products", 42).with_primary_keys(&["ProductId"]);
         let sql = query.to_sql_with_data(&["Name", "Price"]);
 
-        assert!(sql.contains("LEFT OUTER JOIN Products AS T"));
-        assert!(sql.contains("CT.ProductId = T.ProductId"));
-        assert!(sql.contains("T.Name"));
-        assert!(sql.contains("T.Price"));
+        assert!(sql.contains("LEFT OUTER JOIN [Products] AS T"));
+        assert!(sql.contains("[CT].[ProductId] = T.[ProductId]"));
+        assert!(sql.contains("T.[Name]"));
+        assert!(sql.contains("T.[Price]"));
+    }
+
+    /// Issue #186: the query builder spliced identifiers verbatim, so a
+    /// hostile table name could terminate CHANGETABLE(...) and smuggle a
+    /// second statement into the batch. Same rules as the #144 helpers:
+    /// per-part bracketing for the table name, single-identifier bracketing
+    /// with `]`-doubling for alias/column/PK names.
+    #[test]
+    fn test_change_tracking_query_brackets_hostile_identifiers() {
+        let hostile_table = "T, 0) AS CT; DROP TABLE x--";
+        let sql = ChangeTrackingQuery::changes(hostile_table, 42).to_sql();
+        assert!(
+            sql.contains("CHANGETABLE(CHANGES [T, 0) AS CT; DROP TABLE x--], 42)"),
+            "hostile table name must stay one quoted identifier: {sql}"
+        );
+
+        // `]` is doubled so the identifier cannot be closed early.
+        let sql = ChangeTrackingQuery::changes("foo]; DROP TABLE bar--", 1).to_sql();
+        assert!(sql.contains("CHANGETABLE(CHANGES [foo]]; DROP TABLE bar--], 1)"));
+
+        // Schema-qualified names bracket part by part.
+        let sql = ChangeTrackingQuery::changes("dbo.Items", 1).to_sql();
+        assert!(sql.contains("CHANGETABLE(CHANGES [dbo].[Items], 1)"));
+
+        // Alias and column names are bracketed in the SELECT list.
+        let sql = ChangeTrackingQuery::changes("Products", 1)
+            .with_alias("A]; DROP TABLE x--")
+            .with_columns(&["C] FROM x--"])
+            .to_sql();
+        assert!(sql.contains("AS [A]]; DROP TABLE x--]"));
+        assert!(sql.contains("[A]]; DROP TABLE x--].[C]] FROM x--]"));
+
+        // PK and data-column names are bracketed in the join form too.
+        let sql = ChangeTrackingQuery::changes("Products", 1)
+            .with_primary_keys(&["P]--"])
+            .to_sql_with_data(&["D]--"]);
+        assert!(sql.contains("[CT].[P]]--] = T.[P]]--]"));
+        assert!(sql.contains("T.[D]]--]"));
     }
 
     #[test]

--- a/crates/mssql-client/src/client.rs
+++ b/crates/mssql-client/src/client.rs
@@ -45,6 +45,11 @@ use crate::statement_cache::StatementCache;
 use crate::stream::{MultiResultStream, QueryStream};
 use crate::transaction::SavePoint;
 
+/// How long to wait for the server to acknowledge an Attention packet after
+/// a command timeout. SqlClient waits 5 seconds before dooming the
+/// connection; we match it.
+const ATTENTION_ACK_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+
 /// Run a network future under an optional command deadline.
 ///
 /// On timeout this sends an Attention packet via `canceller` and then awaits
@@ -53,7 +58,13 @@ use crate::transaction::SavePoint;
 /// [`Error::CommandTimeout`]. This is the cancel-safe alternative to dropping
 /// the future (e.g. via `tokio::time::timeout`), which would leave unconsumed
 /// TDS data in the connection buffer and desync the next request.
-async fn run_with_deadline<F, T>(
+///
+/// The drain itself is bounded by [`ATTENTION_ACK_TIMEOUT`] — a hung server
+/// that never acknowledges the attention must not turn the timeout into an
+/// infinite wait. When the bound expires the connection is abandoned
+/// mid-response: `in_flight` stays set, so the pool discards the connection
+/// at check-in instead of reusing it.
+pub(crate) async fn run_with_deadline<F, T>(
     fut: F,
     deadline: Option<std::time::Duration>,
     canceller: crate::cancel::CancelHandle,
@@ -71,8 +82,16 @@ where
         () = tokio::time::sleep(d) => {
             // Signal cancellation, then let the in-flight read consume the
             // server's attention acknowledgement so the connection stays usable.
-            let _ = canceller.cancel().await;
-            let _ = fut.await;
+            let drain = async {
+                let _ = canceller.cancel().await;
+                let _ = (&mut fut).await;
+            };
+            if tokio::time::timeout(ATTENTION_ACK_TIMEOUT, drain).await.is_err() {
+                tracing::warn!(
+                    timeout = ?ATTENTION_ACK_TIMEOUT,
+                    "server did not acknowledge attention; abandoning the connection as dirty"
+                );
+            }
             Err(Error::CommandTimeout)
         }
     }
@@ -141,9 +160,33 @@ impl<S: ConnectionState> Client<S> {
     ///
     /// Returns `None` when `command_timeout` is zero, which means "no limit"
     /// (matching ADO.NET's `SqlCommand.CommandTimeout = 0`).
-    fn command_deadline(&self) -> Option<std::time::Duration> {
+    pub(crate) fn command_deadline(&self) -> Option<std::time::Duration> {
         let t = self.config.command_timeout;
         if t.is_zero() { None } else { Some(t) }
+    }
+
+    /// Build a cancel handle for the current connection, regardless of
+    /// connection state. The public, documented surface is
+    /// [`Client::<Ready>::cancel_handle`]; both state-specific methods
+    /// delegate here.
+    pub(crate) fn connection_cancel_handle(&self) -> crate::cancel::CancelHandle {
+        let connection = self
+            .connection
+            .as_ref()
+            .expect("connection should be present");
+        match connection {
+            #[cfg(feature = "tls")]
+            ConnectionHandle::Tls(conn) => {
+                crate::cancel::CancelHandle::from_tls(conn.cancel_handle())
+            }
+            #[cfg(feature = "tls")]
+            ConnectionHandle::TlsPrelogin(conn) => {
+                crate::cancel::CancelHandle::from_tls_prelogin(conn.cancel_handle())
+            }
+            ConnectionHandle::Plain(conn) => {
+                crate::cancel::CancelHandle::from_plain(conn.cancel_handle())
+            }
+        }
     }
 
     /// Process transaction-related EnvChange tokens.
@@ -332,8 +375,17 @@ impl<S: ConnectionState> Client<S> {
             rpc = rpc.param(param);
         }
 
-        self.send_rpc(&rpc).await?;
-        self.read_procedure_result().await
+        let deadline = self.command_deadline();
+        let canceller = self.connection_cancel_handle();
+        run_with_deadline(
+            async {
+                self.send_rpc(&rpc).await?;
+                self.read_procedure_result().await
+            },
+            deadline,
+            canceller,
+        )
+        .await
     }
 
     /// Start a bulk insert operation for the specified table.
@@ -638,16 +690,28 @@ impl<S: ConnectionState> Client<S> {
             "executing statement with named parameters"
         );
 
-        if params.is_empty() {
-            self.send_sql_batch(sql).await?;
-        } else {
-            let rpc_params =
-                Self::convert_named_params(params, self.send_unicode(), self.server_collation())?;
-            let rpc = RpcRequest::execute_sql(sql, rpc_params);
-            self.send_rpc(&rpc).await?;
-        }
+        let deadline = self.command_deadline();
+        let canceller = self.connection_cancel_handle();
+        run_with_deadline(
+            async {
+                if params.is_empty() {
+                    self.send_sql_batch(sql).await?;
+                } else {
+                    let rpc_params = Self::convert_named_params(
+                        params,
+                        self.send_unicode(),
+                        self.server_collation(),
+                    )?;
+                    let rpc = RpcRequest::execute_sql(sql, rpc_params);
+                    self.send_rpc(&rpc).await?;
+                }
 
-        self.read_execute_result().await
+                self.read_execute_result().await
+            },
+            deadline,
+            canceller,
+        )
+        .await
     }
 
     /// Whether string parameters are sent as NVARCHAR (Unicode).
@@ -878,19 +942,28 @@ impl Client<Ready> {
             "executing multi-result query"
         );
 
-        if params.is_empty() {
-            // Simple batch without parameters - use SQL batch
-            self.send_sql_batch(sql).await?;
-        } else {
-            // Parameterized query - use sp_executesql via RPC
-            let rpc_params =
-                Self::convert_params(params, self.send_unicode(), self.server_collation())?;
-            let rpc = RpcRequest::execute_sql(sql, rpc_params);
-            self.send_rpc(&rpc).await?;
-        }
+        let deadline = self.command_deadline();
+        let canceller = self.connection_cancel_handle();
+        let result_sets = run_with_deadline(
+            async {
+                if params.is_empty() {
+                    // Simple batch without parameters - use SQL batch
+                    self.send_sql_batch(sql).await?;
+                } else {
+                    // Parameterized query - use sp_executesql via RPC
+                    let rpc_params =
+                        Self::convert_params(params, self.send_unicode(), self.server_collation())?;
+                    let rpc = RpcRequest::execute_sql(sql, rpc_params);
+                    self.send_rpc(&rpc).await?;
+                }
 
-        // Read all result sets
-        let result_sets = self.read_multi_result_response().await?;
+                // Read all result sets
+                self.read_multi_result_response().await
+            },
+            deadline,
+            canceller,
+        )
+        .await?;
         Ok(MultiResultStream::new(result_sets))
     }
 
@@ -1247,23 +1320,7 @@ impl Client<Ready> {
     /// ```
     #[must_use]
     pub fn cancel_handle(&self) -> crate::cancel::CancelHandle {
-        let connection = self
-            .connection
-            .as_ref()
-            .expect("connection should be present");
-        match connection {
-            #[cfg(feature = "tls")]
-            ConnectionHandle::Tls(conn) => {
-                crate::cancel::CancelHandle::from_tls(conn.cancel_handle())
-            }
-            #[cfg(feature = "tls")]
-            ConnectionHandle::TlsPrelogin(conn) => {
-                crate::cancel::CancelHandle::from_tls_prelogin(conn.cancel_handle())
-            }
-            ConnectionHandle::Plain(conn) => {
-                crate::cancel::CancelHandle::from_plain(conn.cancel_handle())
-            }
-        }
+        self.connection_cancel_handle()
     }
 }
 
@@ -1733,23 +1790,7 @@ impl Client<InTransaction> {
     /// See [`Client<Ready>::cancel_handle`] for usage examples.
     #[must_use]
     pub fn cancel_handle(&self) -> crate::cancel::CancelHandle {
-        let connection = self
-            .connection
-            .as_ref()
-            .expect("connection should be present");
-        match connection {
-            #[cfg(feature = "tls")]
-            ConnectionHandle::Tls(conn) => {
-                crate::cancel::CancelHandle::from_tls(conn.cancel_handle())
-            }
-            #[cfg(feature = "tls")]
-            ConnectionHandle::TlsPrelogin(conn) => {
-                crate::cancel::CancelHandle::from_tls_prelogin(conn.cancel_handle())
-            }
-            ConnectionHandle::Plain(conn) => {
-                crate::cancel::CancelHandle::from_plain(conn.cancel_handle())
-            }
-        }
+        self.connection_cancel_handle()
     }
 }
 

--- a/crates/mssql-client/src/error.rs
+++ b/crates/mssql-client/src/error.rs
@@ -134,6 +134,12 @@ pub enum Error {
     },
 
     /// Command execution timeout occurred.
+    ///
+    /// The driver cancels the command via an Attention packet and drains the
+    /// server's acknowledgement, so the connection normally stays usable. If
+    /// the server never acknowledges within a bounded wait (5 s, SqlClient
+    /// parity), the connection is left mid-response and is discarded by the
+    /// pool instead of being reused.
     #[error("command timed out")]
     CommandTimeout,
 

--- a/crates/mssql-client/src/procedure.rs
+++ b/crates/mssql-client/src/procedure.rs
@@ -239,8 +239,17 @@ impl<'a, S: ConnectionState> ProcedureBuilder<'a, S> {
             rpc = rpc.param(param);
         }
 
-        self.client.send_rpc(&rpc).await?;
-        self.client.read_procedure_result().await
+        let deadline = self.client.command_deadline();
+        let canceller = self.client.connection_cancel_handle();
+        crate::client::run_with_deadline(
+            async {
+                self.client.send_rpc(&rpc).await?;
+                self.client.read_procedure_result().await
+            },
+            deadline,
+            canceller,
+        )
+        .await
     }
 }
 

--- a/crates/mssql-client/tests/resilience.rs
+++ b/crates/mssql-client/tests/resilience.rs
@@ -520,6 +520,84 @@ async fn test_default_command_timeout_enforced() {
     client.close().await.expect("Failed to close");
 }
 
+/// Issue #185 regression: `command_timeout` must cover the stored-procedure,
+/// named-parameter, and multi-result paths — previously only `query()` and
+/// `execute()` ran under the deadline.
+#[tokio::test]
+#[ignore = "Requires SQL Server"]
+async fn test_command_timeout_covers_all_command_paths() {
+    let mut config = get_test_config().expect("SQL Server config required");
+    config.command_timeout = Duration::from_secs(1);
+    let mut client = Client::connect(config).await.expect("Failed to connect");
+
+    const SLOW: &str = "WAITFOR DELAY '00:00:10'";
+
+    client
+        .execute(
+            "CREATE OR ALTER PROCEDURE dbo.slow_proc_185 AS WAITFOR DELAY '00:00:10'",
+            &[],
+        )
+        .await
+        .expect("creating the slow procedure must succeed");
+
+    // Each closure result is checked the same way: CommandTimeout near 1s,
+    // and the connection must answer a fresh query afterwards.
+    fn expect_timeout<T: std::fmt::Debug>(
+        path: &str,
+        start: std::time::Instant,
+        result: Result<T, mssql_client::Error>,
+    ) {
+        match result {
+            Err(mssql_client::Error::CommandTimeout) => {}
+            Err(other) => panic!("{path}: expected CommandTimeout, got {other:?}"),
+            Ok(v) => panic!("{path}: expected CommandTimeout, got Ok({v:?})"),
+        }
+        let elapsed = start.elapsed();
+        assert!(
+            elapsed < Duration::from_secs(5),
+            "{path}: timeout must fire near 1s, not wait out the 10s delay; took {elapsed:?}"
+        );
+    }
+
+    let start = std::time::Instant::now();
+    let result = client.call_procedure("dbo.slow_proc_185", &[]).await;
+    expect_timeout("call_procedure", start, result);
+
+    let start = std::time::Instant::now();
+    let result = client
+        .procedure("dbo.slow_proc_185")
+        .expect("valid procedure name")
+        .execute()
+        .await;
+    expect_timeout("ProcedureBuilder::execute", start, result);
+
+    let start = std::time::Instant::now();
+    let result = client.execute_named(SLOW, &[]).await;
+    expect_timeout("execute_named", start, result);
+
+    let start = std::time::Instant::now();
+    let result = client
+        .query_multiple(&format!("{SLOW}; SELECT 1 AS n"), &[])
+        .await
+        .map(|_| ());
+    expect_timeout("query_multiple", start, result);
+
+    // After four cancels in a row the connection must still be clean.
+    let rows = client
+        .query("SELECT 99 AS n", &[])
+        .await
+        .expect("connection must be usable after timeouts on every path");
+    let data: Vec<_> = rows.filter_map(|r| r.ok()).collect();
+    let n: i32 = data[0].get(0).expect("must read fresh result");
+    assert_eq!(n, 99);
+
+    client
+        .execute("DROP PROCEDURE dbo.slow_proc_185", &[])
+        .await
+        .expect("cleanup must succeed");
+    client.close().await.expect("Failed to close");
+}
+
 /// Test that short timeout interrupts long-running query.
 #[tokio::test]
 #[ignore = "Requires SQL Server"]

--- a/crates/tds-protocol/src/collation.rs
+++ b/crates/tds-protocol/src/collation.rs
@@ -282,8 +282,8 @@ pub fn encoding_for_sort_id(sort_id: u8) -> Option<&'static Encoding> {
         144..=146 => Some(encoding_rs::WINDOWS_1256),
         152..=160 => Some(encoding_rs::WINDOWS_1257),
         192 | 193 | 200 => Some(encoding_rs::SHIFT_JIS), // CP932
-        194 | 195 => Some(encoding_rs::EUC_KR),          // CP949
-        196 | 197 | 201 | 202 => Some(encoding_rs::BIG5), // CP950
+        194 | 195 | 201 => Some(encoding_rs::EUC_KR),    // CP949
+        196 | 197 | 202 => Some(encoding_rs::BIG5),      // CP950
         198 | 199 | 203 => Some(encoding_rs::GB18030),   // CP936
         204..=206 => Some(encoding_rs::WINDOWS_874),
         _ => None,
@@ -310,8 +310,8 @@ pub fn code_page_for_sort_id(sort_id: u8) -> Option<u16> {
         144..=146 => Some(1256),
         152..=160 => Some(1257),
         192 | 193 | 200 => Some(932),
-        194 | 195 => Some(949),
-        196 | 197 | 201 | 202 => Some(950),
+        194 | 195 | 201 => Some(949),
+        196 | 197 | 202 => Some(950),
         198 | 199 | 203 => Some(936),
         204..=206 => Some(874),
         _ => None,
@@ -650,6 +650,13 @@ mod tests {
             Some("Shift_JIS")
         );
         assert_eq!(encoding_for_sort_id(198).map(|e| e.name()), Some("gb18030"));
+
+        // Issue #187: SortId 201 is NLS_CP949_CS (Korean Wansung
+        // case-sensitive) → CP949, not CP950/Big5. Its neighbors stay CP950.
+        assert_eq!(encoding_for_sort_id(201).map(|e| e.name()), Some("EUC-KR"));
+        assert_eq!(code_page_for_sort_id(201), Some(949));
+        assert_eq!(encoding_for_sort_id(202).map(|e| e.name()), Some("Big5"));
+        assert_eq!(code_page_for_sort_id(202), Some(950));
 
         // CP437/CP850 are not representable in encoding_rs: no encoding, but
         // the true code page is still reported for error messages.


### PR DESCRIPTION
## Summary

Fixes three of the residual findings from the post-v0.13.0 verification pass (the code-level re-review of the #151–#167 remediation): the wrong code page for SortId 201, the verbatim-splice SQL injection left in `ChangeTrackingQuery`, and the two gaps in the command-timeout fix (unbounded attention-ack drain; four command paths with no deadline).

## Linked issues

Closes #186
Closes #187
Refs #185 — the drain bound and the `call_procedure` / `execute_named` / `query_multiple` / `ProcedureBuilder::execute` coverage land here; #185 stays open scoped to bulk insert, which needs SqlBulkCopy-style timeout semantics rather than a `run_with_deadline` wrap.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## What changed

**SortId 201 (#187)** — moved from the Big5/CP950 arm to EUC-KR/CP949 in both `encoding_for_sort_id` and `code_page_for_sort_id`, per the mssql-jdbc SortOrder mapping the table is derived from (`NLS_CP949_CS`, Korean Wansung case-sensitive). Regression test pins 201→CP949 and its neighbors 202→CP950.

**ChangeTrackingQuery bracketing (#186)** — `to_sql()`, `to_sql_with_data()`, and `build_select_columns()` now apply the same rules the #144 fix gave the `ChangeTracking` helpers: per-part bracketing with `]`-doubling for the table name, single-identifier bracketing for alias/column/PK names. Generated SQL changes shape (`CHANGETABLE(CHANGES [dbo].[Items], …) AS [CT]`); pass names unbracketed — pre-bracketed input is treated as literal characters, matching the #144 convention. Not an API break (signatures unchanged). Hostile-identifier regression tests included.

**Command timeout (#185)** — the post-ATTENTION drain is now bounded at 5 s (SqlClient parity). If the server never acknowledges, `Error::CommandTimeout` is returned anyway and the connection stays `in_flight`, so the pool discards it at check-in instead of reusing it (documented on the error variant). The four uncovered command paths now run under `run_with_deadline`; the duplicated `cancel_handle` bodies on `Client<Ready>`/`Client<InTransaction>` were hoisted into a `pub(crate) connection_cancel_handle` on the generic impl to enable that.

## Test plan

- [x] `just ci-all` (fmt + clippy `-D warnings` + nextest all-features + `cargo doc -D warnings` + examples) — 858 tests passed
- [x] `just typos` (typos-cli 1.42.3)
- [x] Live ignored-only suite against local SQL Server 2022 (`mssql-ci-local`) — 242 tests passed, including the new `test_command_timeout_covers_all_command_paths` (all four paths cancel near 1 s and the connection stays usable after four consecutive cancels)
- [x] For behavioral changes: new or updated tests cover the change

**Known verification gap:** the drain-bound path itself (server never acknowledges the ATTENTION) is not feasibly testable against a real server; it is covered by code review only.

## Documentation updates

- [x] Updated rustdoc comments on new/changed public items (`Error::CommandTimeout`, `ChangeTrackingQuery::to_sql`)
- [ ] CHANGELOG.md — owned by release-plz (entries derive from the conventional commits), per repo convention

## Breaking changes

None. `ChangeTrackingQuery` output SQL changes shape (identifiers now bracket-quoted), which is a behavior change for anyone string-matching the generated SQL, but signatures and semantics against a real server are unchanged.