### PR TITLE
fix: correctness batch — ENVCHANGE frame-strict decode, TLS flight splitting, DATE range enforcement

### DIFF
--- a/crates/mssql-client/src/bulk.rs
+++ b/crates/mssql-client/src/bulk.rs
@@ -1006,7 +1006,7 @@ impl BulkInsert {
             #[cfg(feature = "chrono")]
             SqlValue::Date(d) => {
                 buf.put_u8(3); // Length
-                mssql_types::encode::encode_date(*d, buf);
+                mssql_types::encode::encode_date(*d, buf)?;
             }
 
             #[cfg(feature = "chrono")]
@@ -1045,7 +1045,7 @@ impl BulkInsert {
                     buf.put_u8(total_len);
                     // Encode time then date
                     encode_time_with_scale(dt.time(), scale, buf);
-                    mssql_types::encode::encode_date(dt.date(), buf);
+                    mssql_types::encode::encode_date(dt.date(), buf)?;
                 }
             }
             #[cfg(feature = "chrono")]
@@ -1083,7 +1083,7 @@ impl BulkInsert {
                 // not the local wall-clock.
                 let utc = dto.naive_utc();
                 encode_time_with_scale(utc.time(), scale, buf);
-                mssql_types::encode::encode_date(utc.date(), buf);
+                mssql_types::encode::encode_date(utc.date(), buf)?;
                 // Timezone offset in minutes
                 use chrono::Offset;
                 let offset_minutes = (dto.offset().fix().local_minus_utc() / 60) as i16;

--- a/crates/mssql-client/src/client/params.rs
+++ b/crates/mssql-client/src/client/params.rs
@@ -125,7 +125,7 @@ impl<S: ConnectionState> Client<S> {
             #[cfg(feature = "chrono")]
             SqlValue::Date(d) => {
                 let mut buf = BytesMut::with_capacity(3);
-                mssql_types::encode::encode_date(*d, &mut buf);
+                mssql_types::encode::encode_date(*d, &mut buf)?;
                 RpcParam::new(name, RpcTypeInfo::date(), buf.freeze())
             }
             #[cfg(feature = "chrono")]
@@ -137,7 +137,7 @@ impl<S: ConnectionState> Client<S> {
             #[cfg(feature = "chrono")]
             SqlValue::DateTime(dt) => {
                 let mut buf = BytesMut::with_capacity(8);
-                mssql_types::encode::encode_datetime2(*dt, &mut buf);
+                mssql_types::encode::encode_datetime2(*dt, &mut buf)?;
                 RpcParam::new(name, RpcTypeInfo::datetime2(7), buf.freeze())
             }
             #[cfg(feature = "chrono")]
@@ -149,7 +149,7 @@ impl<S: ConnectionState> Client<S> {
             #[cfg(feature = "chrono")]
             SqlValue::DateTimeOffset(dto) => {
                 let mut buf = BytesMut::with_capacity(10);
-                mssql_types::encode::encode_datetimeoffset(*dto, &mut buf);
+                mssql_types::encode::encode_datetimeoffset(*dto, &mut buf)?;
                 RpcParam::new(name, RpcTypeInfo::datetimeoffset(7), buf.freeze())
             }
             #[cfg(feature = "json")]

--- a/crates/mssql-tls/src/prelogin_wrapper.rs
+++ b/crates/mssql-tls/src/prelogin_wrapper.rs
@@ -20,6 +20,13 @@ const PACKET_TYPE_PRELOGIN: u8 = 0x12;
 /// TDS packet status for end of message.
 const PACKET_STATUS_EOM: u8 = 0x01;
 
+/// Packet size cap before login completes (MS-TDS: 4096 until a larger size
+/// is negotiated, which cannot happen during the PRELOGIN TLS handshake).
+const HANDSHAKE_PACKET_SIZE: usize = 4096;
+
+/// TLS payload per handshake packet.
+const MAX_HANDSHAKE_PAYLOAD: usize = HANDSHAKE_PACKET_SIZE - HEADER_SIZE;
+
 /// Wrapper for TLS streams that handles TDS packet framing during handshake.
 ///
 /// During the TLS handshake phase, this wrapper:
@@ -181,25 +188,40 @@ impl<S: AsyncWrite + Unpin> AsyncWrite for TlsPreloginWrapper<S> {
     fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
         let this = self.get_mut();
 
-        // If in handshake mode and we have buffered data, wrap it in a TDS packet
+        // If in handshake mode and we have buffered data, wrap it in TDS packets
         if this.pending_handshake && this.write_buf.len() > HEADER_SIZE {
             if !this.header_written {
-                // Write the TDS header at the beginning of the buffer
-                let total_length = this.write_buf.len();
-
-                this.write_buf[0] = PACKET_TYPE_PRELOGIN;
-                this.write_buf[1] = PACKET_STATUS_EOM;
-                this.write_buf[2] = (total_length >> 8) as u8;
-                this.write_buf[3] = total_length as u8;
-                this.write_buf[4] = 0; // SPID
-                this.write_buf[5] = 0; // SPID
-                this.write_buf[6] = 1; // Packet ID
-                this.write_buf[7] = 0; // Window
-
-                this.header_written = true;
+                // The buffered TLS flight can exceed one packet (e.g. a
+                // client-certificate chain). Pre-login packets are capped at
+                // 4096 bytes — and the header length field is a u16, so a
+                // single oversized packet would silently truncate the length
+                // (flight mod 65536) and corrupt the framing. Split the
+                // flight into as many PRELOGIN packets as needed, each a
+                // complete EOM message.
+                let payload = this.write_buf.split_off(HEADER_SIZE);
+                let packets = payload.len().div_ceil(MAX_HANDSHAKE_PAYLOAD);
+                let mut framed = Vec::with_capacity(payload.len() + packets * HEADER_SIZE);
+                for (i, chunk) in payload.chunks(MAX_HANDSHAKE_PAYLOAD).enumerate() {
+                    let total = HEADER_SIZE + chunk.len();
+                    framed.push(PACKET_TYPE_PRELOGIN);
+                    framed.push(PACKET_STATUS_EOM);
+                    framed.push((total >> 8) as u8);
+                    framed.push(total as u8);
+                    framed.push(0); // SPID
+                    framed.push(0); // SPID
+                    framed.push((i as u8).wrapping_add(1)); // Packet ID (mod 256)
+                    framed.push(0); // Window
+                    framed.extend_from_slice(chunk);
+                }
+                this.write_buf = framed;
                 this.write_pos = 0;
+                this.header_written = true;
 
-                tracing::trace!("TLS wrapper: sending {} bytes", total_length);
+                tracing::trace!(
+                    payload_bytes = payload.len(),
+                    packets,
+                    "TLS wrapper: sending handshake flight"
+                );
             }
 
             // Write all buffered data
@@ -214,8 +236,10 @@ impl<S: AsyncWrite + Unpin> AsyncWrite for TlsPreloginWrapper<S> {
                 }
             }
 
-            // Reset for next write
-            this.write_buf.truncate(HEADER_SIZE);
+            // Reset for the next flight: restore the reserved header prefix
+            // that poll_write appends payload after.
+            this.write_buf.clear();
+            this.write_buf.resize(HEADER_SIZE, 0);
             this.write_pos = HEADER_SIZE;
             this.header_written = false;
         }
@@ -225,5 +249,102 @@ impl<S: AsyncWrite + Unpin> AsyncWrite for TlsPreloginWrapper<S> {
 
     fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
         Pin::new(&mut self.get_mut().stream).poll_shutdown(cx)
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    /// Parse `(type, status, packet_id, payload)` for each TDS packet.
+    fn parse_packets(mut bytes: &[u8]) -> Vec<(u8, u8, u8, Vec<u8>)> {
+        let mut packets = Vec::new();
+        while !bytes.is_empty() {
+            let total = usize::from(bytes[2]) << 8 | usize::from(bytes[3]);
+            let (packet, rest) = bytes.split_at(total);
+            packets.push((
+                packet[0],
+                packet[1],
+                packet[6],
+                packet[HEADER_SIZE..].to_vec(),
+            ));
+            bytes = rest;
+        }
+        packets
+    }
+
+    #[tokio::test]
+    async fn small_flight_is_one_prelogin_packet() {
+        let (client, mut server) = tokio::io::duplex(1 << 20);
+        let mut wrapper = TlsPreloginWrapper::new(client);
+        let payload: Vec<u8> = (0..100u8).collect();
+        wrapper.write_all(&payload).await.unwrap();
+        wrapper.flush().await.unwrap();
+
+        let mut received = vec![0u8; payload.len() + HEADER_SIZE];
+        server.read_exact(&mut received).await.unwrap();
+        let packets = parse_packets(&received);
+        assert_eq!(packets.len(), 1);
+        let (ptype, status, id, data) = &packets[0];
+        assert_eq!(*ptype, PACKET_TYPE_PRELOGIN);
+        assert_eq!(*status, PACKET_STATUS_EOM);
+        assert_eq!(*id, 1);
+        assert_eq!(*data, payload);
+    }
+
+    /// Issue #167 regression: a handshake flight larger than 65535 bytes
+    /// (realistic with TLS client-certificate chains) used to be framed as
+    /// ONE packet whose u16 length field silently truncated to
+    /// `flight mod 65536`, corrupting the stream. The flight must be split
+    /// at the 4096-byte pre-login packet cap.
+    #[tokio::test]
+    async fn oversized_flight_splits_at_packet_cap() {
+        let (client, mut server) = tokio::io::duplex(1 << 20);
+        let mut wrapper = TlsPreloginWrapper::new(client);
+        let payload: Vec<u8> = (0..70_000u32).map(|i| (i % 251) as u8).collect();
+        wrapper.write_all(&payload).await.unwrap();
+        wrapper.flush().await.unwrap();
+
+        let expected_packets = payload.len().div_ceil(MAX_HANDSHAKE_PAYLOAD);
+        let mut received = vec![0u8; payload.len() + expected_packets * HEADER_SIZE];
+        server.read_exact(&mut received).await.unwrap();
+
+        let packets = parse_packets(&received);
+        assert_eq!(packets.len(), expected_packets);
+        let mut reassembled = Vec::new();
+        for (i, (ptype, status, id, data)) in packets.iter().enumerate() {
+            assert_eq!(*ptype, PACKET_TYPE_PRELOGIN);
+            assert_eq!(
+                *status, PACKET_STATUS_EOM,
+                "each chunk is its own complete EOM message"
+            );
+            assert_eq!(*id, (i as u8).wrapping_add(1));
+            assert!(data.len() + HEADER_SIZE <= HANDSHAKE_PACKET_SIZE);
+            reassembled.extend_from_slice(data);
+        }
+        assert_eq!(reassembled, payload, "no bytes lost or reordered");
+    }
+
+    #[tokio::test]
+    async fn consecutive_flights_reuse_the_wrapper_cleanly() {
+        // The reset path after a flight must leave the buffer ready for the
+        // next poll_write (header space reserved), or the second flight's
+        // framing corrupts.
+        let (client, mut server) = tokio::io::duplex(1 << 20);
+        let mut wrapper = TlsPreloginWrapper::new(client);
+
+        for round in 0..3u8 {
+            let payload = vec![round; 50];
+            wrapper.write_all(&payload).await.unwrap();
+            wrapper.flush().await.unwrap();
+
+            let mut received = vec![0u8; payload.len() + HEADER_SIZE];
+            server.read_exact(&mut received).await.unwrap();
+            let packets = parse_packets(&received);
+            assert_eq!(packets.len(), 1);
+            assert_eq!(packets[0].3, payload, "round {round} payload intact");
+        }
     }
 }

--- a/crates/mssql-types/src/decode.rs
+++ b/crates/mssql-types/src/decode.rs
@@ -1322,7 +1322,7 @@ mod tests {
             // This is the scenario where Tiberius panics
             let mut buf = BytesMut::new();
             let date = NaiveDate::from_ymd_opt(1753, 1, 1).unwrap();
-            crate::encode::encode_date(date, &mut buf);
+            crate::encode::encode_date(date, &mut buf).unwrap();
             assert_eq!(buf.len(), 3, "DATE encoding is always 3 bytes");
         }
 
@@ -1331,7 +1331,7 @@ mod tests {
             // The DATE epoch: 0001-01-01
             let mut buf = BytesMut::new();
             let date = NaiveDate::from_ymd_opt(1, 1, 1).unwrap();
-            crate::encode::encode_date(date, &mut buf);
+            crate::encode::encode_date(date, &mut buf).unwrap();
             // Days since 0001-01-01 = 0
             assert_eq!(&buf[..], &[0, 0, 0]);
         }
@@ -1341,7 +1341,7 @@ mod tests {
             // SQL Server max DATE: 9999-12-31
             let mut buf = BytesMut::new();
             let date = NaiveDate::from_ymd_opt(9999, 12, 31).unwrap();
-            crate::encode::encode_date(date, &mut buf);
+            crate::encode::encode_date(date, &mut buf).unwrap();
             assert_eq!(buf.len(), 3, "DATE encoding is always 3 bytes");
             // 3652058 days from 0001-01-01 — fits in 3 bytes (max ~16M)
             let days = buf[0] as u32 | ((buf[1] as u32) << 8) | ((buf[2] as u32) << 16);
@@ -1473,7 +1473,7 @@ mod tests {
             ) {
                 let date = NaiveDate::from_ymd_opt(year, month, day).unwrap();
                 let mut buf = BytesMut::new();
-                crate::encode::encode_date(date, &mut buf);
+                crate::encode::encode_date(date, &mut buf).unwrap();
                 prop_assert_eq!(buf.len(), 3);
             }
         }

--- a/crates/mssql-types/src/encode.rs
+++ b/crates/mssql-types/src/encode.rs
@@ -88,27 +88,18 @@ impl TdsEncode for SqlValue {
                 Ok(())
             }
             #[cfg(feature = "chrono")]
-            SqlValue::Date(d) => {
-                encode_date(*d, buf);
-                Ok(())
-            }
+            SqlValue::Date(d) => encode_date(*d, buf),
             #[cfg(feature = "chrono")]
             SqlValue::Time(t) => {
                 encode_time(*t, buf);
                 Ok(())
             }
             #[cfg(feature = "chrono")]
-            SqlValue::DateTime(dt) => {
-                encode_datetime2(*dt, buf);
-                Ok(())
-            }
+            SqlValue::DateTime(dt) => encode_datetime2(*dt, buf),
             #[cfg(feature = "chrono")]
             SqlValue::SmallDateTime(dt) => encode_smalldatetime(*dt, buf),
             #[cfg(feature = "chrono")]
-            SqlValue::DateTimeOffset(dto) => {
-                encode_datetimeoffset(*dto, buf);
-                Ok(())
-            }
+            SqlValue::DateTimeOffset(dto) => encode_datetimeoffset(*dto, buf),
             #[cfg(feature = "json")]
             SqlValue::Json(j) => {
                 // JSON is sent as NVARCHAR string
@@ -388,16 +379,29 @@ pub fn encode_smalldatetime(
 /// Encode a DATE value.
 ///
 /// TDS DATE is the number of days since 0001-01-01.
+///
+/// Returns an error if the date is outside SQL Server's DATE range
+/// (0001-01-01 through 9999-12-31). chrono permits dates beyond both ends,
+/// which previously wrapped silently into garbage wire values.
 #[cfg(feature = "chrono")]
-pub fn encode_date(date: chrono::NaiveDate, buf: &mut BytesMut) {
-    // Calculate days since 0001-01-01
+pub fn encode_date(date: chrono::NaiveDate, buf: &mut BytesMut) -> Result<(), TypeError> {
+    /// Days from 0001-01-01 to 9999-12-31, the last representable DATE.
+    const MAX_DAYS: i64 = 3_652_058;
+
     let base = chrono::NaiveDate::from_ymd_opt(1, 1, 1).expect("valid date");
-    let days = date.signed_duration_since(base).num_days() as u32;
+    let days = date.signed_duration_since(base).num_days();
+    if !(0..=MAX_DAYS).contains(&days) {
+        return Err(TypeError::InvalidDateTime(format!(
+            "DATE must be between 0001-01-01 and 9999-12-31, got {date}"
+        )));
+    }
+    let days = days as u32;
 
     // DATE is encoded as 3 bytes (little-endian)
     buf.put_u8((days & 0xFF) as u8);
     buf.put_u8(((days >> 8) & 0xFF) as u8);
     buf.put_u8(((days >> 16) & 0xFF) as u8);
+    Ok(())
 }
 
 /// Encode a TIME value.
@@ -423,10 +427,16 @@ pub fn encode_time(time: chrono::NaiveTime, buf: &mut BytesMut) {
 /// Encode a DATETIME2 value.
 ///
 /// DATETIME2 is encoded as TIME followed by DATE.
+///
+/// Returns an error if the date portion is outside the DATE range; see
+/// [`encode_date`].
 #[cfg(feature = "chrono")]
-pub fn encode_datetime2(datetime: chrono::NaiveDateTime, buf: &mut BytesMut) {
+pub fn encode_datetime2(
+    datetime: chrono::NaiveDateTime,
+    buf: &mut BytesMut,
+) -> Result<(), TypeError> {
     encode_time(datetime.time(), buf);
-    encode_date(datetime.date(), buf);
+    encode_date(datetime.date(), buf)
 }
 
 /// Encode a DATETIMEOFFSET value.
@@ -435,18 +445,22 @@ pub fn encode_datetime2(datetime: chrono::NaiveDateTime, buf: &mut BytesMut) {
 /// MS-TDS §2.2.5.5.1.9 the date/time portion is the **UTC** instant, not the
 /// local wall-clock; the offset is carried separately.
 #[cfg(feature = "chrono")]
-pub fn encode_datetimeoffset(datetime: chrono::DateTime<chrono::FixedOffset>, buf: &mut BytesMut) {
+pub fn encode_datetimeoffset(
+    datetime: chrono::DateTime<chrono::FixedOffset>,
+    buf: &mut BytesMut,
+) -> Result<(), TypeError> {
     use chrono::Offset;
 
     // Encode the UTC date/time components
     let utc = datetime.naive_utc();
     encode_time(utc.time(), buf);
-    encode_date(utc.date(), buf);
+    encode_date(utc.date(), buf)?;
 
     // Encode timezone offset in minutes (signed 16-bit)
     let offset_seconds = datetime.offset().fix().local_minus_utc();
     let offset_minutes = (offset_seconds / 60) as i16;
     buf.put_i16_le(offset_minutes);
+    Ok(())
 }
 
 #[cfg(test)]
@@ -468,7 +482,7 @@ mod tests {
         let dto = offset.with_ymd_and_hms(2024, 3, 15, 12, 0, 0).unwrap();
 
         let mut buf = BytesMut::new();
-        encode_datetimeoffset(dto, &mut buf);
+        encode_datetimeoffset(dto, &mut buf).unwrap();
         assert_eq!(buf.len(), 10); // 5 time + 3 date + 2 offset
 
         // Time portion: 100ns intervals since midnight of the UTC instant.
@@ -532,11 +546,44 @@ mod tests {
     }
 
     #[cfg(feature = "chrono")]
+    /// Issue #167 regression: chrono dates outside SQL Server's DATE range
+    /// (0001-01-01..9999-12-31) silently wrapped `num_days() as u32` into
+    /// garbage wire values. They must error; the boundaries must encode.
+    #[test]
+    fn test_encode_date_range_enforced() {
+        let mut buf = BytesMut::new();
+
+        // Both boundaries encode.
+        let min = chrono::NaiveDate::from_ymd_opt(1, 1, 1).unwrap();
+        encode_date(min, &mut buf).unwrap();
+        assert_eq!(&buf[buf.len() - 3..], &[0, 0, 0]);
+        let max = chrono::NaiveDate::from_ymd_opt(9999, 12, 31).unwrap();
+        encode_date(max, &mut buf).unwrap();
+        // 3_652_058 = 0x37B9DA little-endian
+        assert_eq!(&buf[buf.len() - 3..], &[0xDA, 0xB9, 0x37]);
+
+        // One day past either boundary errors instead of wrapping.
+        let before = chrono::NaiveDate::from_ymd_opt(0, 12, 31).unwrap();
+        assert!(matches!(
+            encode_date(before, &mut buf),
+            Err(TypeError::InvalidDateTime(_))
+        ));
+        let after = chrono::NaiveDate::from_ymd_opt(10000, 1, 1).unwrap();
+        assert!(matches!(
+            encode_date(after, &mut buf),
+            Err(TypeError::InvalidDateTime(_))
+        ));
+
+        // The composite encoders propagate the range error.
+        let dt = before.and_hms_opt(12, 0, 0).unwrap();
+        assert!(encode_datetime2(dt, &mut buf).is_err());
+    }
+
     #[test]
     fn test_encode_date() {
         let mut buf = BytesMut::new();
         let date = chrono::NaiveDate::from_ymd_opt(2024, 1, 15).unwrap();
-        encode_date(date, &mut buf);
+        encode_date(date, &mut buf).unwrap();
         // Should be 3 bytes representing days since 0001-01-01
         assert_eq!(buf.len(), 3);
     }

--- a/crates/tds-protocol/src/token.rs
+++ b/crates/tds-protocol/src/token.rs
@@ -1896,13 +1896,28 @@ impl EnvChange {
         }
 
         let length = src.get_u16_le() as usize;
+        if length == 0 {
+            // The frame must at least contain the type byte; reading it from
+            // outside a zero-length frame would consume the next token.
+            return Err(ProtocolError::UnexpectedEof);
+        }
         if src.remaining() < length {
             return Err(ProtocolError::IncompletePacket {
                 expected: length,
                 actual: src.remaining(),
             });
         }
-        let remaining_before = src.remaining();
+
+        // Frame-strict decoding (issue #145): the value decoders below only
+        // bounds-check against the *buffer*, so on an under-declared frame
+        // they could read past the declared length into the next token's
+        // bytes. Slice exactly the declared frame and decode from that:
+        // over-read attempts now hit frame end and take the lenient
+        // empty-value fallbacks (preserving the #140 hostile-input
+        // behavior), and the outer buffer always advances by exactly
+        // `length`.
+        let mut frame = src.copy_to_bytes(length);
+        let src = &mut frame;
 
         let env_type_byte = src.get_u8();
         let env_type = EnvChangeType::from_u8(env_type_byte)
@@ -1966,17 +1981,10 @@ impl EnvChange {
             }
         };
 
-        // The declared `length` frames the whole ENVCHANGE data. Value
-        // decoders may legitimately consume less than that — e.g. the
-        // Routing decoder reads only the NewValue, leaving the spec-mandated
-        // zero-length OldValue (two bytes) behind. Skip to the frame
-        // boundary so the leftover bytes are not misparsed as the next
-        // token. (Decoders that tolerantly read *past* an under-declared
-        // length are left as-is — see the transaction/collation branch.)
-        let consumed = remaining_before - src.remaining();
-        if consumed < length {
-            src.advance(length - consumed);
-        }
+        // No frame-boundary fixup needed: the whole declared frame was
+        // consumed from the outer buffer up front, so decoders that
+        // under-consume (e.g. Routing's implicit zero-length OldValue) just
+        // leave bytes behind in the dropped sub-frame.
 
         Ok(Self {
             env_type,
@@ -2784,6 +2792,47 @@ mod tests {
         let mut buf: &[u8] = &data;
         let env = EnvChange::decode(&mut buf).unwrap();
         assert_eq!(env.env_type, EnvChangeType::BeginTransaction);
+    }
+
+    /// Issue #145: an under-declared frame must not let the value decoders
+    /// read past the declared length into the next token's bytes.
+    #[test]
+    fn hostile_env_change_under_declared_cannot_steal_following_bytes() {
+        // length=1 covers only the type byte; the bytes after the frame are
+        // shaped exactly like the transaction-descriptor payload the old
+        // buffer-bounded decoder would have consumed (new_len=8, descriptor,
+        // old_len=0).
+        let mut data = BytesMut::new();
+        data.put_u16_le(1); // declared frame: type byte only
+        data.put_u8(0x08); // BeginTransaction
+        let following: &[u8] = &[0x08, 1, 2, 3, 4, 5, 6, 7, 8, 0x00];
+        data.extend_from_slice(following);
+
+        let mut buf: &[u8] = &data;
+        let env = EnvChange::decode(&mut buf).unwrap();
+        assert_eq!(env.env_type, EnvChangeType::BeginTransaction);
+        match &env.new_value {
+            EnvChangeValue::Binary(b) => {
+                assert!(
+                    b.is_empty(),
+                    "under-declared frame yields the lenient empty value"
+                );
+            }
+            other => panic!("expected empty Binary value, got {other:?}"),
+        }
+        assert_eq!(
+            buf, following,
+            "bytes beyond the declared frame belong to the next token"
+        );
+    }
+
+    /// Issue #145: a zero-length frame cannot supply a type byte; reading
+    /// one from beyond the frame would consume the next token.
+    #[test]
+    fn hostile_env_change_zero_length_frame_errors() {
+        let data = [0x00, 0x00, 0xFD];
+        let mut buf: &[u8] = &data;
+        assert!(EnvChange::decode(&mut buf).is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Three of the five remaining filed correctness bugs, in one batch (one commit per issue):

1. **ENVCHANGE frame-strict decoding (#145).** Value decoders bounds-checked only against the buffer, so an under-declared frame let the transaction/collation branch consume the next token's bytes and misalign the stream. The frame is now sliced to exactly the declared length: over-read attempts hit frame end and take the established #140 lenient empty-value fallbacks; the outer buffer always advances by exactly the declared length. Zero-length frames — which previously read their type byte from beyond the frame — are now a hard error.
2. **TLS handshake flight splitting (#167).** The prelogin wrapper framed the whole buffered TLS flight as one TDS packet: over the 4096-byte pre-login cap it violated spec, and over 65,535 bytes the u16 header length silently truncated (`flight mod 65536`), corrupting framing — realistic with client-certificate chains. Flights now split into as many PRELOGIN packets as needed, each a complete EOM message with sequential packet IDs.
3. **DATE range enforcement (#167).** `encode_date` computed `num_days() as u32`, silently wrapping dates outside 0001-01-01..9999-12-31 into garbage wire values. The date encoders are now fallible (matching the `encode_smalldatetime` precedent), propagated through the RPC-param and bulk encoders.

## Linked issues

Closes #145
Refs #167 (TLS flight + encode_date items; the remaining #167 item — max-response-size cap — and #185-bulk follow in the next batch)

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Breaking change — `encode_date` / `encode_datetime2` / `encode_datetimeoffset` now return `Result<(), TypeError>` (pre-1.0; same shape as the #157 fallibility changes)

## Test plan

- [x] `just ci-all` — 872 tests passed (incl. new: 2 frame-strict hostile-input tests, 3 wire-exact TLS splitting tests incl. a 70,000-byte flight, byte-exact DATE boundary tests)
- [x] `just typos`
- [x] Live ignored-only suite against local SQL Server 2022 — 242 passed
- [x] Existing #140 lenient-input and #143 routing-framing tests pass unchanged (the regression risk #145 flagged)

## Documentation updates

- [x] Rustdoc updated on the changed public encoders (range documented)
- [ ] CHANGELOG.md — owned by release-plz, per repo convention
