### PR TITLE
fix(types)!: carry the breaking-change marker for the 0.13.x date-encoder signature change

### DIFF
--- a/crates/mssql-types/src/encode.rs
+++ b/crates/mssql-types/src/encode.rs
@@ -363,6 +363,8 @@ pub fn datetime_to_smalldatetime_days_minutes(
 /// minutes since midnight (`u16` LE). Seconds are rounded to the nearest
 /// minute (30s rounds up per SQL Server semantics).
 ///
+/// # Errors
+///
 /// Returns an error if the date is outside the SMALLDATETIME range
 /// (1900-01-01 through 2079-06-06).
 #[cfg(feature = "chrono")]
@@ -379,6 +381,8 @@ pub fn encode_smalldatetime(
 /// Encode a DATE value.
 ///
 /// TDS DATE is the number of days since 0001-01-01.
+///
+/// # Errors
 ///
 /// Returns an error if the date is outside SQL Server's DATE range
 /// (0001-01-01 through 9999-12-31). chrono permits dates beyond both ends,
@@ -427,6 +431,8 @@ pub fn encode_time(time: chrono::NaiveTime, buf: &mut BytesMut) {
 /// Encode a DATETIME2 value.
 ///
 /// DATETIME2 is encoded as TIME followed by DATE.
+///
+/// # Errors
 ///
 /// Returns an error if the date portion is outside the DATE range; see
 /// [`encode_date`].


### PR DESCRIPTION
## Summary

PR #199 changed `encode_date` / `encode_datetime2` / `encode_datetimeoffset` from `()` to `Result<(), TypeError>` — a breaking change — but the commit lacked the `!` marker, and the cargo-semver-checks backstop runs with default features while these encoders are behind the `chrono` feature gate. Result: Release PR #195 proposes a **patch** bump (v0.13.2) for an API-breaking main, violating the pre-1.0 breaking→minor policy.

This PR adds standard `# Errors` rustdoc sections to the three encoders, with the commit subject and `BREAKING CHANGE:` footer release-plz needs to regenerate #195 as **v0.14.0**. The commit must touch `crates/mssql-types` for release-plz to attribute it to the crate, hence the (genuine) doc improvement rather than an empty commit.

The underlying tooling blind spot (semver-checks blind to feature-gated APIs) is filed separately.

## Linked issues

Refs #199, #195

## Type of change

- [x] Documentation only (the code change)
- [x] Breaking change (the *marker* — the actual break already landed in #199)

## Test plan

- [x] `cargo doc -D warnings` clean on mssql-types; `cargo fmt --check` clean
- [x] After merge: verify release-plz regenerates #195 as v0.14.0 before it is merged

## Documentation updates

- [x] This PR is the documentation update