### PR TITLE
ci: pin the semver job toolchain; document the gate's verified blind spot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,6 +256,18 @@ jobs:
           # Exclude mssql-testing: testing utilities have relaxed API stability
           # requirements and are not published to crates.io (publish = false).
           exclude: mssql-testing
+          # Pinned: the action defaults to floating latest stable (it ignores
+          # rust-toolchain.toml), and a 2026-06-12 stable release broke the
+          # *baseline* build (E0119 in the time crate via the locked sspi dep
+          # tree), turning this job red on every PR (#202). Bump deliberately
+          # after verifying the baseline tag still builds on the new release.
+          rust-toolchain: "1.92.0"
+          # Explicit all-features: the default heuristic already enables most
+          # features, but be exact about coverage. KNOWN BLIND SPOT either
+          # way: return-type changes pass undetected in cargo-semver-checks
+          # 0.42 (reproduced in #202), so commit-message breaking markers and
+          # Release-PR verification (CLAUDE.md) remain the primary guards.
+          feature-group: all-features
 
   coverage:
     name: Code Coverage

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -313,10 +313,10 @@ Key differences for migrators:
 - **Breaking changes MUST carry the conventional marker**: `!` after the type
   (`fix(types)!:`) or a `BREAKING CHANGE:` footer. A `BREAKING:` line in the
   commit body is **ignored** by release-plz — and the `cargo-semver-checks`
-  backstop runs with default features, so breaking changes in feature-gated
-  API (chrono/uuid/decimal codecs, Always Encrypted, FILESTREAM) are invisible
-  to it (#202). Version correctness rests on the commit message. Precedent:
-  the v0.13.2 wrong bump, corrected by PR #201 before release.
+  backstop has demonstrated blind spots: version 0.42 passes return-type
+  changes (`()` → `Result<...>`) without a finding, reproduced in #202.
+  Version correctness rests on the commit message. Precedent: the v0.13.2
+  wrong bump, corrected by PR #201 before release.
 - Run `cargo fmt --all` **before** committing, not after the CI mirror flags
   it — fmt-check is the first gate in `just ci-all`, and a failure there
   costs a full gauntlet cycle plus a commit amend.


### PR DESCRIPTION
## Summary

Fixes the all-PRs-red Semver Check (toolchain drift broke the baseline build today) and corrects the documented mechanism behind the v0.13.2 wrong bump, based on local reproduction in #202.

## What changed

1. `rust-toolchain: "1.92.0"` pinned on the semver action — it defaults to floating latest stable, and today's stable release rejects the v0.13.x baseline dep tree (E0119 in `time`). Verified: the identical baseline builds + checks cleanly under 1.92.0 locally. Comment carries bump-deliberately guidance.
2. `feature-group: all-features` set explicitly (the default heuristic already enables most features; this makes coverage exact).
3. CLAUDE.md correction: the v0.13.2 wrong bump was **not** feature-gate blindness — cargo-semver-checks 0.42 simply has no finding for return-type changes (`136 checks: 136 pass` against a baseline with three changed signatures, reproduced in #202). The job comment and CLAUDE.md now state the verified blind spot, and the job deliberately stays advisory: commit markers + Release-PR verification are the primary guards.

## Verification note / uncertainty

The CI action downloads the latest CLI (0.47+), which may have gained a return-type lint since 0.42 — unverified (CI never reached linting today). Tracked as a follow-up in #202: if ≥0.47 detects it, raising the setup-tools pin when MSRV allows would shrink the blind spot.

## Linked issues

Refs #202

## Type of change

- [x] Build / CI / tooling

## Test plan

- [x] YAML validated; `just typos` + `just doc-consistency` clean
- [x] Baseline build + check verified green locally under the pinned toolchain
- [x] This PR's own Semver Check run is the end-to-end test of the pin