### PR TITLE
feat(client): max_response_size cap; command_timeout on bulk insert

### DIFF
--- a/crates/mssql-client/src/bulk.rs
+++ b/crates/mssql-client/src/bulk.rs
@@ -1394,7 +1394,15 @@ impl<'a, S: crate::state::ConnectionState> BulkWriter<'a, S> {
     ///
     /// Writes the DONE token, sends the accumulated row data as a BulkLoad
     /// (0x07) message, and reads the server's response.
+    ///
+    /// The transfer runs under
+    /// [`command_timeout`](crate::Config::command_timeout). On expiry it
+    /// returns [`Error::CommandTimeout`] and
+    /// the connection is abandoned mid-request (a cancel cannot be
+    /// interleaved into a partially-sent BulkLoad message), so the pool
+    /// discards it — the same semantics as `SqlBulkCopy.BulkCopyTimeout`.
     pub async fn finish(mut self) -> Result<BulkInsertResult, Error> {
+        let deadline = self.client.command_deadline();
         let total_rows = self.bulk.total_rows();
         tracing::debug!(total_rows = total_rows, "finishing bulk insert");
 
@@ -1402,8 +1410,21 @@ impl<'a, S: crate::state::ConnectionState> BulkWriter<'a, S> {
         self.bulk.write_done();
         let payload = self.bulk.buffer.split().freeze();
 
-        // Send BulkLoad data and read server response
-        let rows_affected = self.client.send_and_read_bulk_load(payload).await?;
+        // Send BulkLoad data and read server response.
+        //
+        // The command timeout here is a hard abandon, not an ATTENTION
+        // cancel: an Attention packet cannot be interleaved into a
+        // partially-sent BulkLoad message without corrupting the framing.
+        // On expiry the connection is left mid-request (in_flight stays
+        // set), so the pool discards it instead of reusing it —
+        // SqlBulkCopy's BulkCopyTimeout behaves the same way.
+        let send_and_read = self.client.send_and_read_bulk_load(payload);
+        let rows_affected = match deadline {
+            Some(d) => tokio::time::timeout(d, send_and_read)
+                .await
+                .map_err(|_| Error::CommandTimeout)??,
+            None => send_and_read.await?,
+        };
 
         Ok(BulkInsertResult {
             rows_affected,

--- a/crates/mssql-client/src/client.rs
+++ b/crates/mssql-client/src/client.rs
@@ -431,9 +431,17 @@ impl<S: ConnectionState> Client<S> {
         // This gives us the exact type encoding the server expects for BulkLoad,
         // following the pattern established by Tiberius.
         let meta_query = format!("SELECT TOP 0 * FROM {}", builder.table_name());
-        self.send_sql_batch(&meta_query).await?;
-
-        let message = self.read_response_message().await?;
+        let deadline = self.command_deadline();
+        let canceller = self.connection_cancel_handle();
+        let message = run_with_deadline(
+            async {
+                self.send_sql_batch(&meta_query).await?;
+                self.read_response_message().await
+            },
+            deadline,
+            canceller,
+        )
+        .await?;
         self.in_flight = false;
 
         // Capture both the raw COLMETADATA bytes and parsed column info
@@ -493,8 +501,17 @@ impl<S: ConnectionState> Client<S> {
 
         // Step 2: Send INSERT BULK statement to put server in bulk load mode
         let stmt = builder.build_insert_bulk_statement()?;
-        self.send_sql_batch(&stmt).await?;
-        self.read_execute_result().await?;
+        let deadline = self.command_deadline();
+        let canceller = self.connection_cancel_handle();
+        run_with_deadline(
+            async {
+                self.send_sql_batch(&stmt).await?;
+                self.read_execute_result().await
+            },
+            deadline,
+            canceller,
+        )
+        .await?;
 
         // Step 3: Create bulk writer with server's metadata
         let raw_meta = if meta_end > meta_start {
@@ -542,8 +559,17 @@ impl<S: ConnectionState> Client<S> {
 
         // Send INSERT BULK statement to put server in bulk load mode
         let stmt = builder.build_insert_bulk_statement()?;
-        self.send_sql_batch(&stmt).await?;
-        self.read_execute_result().await?;
+        let deadline = self.command_deadline();
+        let canceller = self.connection_cancel_handle();
+        run_with_deadline(
+            async {
+                self.send_sql_batch(&stmt).await?;
+                self.read_execute_result().await
+            },
+            deadline,
+            canceller,
+        )
+        .await?;
 
         // Create bulk writer with hand-crafted metadata
         let bulk =

--- a/crates/mssql-client/src/client/connect.rs
+++ b/crates/mssql-client/src/client/connect.rs
@@ -359,6 +359,7 @@ impl Client<Disconnected> {
 
         // Create connection wrapper
         let mut connection = Connection::new(tls_stream);
+        connection.set_max_message_size(config.max_response_size);
 
         // Send PreLogin (encrypted in strict mode)
         let prelogin = Self::build_prelogin(config, EncryptionLevel::Required);
@@ -654,6 +655,7 @@ impl Client<Disconnected> {
 
                 // Create Connection from plain TCP for reading response
                 let mut connection = Connection::new(tcp_stream);
+                connection.set_max_message_size(config.max_response_size);
 
                 // Process login response (comes in plaintext, with timeout)
                 let (server_version, current_database, routing, server_collation) = timeout(
@@ -699,6 +701,7 @@ impl Client<Disconnected> {
                 // Full Encryption (ENCRYPT_ON per MS-TDS spec):
                 // - All communication after TLS handshake goes through TLS
                 let mut connection = Connection::new(tls_stream);
+                connection.set_max_message_size(config.max_response_size);
 
                 // Create SSPI negotiator if integrated auth
                 #[cfg(any(feature = "integrated-auth", feature = "sspi-auth"))]
@@ -763,6 +766,8 @@ impl Client<Disconnected> {
             );
 
             let mut connection = Connection::new(tcp_stream);
+
+            connection.set_max_message_size(config.max_response_size);
 
             // Create SSPI negotiator if integrated auth
             #[cfg(any(feature = "integrated-auth", feature = "sspi-auth"))]
@@ -893,6 +898,8 @@ impl Client<Disconnected> {
         tracing::debug!("Server accepted unencrypted connection");
 
         let mut connection = Connection::new(tcp_stream);
+
+        connection.set_max_message_size(config.max_response_size);
 
         // Create SSPI negotiator if integrated auth
         #[cfg(any(feature = "integrated-auth", feature = "sspi-auth"))]

--- a/crates/mssql-client/src/config.rs
+++ b/crates/mssql-client/src/config.rs
@@ -270,6 +270,17 @@ pub struct Config {
     /// Command timeout.
     pub command_timeout: Duration,
 
+    /// Maximum size in bytes of a single buffered response (default: 0 =
+    /// unlimited).
+    ///
+    /// Query responses are buffered in full before rows are decoded (see the
+    /// crate-level notes on streaming), so a very large SELECT is otherwise
+    /// unbounded client memory. When the cap is exceeded the call fails with
+    /// [`Error::ResponseTooLarge`](crate::Error::ResponseTooLarge) and the
+    /// connection is discarded (the response was abandoned mid-stream).
+    /// Paginate, narrow the SELECT, or raise the cap.
+    pub max_response_size: usize,
+
     /// TDS packet size.
     pub packet_size: u16,
 
@@ -411,6 +422,7 @@ impl Default for Config {
             application_name: "mssql-client".to_string(),
             connect_timeout: timeouts.connect_timeout,
             command_timeout: timeouts.command_timeout,
+            max_response_size: 0,
             packet_size: 4096,
             strict_mode: false,
             trust_server_certificate: false,

--- a/crates/mssql-client/src/config/types.rs
+++ b/crates/mssql-client/src/config/types.rs
@@ -88,12 +88,17 @@ pub struct TimeoutConfig {
     pub login_timeout: Duration,
     /// Default timeout for command execution (default: 30s).
     ///
-    /// Applied to every `query`/`execute` call: if the server does not return
-    /// a complete response within this duration, the driver sends an Attention
-    /// packet to cancel the command, drains the acknowledgement, and returns
-    /// [`Error::CommandTimeout`](crate::Error::CommandTimeout) with the
-    /// connection left usable. Set to `Duration::ZERO` for no limit (matching
-    /// ADO.NET's `CommandTimeout = 0`).
+    /// Applied to every command path — `query`, `execute`, named-parameter
+    /// and multi-result variants, stored-procedure calls, and bulk-insert
+    /// network phases. On expiry the driver sends an Attention packet to
+    /// cancel the command, drains the acknowledgement (bounded at 5 s), and
+    /// returns [`Error::CommandTimeout`](crate::Error::CommandTimeout) with
+    /// the connection left usable. Exceptions that abandon the connection
+    /// instead of cancelling: a server that never acknowledges the
+    /// attention, and a timeout during the bulk-load data transfer (an
+    /// Attention cannot be interleaved into a partially-sent BulkLoad
+    /// message). Set to `Duration::ZERO` for no limit (matching ADO.NET's
+    /// `CommandTimeout = 0`).
     pub command_timeout: Duration,
     /// Time before idle connection is closed (default: 300s).
     pub idle_timeout: Duration,

--- a/crates/mssql-client/src/error.rs
+++ b/crates/mssql-client/src/error.rs
@@ -73,7 +73,23 @@ pub enum Error {
 
     /// Codec error.
     #[error("codec error: {0}")]
-    Codec(#[from] mssql_codec::CodecError),
+    Codec(mssql_codec::CodecError),
+
+    /// Response exceeded [`Config::max_response_size`](crate::Config::max_response_size).
+    ///
+    /// The response was abandoned mid-stream, so the connection is no longer
+    /// usable and is discarded by the pool. Paginate, narrow the SELECT, or
+    /// raise the cap.
+    #[error(
+        "response too large: {size} bytes exceeds the configured {limit}-byte cap; \
+         paginate, narrow the SELECT, or raise Config::max_response_size"
+    )]
+    ResponseTooLarge {
+        /// Bytes accumulated when the cap was exceeded.
+        size: usize,
+        /// The configured cap.
+        limit: usize,
+    },
 
     /// Type conversion error.
     #[error("type error: {0}")]
@@ -225,6 +241,17 @@ impl std::fmt::Display for SharedIoError {
 impl std::error::Error for SharedIoError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         self.0.source()
+    }
+}
+
+impl From<mssql_codec::CodecError> for Error {
+    fn from(e: mssql_codec::CodecError) -> Self {
+        match e {
+            mssql_codec::CodecError::MessageTooLarge { size, limit } => {
+                Self::ResponseTooLarge { size, limit }
+            }
+            other => Self::Codec(other),
+        }
     }
 }
 

--- a/crates/mssql-client/tests/resilience.rs
+++ b/crates/mssql-client/tests/resilience.rs
@@ -520,6 +520,36 @@ async fn test_default_command_timeout_enforced() {
     client.close().await.expect("Failed to close");
 }
 
+/// Issue #167: `max_response_size` caps the buffered response. A SELECT
+/// producing more than the cap must fail loudly instead of buffering
+/// without bound — and the connection is abandoned mid-response.
+#[tokio::test]
+#[ignore = "Requires SQL Server"]
+async fn test_max_response_size_cap_enforced() {
+    let mut config = get_test_config().expect("SQL Server config required");
+    config.max_response_size = 64 * 1024;
+    let mut client = Client::connect(config).await.expect("Failed to connect");
+
+    // ~1 MB of data, far past the 64 KiB cap.
+    let result = client
+        .query(
+            "SELECT REPLICATE(CAST('x' AS VARCHAR(MAX)), 1000000) AS big",
+            &[],
+        )
+        .await;
+    match result {
+        Err(mssql_client::Error::ResponseTooLarge { size, limit }) => {
+            assert_eq!(limit, 64 * 1024);
+            assert!(size > limit, "reported size must exceed the cap");
+        }
+        Err(other) => panic!("expected ResponseTooLarge, got {other:?}"),
+        Ok(_) => panic!("expected ResponseTooLarge, query succeeded"),
+    }
+    // The response was abandoned mid-stream: the connection is poisoned by
+    // design (in_flight stays set, the pool would discard it). Close only.
+    let _ = client.close().await;
+}
+
 /// Issue #185 regression: `command_timeout` must cover the stored-procedure,
 /// named-parameter, and multi-result paths — previously only `query()` and
 /// `execute()` ran under the deadline.

--- a/crates/mssql-codec/src/connection.rs
+++ b/crates/mssql-codec/src/connection.rs
@@ -57,6 +57,8 @@ where
     cancel_notify: Arc<Notify>,
     /// Flag indicating cancellation is in progress.
     cancelling: Arc<std::sync::atomic::AtomicBool>,
+    /// Maximum assembled message size in bytes; 0 means unlimited.
+    max_message_size: usize,
 }
 
 impl<T> Connection<T>
@@ -75,6 +77,7 @@ where
             assembler: MessageAssembler::new(),
             cancel_notify: Arc::new(Notify::new()),
             cancelling: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            max_message_size: 0,
         }
     }
 
@@ -91,7 +94,19 @@ where
             assembler: MessageAssembler::new(),
             cancel_notify: Arc::new(Notify::new()),
             cancelling: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            max_message_size: 0,
         }
+    }
+
+    /// Cap the size of an assembled response message; 0 means unlimited.
+    ///
+    /// Responses are buffered in full before token parsing, so without a
+    /// cap a single large SELECT is unbounded client memory. When the cap
+    /// is exceeded, [`read_message`](Self::read_message) returns
+    /// [`CodecError::MessageTooLarge`] mid-message — the connection is no
+    /// longer usable for that request and should be discarded.
+    pub fn set_max_message_size(&mut self, limit: usize) {
+        self.max_message_size = limit;
     }
 
     /// Get a handle for cancelling queries on this connection.
@@ -129,7 +144,25 @@ where
 
             match self.reader.next().await {
                 Some(Ok(packet)) => {
-                    if let Some(message) = self.assembler.push(packet) {
+                    let result = self.assembler.push(packet);
+                    // Enforce the response-size cap on the accumulating
+                    // buffer AND the completed message (the final packet can
+                    // jump past the limit). Exceeding it abandons the
+                    // message mid-stream: the caller must discard the
+                    // connection.
+                    if self.max_message_size != 0 {
+                        let size = result
+                            .as_ref()
+                            .map_or_else(|| self.assembler.buffer_len(), |m| m.payload.len());
+                        if size > self.max_message_size {
+                            self.assembler.clear();
+                            return Err(CodecError::MessageTooLarge {
+                                size,
+                                limit: self.max_message_size,
+                            });
+                        }
+                    }
+                    if let Some(message) = result {
                         // The cancel flag may have been set while this read was
                         // parked in `next()`. In that case the message belongs
                         // to the request being cancelled (the server discards
@@ -766,5 +799,70 @@ mod tests {
              the interior row bytes were mistaken for the ack and the real \
              ack leaked into the next request"
         );
+    }
+
+    /// Build a raw non-EOM (continuation) TabularResult packet.
+    fn raw_packet_non_eom(payload: &[u8]) -> Vec<u8> {
+        let mut v = vec![0x04, 0x00]; // TabularResult, more packets follow
+        v.extend_from_slice(&((payload.len() + 8) as u16).to_be_bytes());
+        v.extend_from_slice(&[0, 0, 1, 0]);
+        v.extend_from_slice(payload);
+        v
+    }
+
+    /// Issue #167: the assembled response can be capped so a huge SELECT is
+    /// a loud error instead of unbounded client memory. The cap must fire
+    /// mid-assembly, before the message completes.
+    #[tokio::test]
+    async fn test_max_message_size_cap_fires_mid_assembly() {
+        use tokio::io::AsyncWriteExt;
+        let (client, mut server) = tokio::io::duplex(1 << 16);
+        let mut conn = Connection::new(client);
+        conn.set_max_message_size(1000);
+
+        let chunk = vec![0xAA; 600];
+        let mut stream = raw_packet_non_eom(&chunk);
+        stream.extend_from_slice(&raw_packet_non_eom(&chunk)); // buffer hits 1200
+        server.write_all(&stream).await.unwrap();
+
+        let result = conn.read_message().await;
+        let Err(CodecError::MessageTooLarge { size, limit }) = result else {
+            unreachable!("expected MessageTooLarge, got {result:?}");
+        };
+        assert_eq!(limit, 1000);
+        assert!(size > 1000);
+    }
+
+    /// The cap must also catch a message whose final (EOM) packet jumps it
+    /// past the limit.
+    #[tokio::test]
+    async fn test_max_message_size_cap_fires_on_completing_packet() {
+        use tokio::io::AsyncWriteExt;
+        let (client, mut server) = tokio::io::duplex(1 << 16);
+        let mut conn = Connection::new(client);
+        conn.set_max_message_size(1000);
+
+        let chunk = vec![0xAA; 600];
+        let mut stream = raw_packet_non_eom(&chunk);
+        stream.extend_from_slice(&raw_message(&chunk)); // completes at 1200
+        server.write_all(&stream).await.unwrap();
+
+        assert!(matches!(
+            conn.read_message().await,
+            Err(CodecError::MessageTooLarge { .. })
+        ));
+    }
+
+    /// Zero (the default) means unlimited — existing behavior unchanged.
+    #[tokio::test]
+    async fn test_max_message_size_zero_is_unlimited() {
+        use tokio::io::AsyncWriteExt;
+        let (client, mut server) = tokio::io::duplex(1 << 16);
+        let mut conn = Connection::new(client);
+
+        let payload = vec![0xAA; 5000];
+        server.write_all(&raw_message(&payload)).await.unwrap();
+        let msg = conn.read_message().await.unwrap().unwrap();
+        assert_eq!(msg.payload.len(), 5000);
     }
 }

--- a/crates/mssql-codec/src/error.rs
+++ b/crates/mssql-codec/src/error.rs
@@ -23,6 +23,15 @@ pub enum CodecError {
         max: usize,
     },
 
+    /// Assembled response message exceeded the configured size limit.
+    #[error("response message too large: {size} bytes exceeds the {limit}-byte limit")]
+    MessageTooLarge {
+        /// Bytes accumulated when the limit was exceeded.
+        size: usize,
+        /// The configured limit.
+        limit: usize,
+    },
+
     /// Incomplete packet data.
     #[error("incomplete packet: need {needed} more bytes")]
     IncompletePacket {


### PR DESCRIPTION
## Summary

The last two substantive items from the 2026-06 review backlog: the unbounded-response-memory gap (#161/#167) and the bulk-insert timeout gap (#185's remaining scope).

## Linked issues

Closes #185
Refs #167 (response-size cap item — what remains on that tracker after this is doc/test debt: MIGRATION doctest harness, minor ARCHITECTURE internals, the unreachable-in-default-build money f64 note)

## Type of change

- [x] New feature (non-breaking change that adds functionality)
- [x] Bug fix (bulk paths previously had no deadline at all)

## What changed

**`Config::max_response_size`** (default 0 = unlimited — opt-in, no behavior change). Responses are buffered in full before token parsing, so a large SELECT was unbounded client memory. The cap is enforced in the codec assembly loop (`Connection::set_max_message_size`, new `CodecError::MessageTooLarge`) on both the accumulating buffer and the completing packet, and surfaces as the new `Error::ResponseTooLarge` with an actionable message (paginate / narrow / raise the cap). Exceeding it abandons the response mid-stream: the connection stays `in_flight` and the pool discards it.

**Bulk insert under `command_timeout`.** The metadata and INSERT BULK setup round-trips run under `run_with_deadline` (ATTENTION cancel + bounded drain) like every other command path. The data transfer in `finish()` deliberately uses a hard-abandon timeout instead: an Attention packet cannot be interleaved into a partially-sent BulkLoad message without corrupting framing, so on expiry the connection is abandoned — the same semantics as `SqlBulkCopy.BulkCopyTimeout`, documented on `finish()`. The stale `command_timeout` rustdoc ("applied to every query/execute call") now describes the actual coverage and both abandon-instead-of-cancel exceptions.

## Test plan

- [x] `just ci-all` — 875 tests passed (new: 3 codec cap tests — mid-assembly, completing-packet, zero-unlimited)
- [x] `just typos`
- [x] Live ignored-only suite against local SQL Server 2022 — 243 passed, including the new `test_max_response_size_cap_enforced` (~1 MB SELECT through a 64 KiB cap → `ResponseTooLarge`)
- [x] For behavioral changes: new or updated tests cover the change

**Known verification gap:** the bulk-transfer timeout path has no live test — triggering it requires a server that stalls mid-BulkLoad, which the deadline/timeout machinery's other live tests (query, procedure, named, multi-result) already exercise at the shared plumbing level.

## Documentation updates

- [x] Rustdoc: `Config::max_response_size`, `Error::ResponseTooLarge`, `BulkWriter::finish` timeout semantics, corrected `command_timeout` coverage doc
- [ ] CHANGELOG.md — owned by release-plz, per repo convention