### PR TITLE
feat: Azure AD / Entra logins via FEDAUTH SecurityToken workflow (#155 Phase 1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -254,16 +254,23 @@ jobs:
       # break this job while every lockfile-honoring build stays green:
       # time 0.3.48 (published 2026-06-12) conflicts with picky-asn1 0.10.1
       # (E0119) and broke the mssql-auth check exactly that way. Hence the
-      # split below: mssql-auth is checked with default features only
-      # (default = [], skipping the fragile sspi/picky/time optional tree),
-      # every other crate with all features. Revisit the split when upstream
-      # resolves the conflict.
+      # split below: crates whose optional features pull the fragile
+      # sspi/picky/time or azure/time dep trees are checked WITHOUT those
+      # features; every other crate with all features. Revisit the split when
+      # upstream resolves the conflict.
+      #
+      # The azure-identity exclusions on mssql-client / mssql-driver-pool are
+      # LOSSLESS for semver purposes: that feature gates no public items in
+      # either crate (it only forwards to mssql-auth, whose azure surface is
+      # outside its default-features leg anyway). If a future feature DOES
+      # gate public client/pool API, add it to the `features` lists below or
+      # it will not be semver-checked.
       #
       # KNOWN BLIND SPOT regardless of configuration: return-type changes
       # pass undetected (reproduced in #202 on cargo-semver-checks 0.42), so
       # commit-message breaking markers and Release-PR verification
       # (CLAUDE.md) remain the primary guards.
-      - name: Semver check (all crates except mssql-auth, all features)
+      - name: Semver check (all features, crates without fragile dep trees)
         uses: obi1kenobi/cargo-semver-checks-action@v2
         with:
           # Use git tag as baseline to avoid workspace dependency issues.
@@ -271,12 +278,37 @@ jobs:
           baseline-rev: ${{ steps.latest_tag.outputs.tag }}
           # Exclude mssql-testing: testing utilities have relaxed API stability
           # requirements and are not published to crates.io (publish = false).
-          exclude: mssql-testing,mssql-auth
+          exclude: mssql-testing,mssql-auth,mssql-client,mssql-driver-pool
           # Pinned for reproducibility — the action otherwise floats on
           # latest stable (ignoring rust-toolchain.toml). Bump deliberately.
           rust-toolchain: "1.92.0"
           feature-group: all-features
+      - name: Semver check (mssql-client, all features except azure-identity)
+        # Run even when an earlier leg fails — a red leg must not mask the
+        # findings of the others (bitten on PR #210, where the aborted
+        # all-features leg hid the mssql-auth report).
+        if: ${{ !cancelled() }}
+        uses: obi1kenobi/cargo-semver-checks-action@v2
+        with:
+          baseline-rev: ${{ steps.latest_tag.outputs.tag }}
+          package: mssql-client
+          rust-toolchain: "1.92.0"
+          # Defaults (chrono, uuid, decimal, encoding, tls, derive) plus every
+          # optional feature except azure-identity (azure/time tree) and
+          # fuzzing (internal hooks, not public API).
+          feature-group: default-features
+          features: json,otel,zeroize,always-encrypted,integrated-auth,sspi-auth,filestream
+      - name: Semver check (mssql-driver-pool, all features except azure-identity)
+        if: ${{ !cancelled() }}
+        uses: obi1kenobi/cargo-semver-checks-action@v2
+        with:
+          baseline-rev: ${{ steps.latest_tag.outputs.tag }}
+          package: mssql-driver-pool
+          rust-toolchain: "1.92.0"
+          feature-group: default-features
+          features: otel,integrated-auth,sspi-auth,filestream
       - name: Semver check (mssql-auth, default features)
+        if: ${{ !cancelled() }}
         uses: obi1kenobi/cargo-semver-checks-action@v2
         with:
           baseline-rev: ${{ steps.latest_tag.outputs.tag }}

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Architectural Reference: Rust MS SQL Driver
 
-**Version:** 1.8.0
+**Version:** 1.9.0
 **Status:** Design Complete
 **Target Protocol:** MS-TDS 7.3 – 8.0 (SQL Server 2008 – 2025)
 **Toolchain Standard:** Rust 2024 Edition (v1.85+, released February 20, 2025)
@@ -354,7 +354,7 @@ Server=tcp:hostname,port;Database=dbname;User Id=user;Password=pass;Encrypt=stri
 | `Password` | `PWD` | SQL authentication password |
 | `Encrypt` | | `true`, `false`, `strict`, `no_tls` |
 | `TrustServerCertificate` | | Skip certificate validation |
-| `Authentication` (recognized, **not yet supported** — FEDAUTH login wiring pending, see #155) | | `SqlPassword`, `ActiveDirectoryPassword`, `ActiveDirectoryManagedIdentity`, `ActiveDirectoryServicePrincipal` |
+| `Authentication` | | `SqlPassword`, `ActiveDirectoryServicePrincipal` (`User Id=<client-id>@<tenant-id>`), `ActiveDirectoryManagedIdentity` / `ActiveDirectoryMSI` — Azure AD values use the FEDAUTH SecurityToken workflow and require the `azure-identity` feature (#155 Phase 1). `ActiveDirectoryPassword` and the other ADAL/MSAL workflows remain unsupported (#155 Phase 2) |
 | `Application Name` | | Application identifier |
 | `Connect Timeout` | | Connection timeout in seconds |
 | `Command Timeout` | | Default command timeout |
@@ -2050,6 +2050,7 @@ quick-reference cheat sheet.
 | 1.6.0 | 2026-04-07 | Updated for v0.7.0 release: MSRV bumped to 1.88, SSPI integrated auth wired into client login, RUSTSEC advisories resolved, 33 public enums marked non_exhaustive for semver safety, deprecated APIs removed before 1.0 |
 | 1.7.0 | 2026-04-13 | Updated for v0.8.0 release: Stored procedure support (§4.7), SQL Browser instance resolution, pool test_on_checkin, Azure SDK 0.34, mock TLS cross-platform fix |
 | 1.8.0 | 2026-06-11 | Doc-accuracy corrections (#166): header version aligned with history; ADR-002 marks `Authentication` keyword as recognized-but-not-yet-supported (FEDAUTH pending, #155); ADR-013 clarifies Always Encrypted is read-path only (write path NULL-only); §8.3 corrects `cert-auth` dependency (pulls OpenSSL via azure_identity, not pure-rustls) |
+| 1.9.0 | 2026-06-12 | #155 Phase 1: Azure AD / Entra logins via the FEDAUTH SecurityToken workflow (pre-acquired token, managed identity, service principal); ADR-002 `Authentication` keyword supported for SqlPassword / ActiveDirectoryServicePrincipal / ActiveDirectoryManagedIdentity; `azure-identity` feature added to mssql-client |
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ A high-performance MS SQL Server driver for Rust that aims to surpass `prisma/ti
 
 ## Key Architecture Decisions
 
-Refer to `ARCHITECTURE.md` (v1.8.0) for complete details. Critical decisions:
+Refer to `ARCHITECTURE.md` (v1.9.0) for complete details. Critical decisions:
 
 | Decision | Choice | Rationale |
 |----------|--------|-----------|
@@ -88,6 +88,7 @@ The `Config::from_connection_string()` parser conforms to the Microsoft ADO.NET 
 - **`MultiSubnetFailover`**: Parallel TCP connect to all resolved IPs for AG listener failover.
 - **`SendStringParametersAsUnicode`**: When `false`, sends string params as VARCHAR (Windows-1252) instead of NVARCHAR (UTF-16) for index seek compatibility.
 - **`Encrypt`**: Supports `strict`, `mandatory`, `optional`, `no_tls`, plus standard booleans.
+- **`Authentication`**: `SqlPassword`, `ActiveDirectoryServicePrincipal` (`User Id=<client-id>@<tenant-id>`, `Password=<secret>`), `ActiveDirectoryManagedIdentity`/`ActiveDirectoryMSI` — the Azure AD values log in via the LOGIN7 FEDAUTH feature extension (SecurityToken workflow, #155 Phase 1) and require the `azure-identity` feature. FEDAUTH never goes over plaintext (`no_tls` combinations are rejected). The ADAL/MSAL workflows (`ActiveDirectoryPassword`, `Interactive`, …) error with a pointer to #155 Phase 2.
 - **Pool keywords** (`Max Pool Size`, etc.): Recognized with info-level log directing to `PoolConfig`.
 - **Known-but-unsupported keywords** (30+): Recognized at info level instead of silently ignored.
 
@@ -377,4 +378,4 @@ When making changes here, remember:
    - **Never open a PR stacked on another feature branch.** CI only triggers on PRs based on `main` (see convention 5), so a stacked PR gets zero CI until it is retargeted to `main`.
    - **Branch protection requires up-to-date-with-`main`.** Merge each green PR before opening the next to minimize the `update-branch` + CI-re-run churn that comes from keeping many PRs in flight at once.
    - **The Semver Check CI job is advisory** (`continue-on-error: true`), but `gh pr checks --watch` still exits 1 when it fails — a red advisory check is not a blocked PR. Before concluding a PR is stuck, check the required checks / `mergeable` state (`gh api .../pulls/N -q .mergeable_state`). The job's known blind spots are tracked in #202.
-   - The tests excluded from the pre-push command (`azure_sql`, `azure_identity_auth`, `cert_auth`) need a **live Azure SQL environment**, not the local container. One exists for #155 work (credentials live outside the repo, e.g. a local gitignored `.tmp/azure.env`); run that suite when touching authentication or Azure-path code.
+   - The tests excluded from the pre-push command (`azure_sql`, `azure_identity_auth`, `cert_auth`) need a **live Azure SQL environment**, not the local container. One exists (credentials live outside the repo, e.g. a local gitignored `.tmp/azure.env`); run that suite when touching authentication or Azure-path code. The `azure_sql` suite includes live FEDAUTH service-principal login tests (`--features azure-identity`) reading `AZURE_SQL_TENANT_ID`/`AZURE_SQL_CLIENT_ID`/`AZURE_SQL_CLIENT_SECRET` with fallback to the `AZURE_`-prefixed names in the standing env file.

--- a/LIMITATIONS.md
+++ b/LIMITATIONS.md
@@ -21,7 +21,7 @@ For supported features, see [README.md](README.md).
 | Data Types | HIERARCHYID | Use `.ToString()` |
 | Data Types | CLR UDTs | Cast to VARBINARY |
 | Performance | Prepared statement cache (not wired) | `sp_executesql` server plan cache |
-| Auth | Azure AD / Entra and certificate auth (FEDAUTH not wired) | SQL auth or NTLM |
+| Auth | Certificate auth and ADAL/MSAL workflows (FEDAUTH Phase 2) | Azure AD token / service principal / managed identity, SQL auth, or NTLM |
 | Auth | Kerberos untested against live KDC | SQL auth or NTLM |
 | Platforms | SQL Server 2005 and earlier | Upgrade to SQL Server 2008+ |
 | Platforms | 32-bit systems | Use 64-bit |
@@ -135,23 +135,34 @@ Client-side handle caching is planned.
 
 ---
 
-### Azure AD / Entra and Certificate Authentication (FEDAUTH Not Wired)
+### Certificate Authentication and ADAL/MSAL Workflows (FEDAUTH Phase 2)
 
-**Status:** Token acquisition implemented; login wiring not implemented
+**Status:** Azure AD logins implemented (SecurityToken workflow);
+certificate credentials and server-directed token acquisition not wired
 
-The `mssql-auth` providers for Azure AD access tokens, Managed Identity,
-Service Principals, and client certificates can acquire tokens, but the
-LOGIN7 FEDAUTH feature extension is not yet implemented in `mssql-client`,
-so these credential types cannot complete a login. `Client::connect`
-rejects them with a clear configuration error instead of sending an
-empty-credential login (which the server would reject with an opaque
-error 18456).
+Azure AD / Entra credentials — pre-acquired access tokens, Managed
+Identity, and Service Principals — complete logins via the LOGIN7 FEDAUTH
+feature extension (SecurityToken workflow: the token is acquired
+client-side before login; validated against live Azure SQL).
 
-Full FEDAUTH support is tracked in
-[#155](https://github.com/praxiomlabs/rust-mssql-driver/issues/155).
+Still unwired:
 
-**Workaround:** SQL authentication or cross-platform NTLM. For Azure SQL,
-SQL authentication works on every tier.
+- **Client certificate credentials** (`cert-auth`): token acquisition
+  works, but `Client::connect` rejects the credential type with a clear
+  configuration error.
+- **ADAL/MSAL workflows** (`Authentication=ActiveDirectoryPassword`,
+  `ActiveDirectoryInteractive`, …): these need the FEDAUTHINFO
+  round-trip in which the server directs token acquisition; the
+  connection-string parser rejects them with a pointer to the tracking
+  issue.
+
+Both are tracked in
+[#155](https://github.com/praxiomlabs/rust-mssql-driver/issues/155)
+(Phase 2).
+
+**Workaround:** a service principal secret or a pre-acquired token covers
+most certificate-credential scenarios; SQL authentication works on every
+Azure SQL tier.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ for result in rows {
 | `encoding` | Yes | Collation-aware VARCHAR decoding |
 | `json` | No | JSON type support via serde_json |
 | `tls` | Yes | TLS/SSL encryption via rustls (disable for `Encrypt=no_tls` environments) |
+| `azure-identity` | No | Azure AD / Entra logins with Managed Identity or Service Principal credentials (pre-acquired tokens work without it) |
 | `otel` | No | OpenTelemetry tracing and metrics |
 | `zeroize` | No | Secure credential wiping |
 | `filestream` | No | FILESTREAM BLOB access (Windows only, requires OLE DB Driver) |

--- a/crates/mssql-auth/src/azure_ad.rs
+++ b/crates/mssql-auth/src/azure_ad.rs
@@ -3,23 +3,18 @@
 //! This module provides token handling for Azure AD federated authentication,
 //! supporting both pre-acquired tokens and (with feature flags) token acquisition.
 //!
-//! ## ⚠️ Login wiring not yet implemented
+//! ## Authentication Flow
 //!
-//! The token-acquisition side below works, but the LOGIN7 FEDAUTH feature
-//! extension is **not yet implemented** in `mssql-client`, so these
-//! credentials cannot complete a login end-to-end. `Client::connect` rejects
-//! them with a clear error. Tracked in
-//! [#155](https://github.com/praxiomlabs/rust-mssql-driver/issues/155).
+//! Azure AD authentication uses the TDS FEDAUTH feature extension
+//! (MS-TDS §2.2.6.4). Two workflows exist:
 //!
-//! ## Authentication Flow (target design)
-//!
-//! Azure AD authentication uses the TDS FEDAUTH feature extension:
-//!
-//! 1. Client includes FEDAUTH feature in Login7 packet *(not yet implemented)*
-//! 2. Server responds with FEDAUTHINFO containing STS URL and SPN
-//! 3. Client acquires token (or uses pre-acquired token) ✅ this module
-//! 4. Client sends FEDAUTH token packet *(not yet implemented)*
-//! 5. Server validates token and completes authentication
+//! - **SecurityToken** (implemented, #155 Phase 1): the client acquires a
+//!   token *before* login and sends it inside the LOGIN7 FEDAUTH feature
+//!   extension ([`build_security_token_feature_data`]). No FEDAUTHINFO
+//!   round-trip occurs.
+//! - **ADAL/MSAL** (pending, #155 Phase 2): the client declares intent in
+//!   LOGIN7, the server responds with FEDAUTHINFO (STS URL + SPN), and the
+//!   client acquires a token and sends it in a separate FEDAUTH message.
 //!
 //! ## Token Sources (Tier 1 - Core)
 //!
@@ -39,33 +34,73 @@
 use std::borrow::Cow;
 use std::time::{Duration, Instant};
 
-use bytes::Bytes;
+use bytes::{BufMut, Bytes, BytesMut};
 
 use crate::credentials::Credentials;
 use crate::error::AuthError;
 use crate::provider::{AuthData, AuthMethod, AuthProvider};
 
-/// FEDAUTH library options for Login7.
+/// FEDAUTH library identifiers for the LOGIN7 FEDAUTH feature extension.
 ///
-/// These values indicate to the server which token library the client uses.
+/// Per MS-TDS §2.2.6.4, `bFedAuthLibrary` is a 7-bit value that occupies the
+/// high 7 bits of the feature data's Options byte (the low bit is
+/// `fFedAuthEcho`). Live ID Compact Token (0x00) is legacy and not supported;
+/// 0x7F is reserved.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
 #[non_exhaustive]
 pub enum FedAuthLibrary {
-    /// ADAL (Azure Active Directory Authentication Library) - legacy.
-    Adal = 0x01,
-    /// Security token (raw JWT).
-    SecurityToken = 0x02,
-    /// MSAL (Microsoft Authentication Library) - current.
-    Msal = 0x03,
+    /// Security token: a token acquired by the client before login and sent
+    /// inside LOGIN7 (the workflow used for pre-acquired Azure AD tokens).
+    SecurityToken = 0x01,
+    /// ADAL: the client declares intent and acquires the token after the
+    /// server's FEDAUTHINFO response. MSAL (ADAL's successor) uses this same
+    /// wire identifier.
+    Adal = 0x02,
 }
 
 impl FedAuthLibrary {
-    /// Get the byte value for the FEDAUTH feature extension.
+    /// Get the 7-bit library identifier (unshifted).
+    ///
+    /// In the Options byte this value is shifted left by one bit to make room
+    /// for `fFedAuthEcho`: `options = (library << 1) | echo`.
     #[must_use]
     pub fn to_byte(self) -> u8 {
         self as u8
     }
+}
+
+/// Build the LOGIN7 FEDAUTH feature extension data for the SecurityToken
+/// workflow (MS-TDS §2.2.6.4, `bFedAuthLibrary` = 0x01).
+///
+/// Layout:
+///
+/// ```text
+/// Options       = 1 byte: (0x01 << 1) | fFedAuthEcho
+/// FedAuthToken  = DWORD (LE) byte length + token as UTF-16LE
+/// ```
+///
+/// No trailing nonce is emitted: per spec the nonce MUST be present if and
+/// only if the server's PRELOGIN response carried a NONCE option, and this
+/// driver does not send NONCEOPT in PRELOGIN.
+///
+/// `fed_auth_echo` MUST be set if and only if the server's PRELOGIN response
+/// contained FEDAUTHREQUIRED with value 0x01 — the server validates this echo
+/// to detect tampering.
+///
+/// The token must be non-empty (the spec forbids a zero-length FedAuthToken);
+/// callers are expected to validate this before login.
+#[must_use]
+pub fn build_security_token_feature_data(token: &str, fed_auth_echo: bool) -> Bytes {
+    debug_assert!(!token.is_empty(), "FedAuthToken length MUST NOT be 0");
+
+    let token_utf16: Vec<u8> = token.encode_utf16().flat_map(|c| c.to_le_bytes()).collect();
+
+    let mut data = BytesMut::with_capacity(1 + 4 + token_utf16.len());
+    data.put_u8((FedAuthLibrary::SecurityToken.to_byte() << 1) | u8::from(fed_auth_echo));
+    data.put_u32_le(token_utf16.len() as u32);
+    data.put_slice(&token_utf16);
+    data.freeze()
 }
 
 /// FEDAUTH workflow types.
@@ -102,8 +137,6 @@ pub struct AzureAdAuth {
     token: Cow<'static, str>,
     /// When the token expires (if known).
     expires_at: Option<Instant>,
-    /// The library type to report to the server.
-    library: FedAuthLibrary,
 }
 
 impl AzureAdAuth {
@@ -119,7 +152,6 @@ impl AzureAdAuth {
         Self {
             token: token.into(),
             expires_at: None,
-            library: FedAuthLibrary::SecurityToken,
         }
     }
 
@@ -136,7 +168,6 @@ impl AzureAdAuth {
         Self {
             token: token.into(),
             expires_at: Some(Instant::now() + expires_in),
-            library: FedAuthLibrary::SecurityToken,
         }
     }
 
@@ -150,13 +181,6 @@ impl AzureAdAuth {
                 "AzureAdAuth requires Azure AD credentials".into(),
             )),
         }
-    }
-
-    /// Set the library type to report to the server.
-    #[must_use]
-    pub fn with_library(mut self, library: FedAuthLibrary) -> Self {
-        self.library = library;
-        self
     }
 
     /// Check if the token is expired.
@@ -175,28 +199,14 @@ impl AzureAdAuth {
             .unwrap_or(false)
     }
 
-    /// Build the FEDAUTH feature extension data for Login7.
+    /// Build the FEDAUTH feature extension data for Login7 (SecurityToken
+    /// workflow).
     ///
-    /// Format:
-    /// - 1 byte: Library type (ADAL=1, SecurityToken=2, MSAL=3)
-    /// - 1 byte: Workflow (0x00 for pre-acquired token)
-    /// - 4 bytes: FedAuth token length (big-endian)
-    /// - N bytes: FedAuth token (UTF-16LE encoded)
+    /// See [`build_security_token_feature_data`] for the wire layout and the
+    /// `fed_auth_echo` contract.
     #[must_use]
-    pub fn build_feature_data(&self) -> Bytes {
-        let mut data = Vec::with_capacity(6);
-
-        // Library type (1 byte)
-        data.push(self.library.to_byte());
-
-        // Workflow - 0x00 for non-interactive/pre-acquired token
-        data.push(0x00);
-
-        // For FEDAUTH, the actual token is sent in a separate FEDAUTH token packet,
-        // not in the Login7 feature extension. The feature extension just indicates
-        // that we want to use FEDAUTH.
-
-        Bytes::from(data)
+    pub fn build_feature_data(&self, fed_auth_echo: bool) -> Bytes {
+        build_security_token_feature_data(&self.token, fed_auth_echo)
     }
 
     /// Build the FEDAUTH token packet data.
@@ -241,9 +251,10 @@ impl AuthProvider for AzureAdAuth {
         })
     }
 
-    fn feature_extension_data(&self) -> Option<Bytes> {
-        Some(self.build_feature_data())
-    }
+    // Note: `feature_extension_data` deliberately uses the trait default
+    // (`None`). The FEDAUTH feature data depends on the server's PRELOGIN
+    // FEDAUTHREQUIRED response (the echo bit), which is unknowable here;
+    // the login path builds it via `build_feature_data(echo)` instead.
 
     fn needs_refresh(&self) -> bool {
         // Refresh if token expires within 5 minutes
@@ -256,7 +267,6 @@ impl std::fmt::Debug for AzureAdAuth {
         f.debug_struct("AzureAdAuth")
             .field("token", &"[REDACTED]")
             .field("expires_at", &self.expires_at)
-            .field("library", &self.library)
             .finish()
     }
 }
@@ -291,13 +301,57 @@ mod tests {
         assert!(matches!(result, Err(AuthError::TokenExpired)));
     }
 
+    /// Wire-exact encoding of the SecurityToken FEDAUTH feature data per
+    /// MS-TDS §2.2.6.4: Options byte = (0x01 << 1) | echo, then a
+    /// little-endian DWORD byte length, then the token as UTF-16LE. No nonce.
+    #[test]
+    fn test_security_token_feature_data_wire_exact() {
+        // "AB" -> UTF-16LE 41 00 42 00, length 4.
+        let no_echo = build_security_token_feature_data("AB", false);
+        assert_eq!(
+            no_echo.as_ref(),
+            &[0x02, 0x04, 0x00, 0x00, 0x00, 0x41, 0x00, 0x42, 0x00],
+            "echo clear: options must be 0x02 (SecurityToken << 1)"
+        );
+
+        let echo = build_security_token_feature_data("AB", true);
+        assert_eq!(
+            echo.as_ref(),
+            &[0x03, 0x04, 0x00, 0x00, 0x00, 0x41, 0x00, 0x42, 0x00],
+            "echo set: fFedAuthEcho is the low bit of the options byte"
+        );
+    }
+
+    /// Non-BMP characters must encode as UTF-16 surrogate pairs and the DWORD
+    /// length must count bytes (not code units or chars).
+    #[test]
+    fn test_security_token_feature_data_surrogate_pair() {
+        // U+1F600 -> surrogates D83D DE00 -> LE bytes 3D D8 00 DE.
+        let data = build_security_token_feature_data("\u{1F600}", false);
+        assert_eq!(
+            data.as_ref(),
+            &[0x02, 0x04, 0x00, 0x00, 0x00, 0x3D, 0xD8, 0x00, 0xDE]
+        );
+    }
+
+    /// The method form delegates to the free function with the same token.
     #[test]
     fn test_azure_ad_feature_data() {
         let auth = AzureAdAuth::with_token("test_token");
-        let data = auth.build_feature_data();
+        let data = auth.build_feature_data(true);
 
-        assert!(!data.is_empty());
-        assert_eq!(data[0], FedAuthLibrary::SecurityToken.to_byte());
+        assert_eq!(data, build_security_token_feature_data("test_token", true));
+        // Library bits: options >> 1 must be the SecurityToken identifier.
+        assert_eq!(data[0] >> 1, FedAuthLibrary::SecurityToken.to_byte());
+        assert_eq!(data[0] & 1, 1);
+    }
+
+    /// The wire identifiers come from MS-TDS §2.2.6.4 and must never drift:
+    /// SecurityToken = 0x01, ADAL (also used by MSAL) = 0x02.
+    #[test]
+    fn test_fed_auth_library_wire_values() {
+        assert_eq!(FedAuthLibrary::SecurityToken.to_byte(), 0x01);
+        assert_eq!(FedAuthLibrary::Adal.to_byte(), 0x02);
     }
 
     #[test]

--- a/crates/mssql-auth/src/lib.rs
+++ b/crates/mssql-auth/src/lib.rs
@@ -10,18 +10,22 @@
 //! | Method | Feature Flag | Status | Description |
 //! |--------|--------------|--------|-------------|
 //! | SQL Authentication | default | ✅ Implemented | Username/password |
-//! | Azure AD Token | default | ⚠️ Token handling only¹ | Pre-obtained access token |
-//! | Azure Managed Identity | `azure-identity` | ⚠️ Token acquisition only¹ | VM/container identity |
-//! | Service Principal | `azure-identity` | ⚠️ Token acquisition only¹ | App credentials |
+//! | Azure AD Token | default | ✅ Implemented | Pre-obtained access token |
+//! | Azure Managed Identity | `azure-identity` | ✅ Implemented | VM/container identity |
+//! | Service Principal | `azure-identity` | ✅ Implemented | App credentials |
 //! | Integrated (Kerberos) | `integrated-auth` | ✅ Implemented | GSSAPI/Kerberos (Linux/macOS) |
 //! | Windows SSPI | `sspi-auth` | ✅ Implemented | Native Windows SSPI |
 //! | Certificate | `cert-auth` | ⚠️ Token acquisition only¹ | Client certificate (mTLS) |
 //!
-//! ¹ These providers acquire tokens, but the LOGIN7 FEDAUTH feature
-//! extension is not yet implemented in `mssql-client`, so they cannot
-//! complete a login end-to-end. `Client::connect` rejects these credential
-//! types with a clear error. Tracked in
+//! ¹ `CertificateAuth` acquires tokens, but `mssql-client` does not yet wire
+//! certificate credentials into the login sequence; `Client::connect` rejects
+//! them with a clear error. Tracked in
 //! [#155](https://github.com/praxiomlabs/rust-mssql-driver/issues/155).
+//!
+//! The Azure AD methods use the FEDAUTH SecurityToken workflow: the token is
+//! acquired client-side and sent in the LOGIN7 FEDAUTH feature extension
+//! (see [`azure_ad::build_security_token_feature_data`]). The ADAL/MSAL
+//! workflow (server-directed acquisition via FEDAUTHINFO) is #155 Phase 2.
 //!
 //! ## Authentication Tiers
 //!
@@ -30,9 +34,9 @@
 //! ### Tier 1 (Core - Pure Rust, Default)
 //!
 //! - [`SqlServerAuth`] - Username/password via Login7 ✅ Implemented
-//! - [`AzureAdAuth`] - Pre-acquired access token ⚠️ FEDAUTH login wiring pending (#155)
+//! - [`AzureAdAuth`] - Pre-acquired access token ✅ Implemented
 //!
-//! ### Tier 2 (Azure Native - `azure-identity` feature) ⚠️ FEDAUTH login wiring pending (#155)
+//! ### Tier 2 (Azure Native - `azure-identity` feature) ✅ Implemented
 //!
 //! - `ManagedIdentityAuth` - Azure VM/Container identity
 //! - `ServicePrincipalAuth` - Client ID + Secret
@@ -42,7 +46,7 @@
 //! - `IntegratedAuth` - Kerberos (Linux/macOS via GSSAPI)
 //! - `SspiAuth` - Windows SSPI (native Windows, cross-platform via sspi-rs)
 //!
-//! ### Tier 4 (Certificate - `cert-auth` feature) ⚠️ FEDAUTH login wiring pending (#155)
+//! ### Tier 4 (Certificate - `cert-auth` feature) ⚠️ login wiring pending (#155)
 //!
 //! - `CertificateAuth` - Client certificate authentication (mTLS)
 //!

--- a/crates/mssql-client/Cargo.toml
+++ b/crates/mssql-client/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["database", "asynchronous"]
 [package.metadata.docs.rs]
 # docs.rs builds on Linux x86_64. Excluded: sspi-auth (Windows-only) and
 # integrated-auth (libgssapi system library not guaranteed on docs.rs).
-features = ["otel", "json", "always-encrypted", "zeroize", "encoding", "tls", "chrono", "uuid", "decimal", "filestream"]
+features = ["otel", "json", "always-encrypted", "azure-identity", "zeroize", "encoding", "tls", "chrono", "uuid", "decimal", "filestream"]
 
 [features]
 default = ["chrono", "uuid", "decimal", "encoding", "tls", "derive"]
@@ -41,6 +41,11 @@ always-encrypted = ["mssql-auth/always-encrypted"]
 # Forwarded to both tds-protocol (wire-level) and mssql-types (type-level).
 # Both use encoding_rs for codec support.
 encoding = ["tds-protocol/encoding", "mssql-types/encoding"]
+# Azure Managed Identity / Service Principal token acquisition for
+# Azure AD (FEDAUTH) logins. Pre-acquired tokens (Credentials::AzureAccessToken)
+# work without this feature. Note: pulls OpenSSL transitively via the Azure SDK
+# (see the trade-off note in ARCHITECTURE.md ADR-003).
+azure-identity = ["mssql-auth/azure-identity"]
 # Integrated authentication (Kerberos/SPNEGO) - Linux/macOS
 integrated-auth = ["mssql-auth/integrated-auth"]
 # Windows SSPI integrated authentication

--- a/crates/mssql-client/src/client/connect.rs
+++ b/crates/mssql-client/src/client/connect.rs
@@ -27,6 +27,16 @@ use crate::statement_cache::StatementCache;
 
 use super::{Client, ConnectionHandle};
 
+/// Federated authentication parameters for a single LOGIN7 attempt.
+///
+/// `echo` mirrors the server's PRELOGIN FEDAUTHREQUIRED response, as required
+/// for the `fFedAuthEcho` bit (MS-TDS §2.2.6.4).
+#[derive(Clone, Copy)]
+struct FedAuthLogin<'a> {
+    token: &'a str,
+    echo: bool,
+}
+
 impl Client<Disconnected> {
     /// Connect to SQL Server.
     ///
@@ -44,30 +54,13 @@ impl Client<Disconnected> {
     /// # }
     /// ```
     pub async fn connect(config: Config) -> Result<Client<Ready>> {
-        // FEDAUTH-based credentials (Azure AD / Entra and client certificate)
-        // are not yet wired into the login sequence: providers can acquire
-        // tokens, but LOGIN7 carries no FEDAUTH feature extension, so the
-        // server would receive an empty-credential login and reject it with
-        // an opaque error 18456. Fail fast with an actionable error instead.
-        // Full FEDAUTH support is tracked in issue #155.
-        match &config.credentials {
-            mssql_auth::Credentials::SqlServer { .. } => {}
-            #[cfg(any(feature = "integrated-auth", feature = "sspi-auth"))]
-            mssql_auth::Credentials::Integrated => {}
-            // Every other credential type (Azure access token, managed
-            // identity, service principal, client certificate) is
-            // FEDAUTH-based and rejected here.
-            _ => {
-                return Err(Error::Config(
-                    "Azure AD / Entra and client certificate (FEDAUTH) authentication \
-                     are not yet supported: the LOGIN7 FEDAUTH feature extension is not \
-                     implemented (tracked in \
-                     https://github.com/praxiomlabs/rust-mssql-driver/issues/155). \
-                     Use SQL Server or integrated authentication."
-                        .into(),
-                ));
-            }
-        }
+        Self::validate_credential_support(&config)?;
+
+        // Azure AD / Entra credentials use the FEDAUTH SecurityToken workflow
+        // (MS-TDS §2.2.6.4): the access token is acquired client-side before
+        // any TDS traffic and sent in the LOGIN7 FEDAUTH feature extension.
+        // Acquired once here so retries and Azure gateway redirects reuse it.
+        let fed_auth_token = Self::resolve_fed_auth_token(&config).await?;
 
         let retry = config.retry.clone();
         let max_redirects = config.redirect.max_redirects;
@@ -105,7 +98,7 @@ impl Client<Disconnected> {
                         break Err(Error::TooManyRedirects { max: max_redirects });
                     }
 
-                    match Self::try_connect(&current_config).await {
+                    match Self::try_connect(&current_config, fed_auth_token.as_deref()).await {
                         Ok(client) => break Ok(client),
                         Err(Error::Routing { host, port }) => {
                             if !follow_redirects {
@@ -154,7 +147,111 @@ impl Client<Disconnected> {
         }
     }
 
-    async fn try_connect(config: &Config) -> Result<Client<Ready>> {
+    /// Validate that the configured credentials can complete a login.
+    ///
+    /// Fails fast with an actionable error instead of sending a login the
+    /// server would reject with an opaque error 18456 (or worse, leaking a
+    /// bearer token over plaintext).
+    fn validate_credential_support(config: &Config) -> Result<()> {
+        match &config.credentials {
+            mssql_auth::Credentials::SqlServer { .. } => Ok(()),
+            #[cfg(any(feature = "integrated-auth", feature = "sspi-auth"))]
+            mssql_auth::Credentials::Integrated => Ok(()),
+            creds if creds.is_azure_ad() => {
+                // A FEDAUTH login carries a bearer token; sending it over a
+                // plaintext connection would hand the token to any on-path
+                // observer. Azure SQL always requires TLS anyway.
+                #[cfg(not(feature = "tls"))]
+                {
+                    return Err(Error::Config(
+                        "Azure AD / Entra (FEDAUTH) authentication requires TLS: \
+                         enable the 'tls' feature."
+                            .into(),
+                    ));
+                }
+                #[cfg(feature = "tls")]
+                {
+                    if config.no_tls {
+                        return Err(Error::Config(
+                            "Azure AD / Entra (FEDAUTH) authentication cannot be combined \
+                             with Encrypt=no_tls: the access token would be sent in \
+                             plaintext. Use Encrypt=mandatory or Encrypt=strict."
+                                .into(),
+                        ));
+                    }
+                    if matches!(&config.credentials,
+                        mssql_auth::Credentials::AzureAccessToken { token } if token.is_empty())
+                    {
+                        return Err(Error::Config(
+                            "Azure AD access token is empty (the FEDAUTH token length \
+                             must not be zero)"
+                                .into(),
+                        ));
+                    }
+                    if !config.strict_mode && !config.tds_version.supports_fed_auth() {
+                        return Err(Error::Config(format!(
+                            "Azure AD / Entra (FEDAUTH) authentication requires TDS 7.4 \
+                             or later (configured: {})",
+                            config.tds_version
+                        )));
+                    }
+                    Ok(())
+                }
+            }
+            // Remaining credential types (client certificate) cannot complete
+            // a login yet: certificate-acquired tokens are not wired into the
+            // login sequence. Tracked in issue #155.
+            _ => Err(Error::Config(
+                "client certificate (FEDAUTH) authentication is not yet supported \
+                 (tracked in https://github.com/praxiomlabs/rust-mssql-driver/issues/155). \
+                 Use SQL Server, integrated, or Azure AD / Entra authentication."
+                    .into(),
+            )),
+        }
+    }
+
+    /// Resolve the federated authentication access token, if these
+    /// credentials use FEDAUTH.
+    ///
+    /// Pre-acquired tokens are passed through; managed identity and service
+    /// principal credentials acquire a token from Entra ID (network I/O).
+    /// Returns `None` for non-FEDAUTH credentials.
+    async fn resolve_fed_auth_token(config: &Config) -> Result<Option<String>> {
+        match &config.credentials {
+            mssql_auth::Credentials::AzureAccessToken { token } => Ok(Some(token.to_string())),
+            #[cfg(feature = "azure-identity")]
+            mssql_auth::Credentials::AzureManagedIdentity { client_id } => {
+                let auth = match client_id {
+                    Some(id) => {
+                        mssql_auth::ManagedIdentityAuth::user_assigned_client_id(id.to_string())?
+                    }
+                    None => mssql_auth::ManagedIdentityAuth::system_assigned()?,
+                };
+                tracing::debug!("acquiring Azure SQL access token via managed identity");
+                Ok(Some(auth.get_token().await?))
+            }
+            #[cfg(feature = "azure-identity")]
+            mssql_auth::Credentials::AzureServicePrincipal {
+                tenant_id,
+                client_id,
+                client_secret,
+            } => {
+                let auth = mssql_auth::ServicePrincipalAuth::new(
+                    tenant_id.as_ref(),
+                    client_id.to_string(),
+                    client_secret.to_string(),
+                )?;
+                tracing::debug!(
+                    client_id = %client_id,
+                    "acquiring Azure SQL access token via service principal"
+                );
+                Ok(Some(auth.get_token().await?))
+            }
+            _ => Ok(None),
+        }
+    }
+
+    async fn try_connect(config: &Config, fed_auth_token: Option<&str>) -> Result<Client<Ready>> {
         // If a named instance is specified, resolve the TCP port via SQL Browser
         let port = if let Some(ref instance) = config.instance {
             let resolved = crate::browser::resolve_instance(
@@ -213,15 +310,19 @@ impl Client<Disconnected> {
 
             // Step 2: Handle TDS 8.0 strict mode (TLS before any TDS traffic)
             if tls_mode.is_tls_first() {
-                return Self::connect_tds_8(config, tcp_stream).await;
+                return Self::connect_tds_8(config, tcp_stream, fed_auth_token).await;
             }
 
             // Step 3: TDS 7.x flow - PreLogin first, then TLS, then Login7
-            Self::connect_tds_7x(config, tcp_stream).await
+            Self::connect_tds_7x(config, tcp_stream, fed_auth_token).await
         }
 
         #[cfg(not(feature = "tls"))]
         {
+            // FEDAUTH credentials were rejected by validate_credential_support
+            // (no TLS feature means no way to protect the bearer token).
+            let _ = fed_auth_token;
+
             // When TLS feature is disabled, only no_tls connections are supported
             if config.strict_mode {
                 return Err(Error::Config(
@@ -335,7 +436,11 @@ impl Client<Disconnected> {
     ///
     /// Flow: TCP -> TLS -> PreLogin (encrypted) -> Login7 (encrypted)
     #[cfg(feature = "tls")]
-    async fn connect_tds_8(config: &Config, tcp_stream: TcpStream) -> Result<Client<Ready>> {
+    async fn connect_tds_8(
+        config: &Config,
+        tcp_stream: TcpStream,
+        fed_auth_token: Option<&str>,
+    ) -> Result<Client<Ready>> {
         tracing::debug!("using TDS 8.0 strict mode (TLS first)");
 
         // Build TLS configuration from the user's `config.tls` plus the
@@ -364,7 +469,7 @@ impl Client<Disconnected> {
         // Send PreLogin (encrypted in strict mode)
         let prelogin = Self::build_prelogin(config, EncryptionLevel::Required);
         Self::send_prelogin(&mut connection, &prelogin).await?;
-        let _prelogin_response = Self::receive_prelogin(&mut connection).await?;
+        let prelogin_response = Self::receive_prelogin(&mut connection).await?;
 
         // Create SSPI negotiator if integrated auth
         #[cfg(any(feature = "integrated-auth", feature = "sspi-auth"))]
@@ -378,7 +483,11 @@ impl Client<Disconnected> {
         let sspi_token: Option<Vec<u8>> = None;
 
         // Send Login7
-        let login = Self::build_login7(config, sspi_token);
+        let fed_auth = fed_auth_token.map(|token| FedAuthLogin {
+            token,
+            echo: prelogin_response.fed_auth_required,
+        });
+        let login = Self::build_login7(config, sspi_token, fed_auth);
         Self::send_login7(&mut connection, &login).await?;
 
         // Process login response (with timeout to prevent hangs during redirect)
@@ -430,7 +539,11 @@ impl Client<Disconnected> {
     /// upgrading to TLS. We use low-level I/O for this initial exchange
     /// since the Connection struct splits the stream immediately.
     #[cfg(feature = "tls")]
-    async fn connect_tds_7x(config: &Config, mut tcp_stream: TcpStream) -> Result<Client<Ready>> {
+    async fn connect_tds_7x(
+        config: &Config,
+        mut tcp_stream: TcpStream,
+        fed_auth_token: Option<&str>,
+    ) -> Result<Client<Ready>> {
         use bytes::BufMut;
         use tds_protocol::packet::{PACKET_HEADER_SIZE, PacketHeader, PacketStatus};
         use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -536,6 +649,12 @@ impl Client<Disconnected> {
         let server_encryption = prelogin_response.encryption;
         tracing::debug!(encryption = ?server_encryption, "server encryption level");
 
+        // FEDAUTH: echo the server's FEDAUTHREQUIRED response (fFedAuthEcho).
+        let fed_auth = fed_auth_token.map(|token| FedAuthLogin {
+            token,
+            echo: prelogin_response.fed_auth_required,
+        });
+
         // Determine negotiated encryption level (follows TDS 7.x rules)
         // - NotSupported + NotSupported = NotSupported (no TLS at all)
         // - Off + Off = Off (TLS for login only, then plain)
@@ -609,7 +728,7 @@ impl Client<Disconnected> {
                 let sspi_token: Option<Vec<u8>> = None;
 
                 // Build and send Login7 directly through TLS
-                let login = Self::build_login7(config, sspi_token);
+                let login = Self::build_login7(config, sspi_token, fed_auth);
                 let login_payload = login.encode();
 
                 // Create TDS packet manually for Login7
@@ -715,7 +834,7 @@ impl Client<Disconnected> {
                 let sspi_token: Option<Vec<u8>> = None;
 
                 // Send Login7
-                let login = Self::build_login7(config, sspi_token);
+                let login = Self::build_login7(config, sspi_token, fed_auth);
                 Self::send_login7(&mut connection, &login).await?;
 
                 // Process login response (with timeout)
@@ -780,8 +899,10 @@ impl Client<Disconnected> {
             #[cfg(not(any(feature = "integrated-auth", feature = "sspi-auth")))]
             let sspi_token: Option<Vec<u8>> = None;
 
-            // Build and send Login7
-            let login = Self::build_login7(config, sspi_token);
+            // Build and send Login7. `fed_auth` is provably None here: a
+            // plaintext connection requires Encrypt=no_tls, which
+            // validate_credential_support rejects for FEDAUTH credentials.
+            let login = Self::build_login7(config, sspi_token, fed_auth);
             Self::send_login7(&mut connection, &login).await?;
 
             // Process login response (with timeout)
@@ -912,8 +1033,9 @@ impl Client<Disconnected> {
         #[cfg(not(any(feature = "integrated-auth", feature = "sspi-auth")))]
         let sspi_token: Option<Vec<u8>> = None;
 
-        // Build and send Login7
-        let login = Self::build_login7(config, sspi_token);
+        // Build and send Login7 (FEDAUTH credentials were rejected by
+        // validate_credential_support: no TLS feature, no token protection).
+        let login = Self::build_login7(config, sspi_token, None);
         Self::send_login7(&mut connection, &login).await?;
 
         // Process login response (with timeout)
@@ -978,6 +1100,12 @@ impl Client<Disconnected> {
             prelogin = prelogin.with_instance(instance);
         }
 
+        // Advertise federated authentication so the server's response carries
+        // the FEDAUTHREQUIRED value we must echo in LOGIN7 (fFedAuthEcho).
+        if config.credentials.is_azure_ad() {
+            prelogin = prelogin.with_fed_auth_required(true);
+        }
+
         prelogin
     }
 
@@ -1003,7 +1131,16 @@ impl Client<Disconnected> {
     ///
     /// When `sspi_token` is provided (integrated auth), the Login7 packet is
     /// built with the integrated security flag and the initial SSPI blob.
-    fn build_login7(config: &Config, sspi_token: Option<Vec<u8>>) -> Login7 {
+    ///
+    /// When `fed_auth` is provided (Azure AD / Entra), the packet carries the
+    /// FEDAUTH feature extension (SecurityToken workflow) and no username or
+    /// password — per MS-TDS §2.2.6.4, `fIntSecurity` must be 0 and the
+    /// credential fields stay empty.
+    fn build_login7(
+        config: &Config,
+        sspi_token: Option<Vec<u8>>,
+        fed_auth: Option<FedAuthLogin<'_>>,
+    ) -> Login7 {
         // Use the configured TDS version (strict_mode overrides to V8_0)
         let version = if config.strict_mode {
             tds_protocol::version::TdsVersion::V8_0
@@ -1036,6 +1173,17 @@ impl Client<Disconnected> {
         if let Some(token) = sspi_token {
             // Integrated auth: set SSPI data and integrated security flag
             login = login.with_integrated_auth(token);
+        } else if let Some(fed) = fed_auth {
+            // Azure AD / Entra: FEDAUTH feature extension, SecurityToken
+            // workflow. Username/password stay empty.
+            login = login.with_feature(tds_protocol::login7::FeatureExtension {
+                feature_id: tds_protocol::login7::FeatureId::FedAuth,
+                data: mssql_auth::azure_ad::build_security_token_feature_data(fed.token, fed.echo),
+            });
+            tracing::debug!(
+                fed_auth_echo = fed.echo,
+                "Login7: adding FEDAUTH feature extension (SecurityToken workflow)"
+            );
         } else if let mssql_auth::Credentials::SqlServer { username, password } =
             &config.credentials
         {
@@ -1246,6 +1394,15 @@ impl Client<Disconnected> {
                             "server info message"
                         );
                     }
+                    Token::FeatureExtAck(ack) => {
+                        for feature in &ack.features {
+                            tracing::debug!(
+                                feature_id = feature.feature_id,
+                                data_len = feature.data.len(),
+                                "server acknowledged feature extension"
+                            );
+                        }
+                    }
                     Token::Done(done) => {
                         if done.status.error {
                             return Err(Error::Protocol("login failed".to_string()));
@@ -1404,5 +1561,126 @@ mod tls_config_tests {
 
         let non_strict = connection_tls_config(&config, false);
         assert!(!non_strict.strict_mode);
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod fed_auth_login_tests {
+    use super::*;
+    use tds_protocol::prelogin::EncryptionLevel;
+
+    fn azure_config(token: &str) -> Config {
+        Config::new().credentials(mssql_auth::Credentials::azure_token(token.to_string()))
+    }
+
+    /// Wire-exact assembly of the FEDAUTH feature extension inside the
+    /// encoded LOGIN7, located through the ibExtension pointer indirection
+    /// (MS-TDS §2.2.6.4): FeatureId 0x02, DWORD-LE data length, options byte
+    /// `(SecurityToken << 1) | echo`, DWORD-LE token byte length, UTF-16LE
+    /// token, 0xFF terminator. Username/password must stay empty and
+    /// fIntSecurity clear.
+    #[test]
+    fn login7_fed_auth_feature_block_wire_exact() {
+        let config = azure_config("AB");
+        let login = Client::<Disconnected>::build_login7(
+            &config,
+            None,
+            Some(FedAuthLogin {
+                token: "AB",
+                echo: true,
+            }),
+        );
+
+        assert!(
+            !login.option_flags2.integrated_security,
+            "fIntSecurity MUST be 0 when FEDAUTH is present"
+        );
+        assert!(
+            login.username.is_empty() && login.password.is_empty(),
+            "FEDAUTH logins must not carry username/password"
+        );
+
+        let encoded = login.encode();
+
+        // OptionFlags3 (byte 27) must have fExtension (0x10) set.
+        assert_eq!(encoded[27] & 0x10, 0x10, "fExtension bit must be set");
+
+        // ibExtension/cbExtension are the 6th (offset, length) pair in the
+        // offset table starting at byte 36. The u32 it points to holds the
+        // absolute offset of the FeatureExt block.
+        const EXTENSION_SLOT: usize = 36 + 5 * 4;
+        let ib_extension =
+            u16::from_le_bytes([encoded[EXTENSION_SLOT], encoded[EXTENSION_SLOT + 1]]) as usize;
+        let feature_off =
+            u32::from_le_bytes(encoded[ib_extension..ib_extension + 4].try_into().unwrap())
+                as usize;
+
+        assert_eq!(
+            encoded[feature_off], 0x02,
+            "FeatureId must be FEDAUTH (0x02)"
+        );
+        let data_len = u32::from_le_bytes(
+            encoded[feature_off + 1..feature_off + 5]
+                .try_into()
+                .unwrap(),
+        ) as usize;
+        // options(1) + token length DWORD(4) + "AB" as UTF-16LE(4)
+        assert_eq!(data_len, 9, "FeatureDataLen must cover options + token");
+
+        let data = &encoded[feature_off + 5..feature_off + 5 + data_len];
+        assert_eq!(
+            data,
+            &[0x03, 0x04, 0x00, 0x00, 0x00, 0x41, 0x00, 0x42, 0x00],
+            "options must be (SecurityToken << 1) | echo, then DWORD-LE \
+             token byte length, then UTF-16LE token"
+        );
+        assert_eq!(
+            encoded[feature_off + 5 + data_len],
+            0xFF,
+            "FeatureExt terminator must follow"
+        );
+    }
+
+    /// The echo bit mirrors the server's PRELOGIN FEDAUTHREQUIRED response;
+    /// when the server sent 0x00 the options byte must be 0x02 (echo clear).
+    #[test]
+    fn login7_fed_auth_echo_clear() {
+        let config = azure_config("AB");
+        let login = Client::<Disconnected>::build_login7(
+            &config,
+            None,
+            Some(FedAuthLogin {
+                token: "AB",
+                echo: false,
+            }),
+        );
+        let encoded = login.encode();
+
+        const EXTENSION_SLOT: usize = 36 + 5 * 4;
+        let ib_extension =
+            u16::from_le_bytes([encoded[EXTENSION_SLOT], encoded[EXTENSION_SLOT + 1]]) as usize;
+        let feature_off =
+            u32::from_le_bytes(encoded[ib_extension..ib_extension + 4].try_into().unwrap())
+                as usize;
+        assert_eq!(encoded[feature_off], 0x02);
+        assert_eq!(
+            encoded[feature_off + 5],
+            0x02,
+            "options byte must have fFedAuthEcho clear"
+        );
+    }
+
+    /// PRELOGIN must advertise FEDAUTHREQUIRED for Azure AD credentials and
+    /// must not for SQL authentication.
+    #[test]
+    fn prelogin_advertises_fed_auth_for_azure_credentials() {
+        let azure = azure_config("tok");
+        let prelogin = Client::<Disconnected>::build_prelogin(&azure, EncryptionLevel::On);
+        assert!(prelogin.fed_auth_required);
+
+        let sql = Config::new().credentials(mssql_auth::Credentials::sql_server("u", "p"));
+        let prelogin = Client::<Disconnected>::build_prelogin(&sql, EncryptionLevel::On);
+        assert!(!prelogin.fed_auth_required);
     }
 }

--- a/crates/mssql-client/src/config.rs
+++ b/crates/mssql-client/src/config.rs
@@ -41,9 +41,10 @@
 //!
 //! | Keyword | Aliases | Default | Description |
 //! |---------|---------|---------|-------------|
-//! | `User Id` | `UID`, `User` | (empty) | SQL Server login username. |
-//! | `Password` | `PWD` | (empty) | SQL Server login password. |
+//! | `User Id` | `UID`, `User` | (empty) | SQL Server login username. Reinterpreted by `Authentication` (see below). |
+//! | `Password` | `PWD` | (empty) | SQL Server login password. Reinterpreted by `Authentication` (see below). |
 //! | `Database` | `Initial Catalog` | none | Target database. |
+//! | `Authentication` | — | none | Authentication method (ADO.NET `SqlAuthenticationMethod`; spaced forms like `Active Directory Service Principal` also accepted). `SqlPassword`: SQL authentication (the default). `ActiveDirectoryServicePrincipal`: Azure AD service principal — `User Id=<client-id>@<tenant-id>`, `Password=<client secret>`; requires the `azure-identity` feature. `ActiveDirectoryManagedIdentity` (alias `ActiveDirectoryMSI`): Azure managed identity — optional `User Id=<client-id>` selects a user-assigned identity; requires the `azure-identity` feature. Azure AD methods log in via the FEDAUTH SecurityToken workflow and require an encrypted connection. The ADAL/MSAL values (`ActiveDirectoryPassword`, `ActiveDirectoryInteractive`, …) are recognized but unsupported ([#155](https://github.com/praxiomlabs/rust-mssql-driver/issues/155)). |
 //!
 //! ### Security
 //!
@@ -466,6 +467,11 @@ impl Config {
         let mut config = Self::default();
         let pairs = split_connection_string(conn_str)?;
 
+        // The Authentication keyword is recorded during the loop and applied
+        // afterwards, so the outcome does not depend on whether it appears
+        // before or after User Id / Password.
+        let mut authentication: Option<String> = None;
+
         for (key, value) in &pairs {
             let key = key.trim().to_lowercase();
             let value = value.trim();
@@ -527,6 +533,12 @@ impl Config {
                         config.credentials =
                             Credentials::sql_server(username.clone(), value.to_string());
                     }
+                }
+                // ADO.NET accepts both spaced ("Active Directory Service
+                // Principal") and compact (ActiveDirectoryServicePrincipal)
+                // forms; normalize for the post-loop match.
+                "authentication" => {
+                    authentication = non_empty(value).map(|v| v.to_lowercase().replace(' ', ""));
                 }
                 // --- Application ---
                 "application name" | "app" => {
@@ -705,7 +717,6 @@ impl Config {
                 | "async"
                 | "transparentnetworkipresolution"
                 | "poolblockingperiod"
-                | "authentication"
                 | "hostnameincertificate"
                 | "servercertificate" => {
                     tracing::info!(
@@ -725,7 +736,125 @@ impl Config {
             }
         }
 
+        if let Some(method) = authentication {
+            config.apply_authentication_keyword(&method)?;
+        }
+
         Ok(config)
+    }
+
+    /// Apply a (normalized) `Authentication=` connection-string value.
+    ///
+    /// Called after the keyword loop: `User Id` / `Password` have their final
+    /// values, which the Azure AD methods reinterpret (client id / secret).
+    /// Values follow ADO.NET `SqlAuthenticationMethod` and ADR-002.
+    fn apply_authentication_keyword(&mut self, method: &str) -> Result<(), crate::error::Error> {
+        // ADO.NET semantics: Authentication and Integrated Security are
+        // mutually exclusive, whatever the Authentication value.
+        #[cfg(any(feature = "integrated-auth", feature = "sspi-auth"))]
+        if matches!(self.credentials, Credentials::Integrated) {
+            return Err(crate::error::Error::Config(
+                "the Authentication keyword cannot be combined with Integrated Security".into(),
+            ));
+        }
+
+        match method {
+            // Explicit SQL authentication: User Id / Password already hold
+            // the credentials; nothing to transform.
+            "sqlpassword" => {}
+            "activedirectorymanagedidentity" | "activedirectorymsi" => {
+                #[cfg(not(feature = "azure-identity"))]
+                return Err(crate::error::Error::Config(format!(
+                    "Authentication={method} requires the 'azure-identity' feature. \
+                     Enable it in your Cargo.toml: \
+                     mssql-client = {{ features = [\"azure-identity\"] }}"
+                )));
+                #[cfg(feature = "azure-identity")]
+                {
+                    // Optional User Id selects a user-assigned identity.
+                    let client_id = match &self.credentials {
+                        Credentials::SqlServer { username, .. } if !username.is_empty() => {
+                            Some(username.clone())
+                        }
+                        _ => None,
+                    };
+                    self.credentials = Credentials::AzureManagedIdentity { client_id };
+                }
+            }
+            "activedirectoryserviceprincipal" => {
+                #[cfg(not(feature = "azure-identity"))]
+                return Err(crate::error::Error::Config(format!(
+                    "Authentication={method} requires the 'azure-identity' feature. \
+                     Enable it in your Cargo.toml: \
+                     mssql-client = {{ features = [\"azure-identity\"] }}"
+                )));
+                #[cfg(feature = "azure-identity")]
+                {
+                    let Credentials::SqlServer { username, password } = &self.credentials else {
+                        return Err(crate::error::Error::Config(
+                            "Authentication=ActiveDirectoryServicePrincipal requires \
+                             User Id and Password (client id and secret)"
+                                .into(),
+                        ));
+                    };
+                    // The tenant rides in User Id: client-side token
+                    // acquisition (FEDAUTH SecurityToken workflow) needs it
+                    // before any server contact.
+                    let Some((client_id, tenant_id)) = username.split_once('@') else {
+                        return Err(crate::error::Error::Config(
+                            "Authentication=ActiveDirectoryServicePrincipal requires \
+                             User Id=<client-id>@<tenant-id> (the tenant id is needed \
+                             for client-side token acquisition)"
+                                .into(),
+                        ));
+                    };
+                    if client_id.is_empty() || tenant_id.is_empty() {
+                        return Err(crate::error::Error::Config(
+                            "Authentication=ActiveDirectoryServicePrincipal: client id \
+                             and tenant id must both be non-empty in \
+                             User Id=<client-id>@<tenant-id>"
+                                .into(),
+                        ));
+                    }
+                    if password.is_empty() {
+                        return Err(crate::error::Error::Config(
+                            "Authentication=ActiveDirectoryServicePrincipal requires \
+                             Password=<client secret>"
+                                .into(),
+                        ));
+                    }
+                    let (client_id, tenant_id) = (client_id.to_string(), tenant_id.to_string());
+                    let client_secret = password.clone();
+                    self.credentials = Credentials::AzureServicePrincipal {
+                        tenant_id: tenant_id.into(),
+                        client_id: client_id.into(),
+                        client_secret,
+                    };
+                }
+            }
+            "activedirectorypassword"
+            | "activedirectoryintegrated"
+            | "activedirectoryinteractive"
+            | "activedirectorydefault"
+            | "activedirectorydevicecodeflow" => {
+                return Err(crate::error::Error::Config(format!(
+                    "Authentication value '{method}' is not supported. Supported values: \
+                     SqlPassword, ActiveDirectoryServicePrincipal, \
+                     ActiveDirectoryManagedIdentity (alias ActiveDirectoryMSI). The remaining \
+                     ADAL/MSAL workflows are tracked in \
+                     https://github.com/praxiomlabs/rust-mssql-driver/issues/155"
+                )));
+            }
+            other => {
+                return Err(crate::error::Error::Config(format!(
+                    "invalid Authentication value: '{other}'. Supported values: \
+                     SqlPassword, ActiveDirectoryServicePrincipal, \
+                     ActiveDirectoryManagedIdentity (alias ActiveDirectoryMSI)"
+                )));
+            }
+        }
+
+        Ok(())
     }
 
     /// Set the server host.

--- a/crates/mssql-client/tests/azure_sql.rs
+++ b/crates/mssql-client/tests/azure_sql.rs
@@ -456,3 +456,164 @@ async fn test_azure_datetime_types() {
 
     client.close().await.expect("Close failed");
 }
+
+// =============================================================================
+// Azure AD / Entra Authentication (FEDAUTH SecurityToken workflow, #155)
+// =============================================================================
+
+/// Service principal fixture from the environment.
+///
+/// Prefers the `AZURE_SQL_`-prefixed names from the issue; falls back to the
+/// generic `AZURE_` names used by azure_identity's EnvironmentCredential and
+/// the standing test fixture.
+#[cfg(feature = "azure-identity")]
+fn get_azure_sp_env() -> Option<(String, String, String)> {
+    fn var2(primary: &str, fallback: &str) -> Option<String> {
+        std::env::var(primary)
+            .or_else(|_| std::env::var(fallback))
+            .ok()
+    }
+    let tenant_id = var2("AZURE_SQL_TENANT_ID", "AZURE_TENANT_ID")?;
+    let client_id = var2("AZURE_SQL_CLIENT_ID", "AZURE_CLIENT_ID")?;
+    let client_secret = var2("AZURE_SQL_CLIENT_SECRET", "AZURE_CLIENT_SECRET")?;
+    Some((tenant_id, client_id, client_secret))
+}
+
+#[cfg(feature = "azure-identity")]
+fn get_azure_host_db() -> Option<(String, String)> {
+    let host = std::env::var("AZURE_SQL_HOST").ok()?;
+    let database = std::env::var("AZURE_SQL_DATABASE").ok()?;
+    Some((host, database))
+}
+
+/// Query the authenticated principal and the login's authentication type.
+#[cfg(feature = "azure-identity")]
+async fn current_principal(
+    client: &mut mssql_client::Client<mssql_client::Ready>,
+) -> (String, String) {
+    let rows = client
+        .query(
+            "SELECT SUSER_SNAME() AS principal, \
+             (SELECT authentication_type_desc FROM sys.database_principals \
+              WHERE name = USER_NAME()) AS auth_type",
+            &[],
+        )
+        .await
+        .expect("principal query failed");
+
+    let mut result = (String::new(), String::new());
+    for row_result in rows {
+        let row = row_result.expect("Row error");
+        result.0 = row.get::<String>(0).expect("principal");
+        result.1 = row
+            .get::<Option<String>>(1)
+            .ok()
+            .flatten()
+            .unwrap_or_default();
+    }
+    result
+}
+
+/// End-to-end FEDAUTH login with service principal credentials: the driver
+/// acquires the token from Entra ID and sends it in the LOGIN7 FEDAUTH
+/// feature extension (SecurityToken workflow).
+#[cfg(feature = "azure-identity")]
+#[tokio::test]
+#[ignore = "Requires Azure SQL Database and an Entra service principal"]
+async fn test_azure_ad_service_principal_login() {
+    use mssql_client::Client;
+
+    let (tenant_id, client_id, client_secret) =
+        get_azure_sp_env().expect("service principal env vars required");
+    let (host, database) = get_azure_host_db().expect("AZURE_SQL_HOST/DATABASE required");
+
+    let config = Config::new().host(host).database(database).credentials(
+        mssql_client::Credentials::AzureServicePrincipal {
+            tenant_id: tenant_id.into(),
+            client_id: client_id.clone().into(),
+            client_secret: client_secret.into(),
+        },
+    );
+
+    let mut client = Client::connect(config).await.expect("FEDAUTH login failed");
+
+    let (principal, auth_type) = current_principal(&mut client).await;
+    println!("service principal login: principal={principal}, auth_type={auth_type}");
+    // Azure SQL reports service principals as <client-id>@<tenant-id>.
+    assert!(
+        principal
+            .to_lowercase()
+            .starts_with(&client_id.to_lowercase()),
+        "SUSER_SNAME() ({principal}) must identify the service principal ({client_id})"
+    );
+    assert_eq!(
+        auth_type, "EXTERNAL",
+        "service principal must authenticate as an EXTERNAL (Entra) principal"
+    );
+
+    client.close().await.expect("Close failed");
+}
+
+/// Pre-acquired token path: acquire via mssql-auth's ServicePrincipalAuth,
+/// then log in with Credentials::AzureAccessToken (Tier 1 — what users with
+/// their own token plumbing do).
+#[cfg(feature = "azure-identity")]
+#[tokio::test]
+#[ignore = "Requires Azure SQL Database and an Entra service principal"]
+async fn test_azure_ad_access_token_login() {
+    use mssql_client::Client;
+
+    let (tenant_id, client_id, client_secret) =
+        get_azure_sp_env().expect("service principal env vars required");
+    let (host, database) = get_azure_host_db().expect("AZURE_SQL_HOST/DATABASE required");
+
+    let auth = mssql_auth::ServicePrincipalAuth::new(tenant_id, client_id, client_secret)
+        .expect("credential construction failed");
+    let token = auth.get_token().await.expect("token acquisition failed");
+
+    let config = Config::new()
+        .host(host)
+        .database(database)
+        .credentials(mssql_client::Credentials::azure_token(token));
+
+    let mut client = Client::connect(config).await.expect("FEDAUTH login failed");
+
+    let (principal, auth_type) = current_principal(&mut client).await;
+    println!("access token login: principal={principal}, auth_type={auth_type}");
+    assert_eq!(auth_type, "EXTERNAL");
+
+    client.close().await.expect("Close failed");
+}
+
+/// Connection-string path: Authentication=ActiveDirectoryServicePrincipal
+/// with User Id=<client-id>@<tenant-id> (ADR-002).
+#[cfg(feature = "azure-identity")]
+#[tokio::test]
+#[ignore = "Requires Azure SQL Database and an Entra service principal"]
+async fn test_azure_ad_connection_string_service_principal() {
+    use mssql_client::Client;
+
+    let (tenant_id, client_id, client_secret) =
+        get_azure_sp_env().expect("service principal env vars required");
+    let (host, database) = get_azure_host_db().expect("AZURE_SQL_HOST/DATABASE required");
+
+    let conn_str = format!(
+        "Server={host};Database={database};Encrypt=mandatory;\
+         Authentication=Active Directory Service Principal;\
+         User Id={client_id}@{tenant_id};Password={client_secret}"
+    );
+    let config = Config::from_connection_string(&conn_str).expect("Valid connection string");
+
+    let mut client = Client::connect(config).await.expect("FEDAUTH login failed");
+
+    let rows = client
+        .query("SELECT 1", &[])
+        .await
+        .expect("query after FEDAUTH login failed");
+    for row_result in rows {
+        let row = row_result.expect("Row error");
+        assert_eq!(row.get::<i32>(0).expect("value"), 1);
+    }
+
+    client.close().await.expect("Close failed");
+}

--- a/crates/mssql-client/tests/config.rs
+++ b/crates/mssql-client/tests/config.rs
@@ -2,7 +2,7 @@
 //!
 //! Tests edge cases that users commonly encounter with connection strings.
 
-#![allow(clippy::unwrap_used, clippy::expect_used)]
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 
 use mssql_client::Config;
 
@@ -327,33 +327,224 @@ fn test_repeated_keys_last_wins() {
 }
 
 // ============================================================================
-// FEDAUTH Credential Gate (issue #159)
+// FEDAUTH Credential Gate (issues #159, #155)
 // ============================================================================
+//
+// Azure AD credentials are wired into the login sequence (LOGIN7 FEDAUTH
+// feature extension, SecurityToken workflow — #155 Phase 1), so they are no
+// longer rejected wholesale. The gate now fails fast only on configurations
+// that cannot produce a valid (or safe) FEDAUTH login. All tests use an
+// unresolvable host: the error must arrive before any network I/O.
 
-/// Azure AD credentials are not yet wired into the login sequence (no LOGIN7
-/// FEDAUTH feature extension — see #155). connect() must fail fast with an
-/// actionable configuration error instead of sending an empty-credential
-/// login that the server rejects with an opaque 18456.
+/// A bearer token must never be sent over a plaintext connection.
 #[tokio::test]
-async fn test_azure_credentials_fail_fast_before_io() {
-    let config = Config::new()
-        .host("host-that-must-never-be-contacted.invalid")
-        .credentials(mssql_client::Credentials::AzureAccessToken {
-            token: "test-token".into(),
-        });
+async fn test_azure_credentials_rejected_with_no_tls() {
+    let config = Config::from_connection_string(
+        "Server=host-that-must-never-be-contacted.invalid;Encrypt=no_tls",
+    )
+    .unwrap()
+    .credentials(mssql_client::Credentials::AzureAccessToken {
+        token: "test-token".into(),
+    });
 
     let err = mssql_client::Client::connect(config)
         .await
-        .expect_err("Azure credentials must be rejected at connect time");
+        .expect_err("FEDAUTH over no_tls must be rejected at connect time");
 
     let msg = err.to_string();
     assert!(
         matches!(err, mssql_client::Error::Config(_)),
         "expected Error::Config, got: {msg}"
     );
-    assert!(msg.contains("FEDAUTH"), "error should name FEDAUTH: {msg}");
+    assert!(
+        msg.contains("no_tls") && msg.contains("plaintext"),
+        "error should explain the plaintext-token hazard: {msg}"
+    );
+}
+
+/// The FEDAUTH token length must not be zero (MS-TDS §2.2.6.4); an empty
+/// token is a configuration mistake caught before any network I/O.
+#[tokio::test]
+async fn test_azure_credentials_rejected_with_empty_token() {
+    let config = Config::new()
+        .host("host-that-must-never-be-contacted.invalid")
+        .credentials(mssql_client::Credentials::AzureAccessToken { token: "".into() });
+
+    let err = mssql_client::Client::connect(config)
+        .await
+        .expect_err("an empty Azure access token must be rejected");
+
+    let msg = err.to_string();
+    assert!(
+        matches!(err, mssql_client::Error::Config(_)),
+        "expected Error::Config, got: {msg}"
+    );
+    assert!(
+        msg.contains("empty"),
+        "error should say the token is empty: {msg}"
+    );
+}
+
+/// The FEDAUTH feature extension requires the LOGIN7 FeatureExt block, which
+/// exists only in TDS 7.4+.
+#[tokio::test]
+async fn test_azure_credentials_rejected_below_tds_74() {
+    let config = Config::from_connection_string(
+        "Server=host-that-must-never-be-contacted.invalid;TdsVersion=7.3",
+    )
+    .unwrap()
+    .credentials(mssql_client::Credentials::AzureAccessToken {
+        token: "test-token".into(),
+    });
+
+    let err = mssql_client::Client::connect(config)
+        .await
+        .expect_err("FEDAUTH below TDS 7.4 must be rejected");
+
+    let msg = err.to_string();
+    assert!(
+        matches!(err, mssql_client::Error::Config(_)),
+        "expected Error::Config, got: {msg}"
+    );
+    assert!(
+        msg.contains("7.4"),
+        "error should name the TDS floor: {msg}"
+    );
+}
+
+// ============================================================================
+// Authentication keyword (ADR-002, #155)
+// ============================================================================
+
+#[test]
+fn test_authentication_sql_password_keeps_sql_credentials() {
+    let config = Config::from_connection_string(
+        "Server=s;User Id=sa;Password=pw;Authentication=SqlPassword",
+    )
+    .unwrap();
+
+    match config.credentials {
+        mssql_client::Credentials::SqlServer { username, password } => {
+            assert_eq!(username.as_ref(), "sa");
+            assert_eq!(password.as_ref(), "pw");
+        }
+        other => panic!("expected SqlServer credentials, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_authentication_unsupported_ad_value_errors_with_tracking_issue() {
+    let err = Config::from_connection_string(
+        "Server=s;User Id=u;Password=p;Authentication=ActiveDirectoryPassword",
+    )
+    .expect_err("ActiveDirectoryPassword is not supported");
+
+    let msg = err.to_string();
+    assert!(msg.contains("not supported"), "{msg}");
     assert!(
         msg.contains("155"),
-        "error should link tracking issue: {msg}"
+        "should reference the tracking issue: {msg}"
     );
+}
+
+#[test]
+fn test_authentication_invalid_value_errors() {
+    let err = Config::from_connection_string("Server=s;Authentication=BogusMethod")
+        .expect_err("unknown Authentication value must error");
+
+    let msg = err.to_string();
+    assert!(msg.contains("invalid Authentication value"), "{msg}");
+}
+
+#[cfg(feature = "azure-identity")]
+mod authentication_azure_identity {
+    use super::*;
+
+    #[test]
+    fn test_service_principal_parses_client_and_tenant() {
+        // Spaced ADO.NET form, and Authentication placed BEFORE the
+        // credentials it reinterprets — order must not matter.
+        let config = Config::from_connection_string(
+            "Server=s;Authentication=Active Directory Service Principal;\
+             User Id=client-guid@tenant-guid;Password=s3cret",
+        )
+        .unwrap();
+
+        match config.credentials {
+            mssql_client::Credentials::AzureServicePrincipal {
+                tenant_id,
+                client_id,
+                client_secret,
+            } => {
+                assert_eq!(client_id.as_ref(), "client-guid");
+                assert_eq!(tenant_id.as_ref(), "tenant-guid");
+                assert_eq!(client_secret.as_ref(), "s3cret");
+            }
+            other => panic!("expected AzureServicePrincipal, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_service_principal_requires_tenant_in_user_id() {
+        let err = Config::from_connection_string(
+            "Server=s;User Id=client-only;Password=s3cret;\
+             Authentication=ActiveDirectoryServicePrincipal",
+        )
+        .expect_err("missing tenant id must error");
+
+        let msg = err.to_string();
+        assert!(
+            msg.contains("<client-id>@<tenant-id>"),
+            "error must show the expected User Id format: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_service_principal_requires_secret() {
+        let err = Config::from_connection_string(
+            "Server=s;User Id=c@t;Authentication=ActiveDirectoryServicePrincipal",
+        )
+        .expect_err("missing client secret must error");
+
+        assert!(err.to_string().contains("client secret"), "{err}");
+    }
+
+    #[test]
+    fn test_managed_identity_system_assigned() {
+        let config = Config::from_connection_string(
+            "Server=s;Authentication=ActiveDirectoryManagedIdentity",
+        )
+        .unwrap();
+
+        assert!(matches!(
+            config.credentials,
+            mssql_client::Credentials::AzureManagedIdentity { client_id: None }
+        ));
+    }
+
+    #[test]
+    fn test_managed_identity_user_assigned_via_user_id_and_msi_alias() {
+        let config = Config::from_connection_string(
+            "Server=s;User Id=uami-client-id;Authentication=Active Directory MSI",
+        )
+        .unwrap();
+
+        match config.credentials {
+            mssql_client::Credentials::AzureManagedIdentity {
+                client_id: Some(id),
+            } => assert_eq!(id.as_ref(), "uami-client-id"),
+            other => panic!("expected user-assigned AzureManagedIdentity, got {other:?}"),
+        }
+    }
+}
+
+#[cfg(any(feature = "integrated-auth", feature = "sspi-auth"))]
+#[test]
+fn test_authentication_conflicts_with_integrated_security() {
+    let err = Config::from_connection_string(
+        "Server=s;Integrated Security=true;Authentication=SqlPassword",
+    )
+    .expect_err("Authentication + Integrated Security must error");
+
+    assert!(err.to_string().contains("Integrated Security"), "{err}");
 }

--- a/crates/mssql-pool/Cargo.toml
+++ b/crates/mssql-pool/Cargo.toml
@@ -16,6 +16,9 @@ features = ["otel", "filestream"]
 
 [features]
 default = []
+# Azure Managed Identity / Service Principal token acquisition for Azure AD
+# (FEDAUTH) logins; each pooled connection acquires a fresh token.
+azure-identity = ["mssql-client/azure-identity"]
 # Integrated authentication (Kerberos/SPNEGO) - Linux/macOS
 integrated-auth = ["mssql-client/integrated-auth"]
 # Windows SSPI integrated authentication

--- a/crates/tds-protocol/src/prelogin.rs
+++ b/crates/tds-protocol/src/prelogin.rs
@@ -189,6 +189,19 @@ impl PreLogin {
         self
     }
 
+    /// Advertise federated authentication support (FEDAUTHREQUIRED option).
+    ///
+    /// When set on a client PreLogin, the encoded message carries the
+    /// FEDAUTHREQUIRED option with value 0x01. The server's response echoes
+    /// its own FEDAUTHREQUIRED value in [`PreLogin::fed_auth_required`]; per
+    /// MS-TDS §2.2.6.4 the LOGIN7 FEDAUTH feature extension's `fFedAuthEcho`
+    /// bit MUST mirror that response value.
+    #[must_use]
+    pub fn with_fed_auth_required(mut self, required: bool) -> Self {
+        self.fed_auth_required = required;
+        self
+    }
+
     /// Encode the pre-login message to bytes.
     #[must_use]
     pub fn encode(&self) -> Bytes {
@@ -454,6 +467,32 @@ mod tests {
         assert!(EncryptionLevel::On.is_required());
         assert!(!EncryptionLevel::Off.is_required());
         assert!(!EncryptionLevel::NotSupported.is_required());
+    }
+
+    /// FEDAUTHREQUIRED (option 0x06) must be emitted with payload 0x01 when
+    /// requested and omitted otherwise, and must survive an encode/decode
+    /// round trip — the login path reads the decoded flag back as the
+    /// LOGIN7 `fFedAuthEcho` source.
+    #[test]
+    fn test_prelogin_fed_auth_required_roundtrip() {
+        let without = PreLogin::new().encode();
+        let decoded = PreLogin::decode(without.as_ref()).unwrap();
+        assert!(
+            !decoded.fed_auth_required,
+            "FEDAUTHREQUIRED must default to absent/false"
+        );
+
+        let with = PreLogin::new().with_fed_auth_required(true).encode();
+        // Option header present: type 0x06 somewhere in the header section.
+        let header_end = with.iter().position(|&b| b == 0xFF).unwrap();
+        assert!(
+            with[..header_end]
+                .chunks(5)
+                .any(|opt| opt[0] == PreLoginOption::FedAuthRequired as u8),
+            "encoded PreLogin must contain a FEDAUTHREQUIRED option header"
+        );
+        let decoded = PreLogin::decode(with.as_ref()).unwrap();
+        assert!(decoded.fed_auth_required);
     }
 
     #[test]

--- a/crates/tds-protocol/src/token.rs
+++ b/crates/tds-protocol/src/token.rs
@@ -2146,10 +2146,11 @@ impl SspiToken {
 }
 
 impl FedAuthInfo {
-    /// `FedAuthInfoID` for the service principal name (MS-TDS §2.2.7.12).
-    const ID_SPN: u8 = 0x01;
-    /// `FedAuthInfoID` for the STS URL (MS-TDS §2.2.7.12).
-    const ID_STSURL: u8 = 0x02;
+    /// `FedAuthInfoID` for the STS URL (MS-TDS §2.2.7.12: %0x01 = STSURL).
+    const ID_STSURL: u8 = 0x01;
+    /// `FedAuthInfoID` for the service principal name (MS-TDS §2.2.7.12:
+    /// %0x02 = SPN).
+    const ID_SPN: u8 = 0x02;
     /// Size of one `FedAuthInfoOpt` header: ID (1) + DataLen (4) + DataOffset (4).
     const OPT_HEADER_LEN: usize = 9;
 
@@ -4072,8 +4073,10 @@ mod tests {
     fn test_fed_auth_info_decodes_spec_layout() {
         const STS: &str = "https://login.microsoftonline.com/common";
         const SPN: &str = "https://database.windows.net/";
-        // STSURL (0x02) listed first, SPN (0x01) second, like real servers.
-        let token = build_fed_auth_info_token(&[(0x02, STS), (0x01, SPN)]);
+        // STSURL (0x01) listed first, SPN (0x02) second. Real Azure servers
+        // list SPN first (see the captured-token test below); decoding must
+        // not depend on option order.
+        let token = build_fed_auth_info_token(&[(0x01, STS), (0x02, SPN)]);
 
         let mut parser = TokenParser::new(Bytes::from(token));
         let parsed = parser.next_token().unwrap().unwrap();
@@ -4091,8 +4094,8 @@ mod tests {
         // the tokens that follow FEDAUTHINFO during login. A DONE token
         // appended after it must survive.
         let mut stream = build_fed_auth_info_token(&[
-            (0x02, "https://sts.example/"),
-            (0x01, "https://db.example/"),
+            (0x01, "https://sts.example/"),
+            (0x02, "https://db.example/"),
         ]);
         stream.push(0xFD); // DONE
         stream.extend_from_slice(&0u16.to_le_bytes()); // status
@@ -4115,7 +4118,7 @@ mod tests {
     fn test_fed_auth_info_unknown_ids_ignored() {
         // Spec: unrecognized FedAuthInfoIDs must be ignored.
         let token =
-            build_fed_auth_info_token(&[(0x7F, "ignore-me"), (0x02, "https://sts.example/")]);
+            build_fed_auth_info_token(&[(0x7F, "ignore-me"), (0x01, "https://sts.example/")]);
         let mut parser = TokenParser::new(Bytes::from(token));
         let Some(Token::FedAuthInfo(info)) = parser.next_token().unwrap() else {
             panic!("expected FedAuthInfo");
@@ -4174,5 +4177,50 @@ mod tests {
         let mut skipper = TokenParser::new(Bytes::from(token));
         skipper.skip_token().unwrap();
         assert_eq!(skipper.position(), total, "skip consumption");
+    }
+
+    /// A FEDAUTHINFO token captured from a live Azure SQL Database login on
+    /// 2026-06-12 (the client declared the ADAL library in LOGIN7; the server
+    /// responded with this token). The tenant GUID inside the STS URL is
+    /// replaced with an all-zero GUID of identical length, so every offset
+    /// and length is byte-identical to the wire capture.
+    ///
+    /// This is the regression test deferred from PR #193, and it earns its
+    /// keep: the real token proves FedAuthInfoID 0x01 = STSURL and
+    /// 0x02 = SPN (Azure lists SPN first), which the synthetic tests
+    /// originally had swapped.
+    #[test]
+    fn test_fed_auth_info_captured_from_azure() {
+        const CAPTURED: &[u8] = &[
+            0xEE, 0xCC, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x02, 0x3A, 0x00, 0x00, 0x00,
+            0x16, 0x00, 0x00, 0x00, 0x01, 0x7C, 0x00, 0x00, 0x00, 0x50, 0x00, 0x00, 0x00, 0x68,
+            0x00, 0x74, 0x00, 0x74, 0x00, 0x70, 0x00, 0x73, 0x00, 0x3A, 0x00, 0x2F, 0x00, 0x2F,
+            0x00, 0x64, 0x00, 0x61, 0x00, 0x74, 0x00, 0x61, 0x00, 0x62, 0x00, 0x61, 0x00, 0x73,
+            0x00, 0x65, 0x00, 0x2E, 0x00, 0x77, 0x00, 0x69, 0x00, 0x6E, 0x00, 0x64, 0x00, 0x6F,
+            0x00, 0x77, 0x00, 0x73, 0x00, 0x2E, 0x00, 0x6E, 0x00, 0x65, 0x00, 0x74, 0x00, 0x2F,
+            0x00, 0x68, 0x00, 0x74, 0x00, 0x74, 0x00, 0x70, 0x00, 0x73, 0x00, 0x3A, 0x00, 0x2F,
+            0x00, 0x2F, 0x00, 0x6C, 0x00, 0x6F, 0x00, 0x67, 0x00, 0x69, 0x00, 0x6E, 0x00, 0x2E,
+            0x00, 0x77, 0x00, 0x69, 0x00, 0x6E, 0x00, 0x64, 0x00, 0x6F, 0x00, 0x77, 0x00, 0x73,
+            0x00, 0x2E, 0x00, 0x6E, 0x00, 0x65, 0x00, 0x74, 0x00, 0x2F, 0x00, 0x30, 0x00, 0x30,
+            0x00, 0x30, 0x00, 0x30, 0x00, 0x30, 0x00, 0x30, 0x00, 0x30, 0x00, 0x30, 0x00, 0x2D,
+            0x00, 0x30, 0x00, 0x30, 0x00, 0x30, 0x00, 0x30, 0x00, 0x2D, 0x00, 0x30, 0x00, 0x30,
+            0x00, 0x30, 0x00, 0x30, 0x00, 0x2D, 0x00, 0x30, 0x00, 0x30, 0x00, 0x30, 0x00, 0x30,
+            0x00, 0x2D, 0x00, 0x30, 0x00, 0x30, 0x00, 0x30, 0x00, 0x30, 0x00, 0x30, 0x00, 0x30,
+            0x00, 0x30, 0x00, 0x30, 0x00, 0x30, 0x00, 0x30, 0x00, 0x30, 0x00, 0x30, 0x00,
+        ];
+
+        let mut parser = TokenParser::new(Bytes::from_static(CAPTURED));
+        let Some(Token::FedAuthInfo(info)) = parser.next_token().unwrap() else {
+            panic!("expected FedAuthInfo");
+        };
+        assert_eq!(
+            info.sts_url,
+            "https://login.windows.net/00000000-0000-0000-0000-000000000000"
+        );
+        assert_eq!(info.spn, "https://database.windows.net/");
+        assert!(
+            parser.next_token().unwrap().is_none(),
+            "the captured token must be consumed exactly"
+        );
     }
 }

--- a/crates/tds-protocol/src/version.rs
+++ b/crates/tds-protocol/src/version.rs
@@ -105,6 +105,15 @@ impl TdsVersion {
         self.is_tds_8() || self.0 >= Self::V7_4.0
     }
 
+    /// Check if this version supports federated authentication (FEDAUTH).
+    ///
+    /// The FEDAUTH feature extension was introduced with the LOGIN7
+    /// FeatureExt block in TDS 7.4.
+    #[must_use]
+    pub const fn supports_fed_auth(self) -> bool {
+        self.is_tds_8() || self.0 >= Self::V7_4.0
+    }
+
     /// Check if this version supports column encryption (Always Encrypted).
     ///
     /// Column encryption was introduced in SQL Server 2016 (still TDS 7.4).


### PR DESCRIPTION
## Summary

Implements #155 **Phase 1**: Azure AD / Entra logins via the LOGIN7 FEDAUTH feature extension, SecurityToken workflow (token acquired client-side, no FEDAUTHINFO round-trip). `Credentials::AzureAccessToken`, `AzureManagedIdentity`, and `AzureServicePrincipal` now complete logins end-to-end — validated against live Azure SQL with an Entra service principal.

Along the way, the captured-token regression test deferred from PR #193 caught a real parser bug: the FEDAUTHINFO option IDs were swapped (spec says STSURL=0x01, SPN=0x02; we had them reversed, and the synthetic test vectors encoded the same swap). Fixed here with the captured Azure token as the regression test.

## Linked issues

Refs #155 (Phase 1 of 2 — the issue stays open for the ADAL/MSAL workflow and certificate credentials; see the scope comment on the issue)

## Type of change

- [x] New feature (non-breaking change that adds functionality)
- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Breaking change (fix or feature that changes existing API — see breaking-change checklist below)

## What's in here (by commit)

1. `fix(auth)!` — spec-correct FEDAUTH wire constants and SecurityToken feature data (`options = (library << 1) | fFedAuthEcho`, DWORD-LE token byte length, UTF-16LE token, no nonce). Verified against MS-TDS §2.2.6.4 and tiberius' `aad_token` encoding. Wire-exact tests.
2. `feat(protocol)` — `PreLogin::with_fed_auth_required` builder + `TdsVersion::supports_fed_auth`.
3. `feat(client)` — the wiring: token resolved once in `connect()` (reused across retries/redirects), PRELOGIN advertises FEDAUTHREQUIRED, LOGIN7 carries the FEDAUTH feature ext with the echo bit mirroring the server's PRELOGIN response; `azure-identity` feature passthrough; `Authentication=` connection-string keyword per ADR-002; the #159 gate narrowed to genuinely-unsupported/unsafe configs (cert auth, `no_tls`+FedAuth, empty token, TDS<7.4).
4. `fix(protocol)` — FEDAUTHINFO STSURL/SPN ID swap + captured-token regression test (tenant GUID sanitized to an equal-length zero GUID so all offsets stay byte-identical).
5. `test(client)` — three live Azure AD login tests (SP credentials, pre-acquired token, connection string).
6. `docs` — ADR-002/ARCHITECTURE 1.9.0, CLAUDE.md, LIMITATIONS.md, README; `azure-identity` forwarded through `mssql-driver-pool`.

## Test plan

- [x] `just ci-all` (fmt, clippy `--all-features --all-targets -D warnings`, nextest all-features, `cargo doc -D warnings`, examples) — green
- [x] `just typos` — green
- [x] `just doc-consistency` — all 25 checks green
- [x] Live ignored-only suite vs local SQL Server 2022 container: 243 passed
- [x] Live Azure SQL (Frankfurt): all three new FEDAUTH login tests green (`SUSER_SNAME()` = `<client-id>@<tenant-id>`, `authentication_type_desc = EXTERNAL`); SQL-auth Azure path re-verified
- [x] Feature combos: default, `--no-default-features`, `--no-default-features --features azure-identity`, `--all-features`, pool `--features azure-identity`

## Documentation updates

- [x] Rustdoc on all new/changed public items (`azure_ad` module rewrite, `config` keyword table, feature docs)
- [ ] CHANGELOG.md — intentionally untouched: this repo's `[Unreleased]` stays empty between releases and release-plz generates entries from the conventional commits (the `fix(auth)!` BREAKING CHANGE footer drives the bump); per CLAUDE.md the Release PR gets verified against `git log` before merge
- [x] README.md (`azure-identity` feature row)
- [x] Module rustdoc (config keyword reference, mssql-auth status tables)
- [x] ARCHITECTURE.md → 1.9.0 (ADR-002 Authentication keyword now supported)

### What breaks

`mssql-auth` only: `FedAuthLibrary` discriminants now match MS-TDS §2.2.6.4 (`SecurityToken` = 0x01, `Adal` = 0x02), the nonexistent `Msal` (= 0x03) variant and `AzureAdAuth::with_library` are removed, and `AzureAdAuth::build_feature_data` takes a `fed_auth_echo: bool` argument. The old values/layout never produced a working login (the #159 gate rejected all FEDAUTH credentials), so no working code can be depending on them.

### Migration guide

```rust
// Before (0.14.x): never worked end-to-end — connect() rejected FEDAUTH credentials
let auth = AzureAdAuth::with_token(token).with_library(FedAuthLibrary::Msal);
let data = auth.build_feature_data();

// After: echo comes from the server's PRELOGIN FEDAUTHREQUIRED response
let auth = AzureAdAuth::with_token(token);
let data = auth.build_feature_data(fed_auth_echo);
// or simply let the driver do it:
let client = Client::connect(config.credentials(Credentials::azure_token(token))).await?;
```

### Pre-1.0 policy check

- [x] Allowed under STABILITY.md § Pre-1.0 Releases (breaking → minor pre-1.0)
- [x] Breaking marker on the commit (`fix(auth)!` + `BREAKING CHANGE:` footer) so release-plz bumps minor
- [x] Not an MSRV change

## Security considerations

- Bearer tokens never go over plaintext: `Encrypt=no_tls` (and TLS-less builds) are rejected for FEDAUTH credentials before any I/O.
- Tokens are never logged; `Debug` impls stay redacted.
- The captured FEDAUTHINFO test data has the tenant GUID replaced with an all-zero GUID of identical length.
