### PR TITLE
ci: fail PRs whose commits hide breaking changes in ignored BREAKING: body lines

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -267,7 +267,8 @@ jobs:
       # it will not be semver-checked.
       #
       # KNOWN BLIND SPOT regardless of configuration: return-type changes
-      # pass undetected (reproduced in #202 on cargo-semver-checks 0.42), so
+      # pass undetected (reproduced in #202 on cargo-semver-checks 0.42 and
+      # verified again on 0.48.0), so
       # commit-message breaking markers and Release-PR verification
       # (CLAUDE.md) remain the primary guards.
       - name: Semver check (all features, crates without fragile dep trees)
@@ -512,3 +513,37 @@ jobs:
             exit 1
           fi
           echo "No AI-branding trailers in PR commit range."
+
+  commit-breaking-markers:
+    name: Breaking-Marker Hygiene
+    # PR-only: needs a base..head commit range. release-plz derives versions
+    # from commit messages, and a body line like "BREAKING: ..." is NOT a
+    # conventional-commits marker — it is silently ignored, which is exactly
+    # how the v0.13.2 under-bump happened (#202). Fail loudly instead.
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Reject BREAKING body lines that release-plz would ignore
+        run: |
+          base="${{ github.event.pull_request.base.sha }}"
+          head="${{ github.event.pull_request.head.sha }}"
+          bad=0
+          for sha in $(git rev-list --no-merges "$base..$head"); do
+            subject=$(git log -1 --format='%s' "$sha")
+            body=$(git log -1 --format='%b' "$sha")
+            # Real markers: `!` before the subject colon, or a
+            # `BREAKING CHANGE:` / `BREAKING-CHANGE:` footer line.
+            if grep -qE '^BREAKING' <<<"$body" \
+              && ! grep -qE '^BREAKING[- ]CHANGE:' <<<"$body" \
+              && ! grep -qE '^[a-z]+(\([^)]*\))?!:' <<<"$subject"; then
+              echo "::error::Commit $sha ('$subject') has a BREAKING body line that release-plz ignores. Use 'type!:' in the subject or a 'BREAKING CHANGE:' footer (or rephrase the line)."
+              bad=1
+            fi
+          done
+          if [ "$bad" -ne 0 ]; then
+            exit 1
+          fi
+          echo "No ignored BREAKING body lines in PR commit range."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -269,7 +269,7 @@ Rules for agents: **never run `cargo publish`, never create version tags, never 
 
 ### CI/CD workflows
 
-- `.github/workflows/ci.yml` — runs on pushes to main and PRs to main. Cross-platform matrix (Linux / macOS / Windows) plus hygiene (typos, unused deps), ADR-011 (no mod.rs), doc-consistency, and AI-branding gates. Has `workflow_dispatch` for manual reruns.
+- `.github/workflows/ci.yml` — runs on pushes to main and PRs to main. Cross-platform matrix (Linux / macOS / Windows) plus hygiene (typos, unused deps), ADR-011 (no mod.rs), doc-consistency, AI-branding, and breaking-marker gates. Has `workflow_dispatch` for manual reruns.
 - `.github/workflows/benchmarks.yml` — runs on pushes/PRs to main. Performance regression detection.
 - `.github/workflows/fuzz-nightly.yml` — daily scheduled long-budget fuzzing (5 min per target, all 12 targets); crash artifacts uploaded for triage. The per-PR `fuzz-smoke` job in ci.yml stays at 15 s/target.
 - `.github/workflows/security-audit.yml` — weekly schedule + dep-file changes on pushes/PRs to main.
@@ -313,9 +313,11 @@ Key differences for migrators:
 - Use conventional commits (feat, fix, refactor, docs, test)
 - **Breaking changes MUST carry the conventional marker**: `!` after the type
   (`fix(types)!:`) or a `BREAKING CHANGE:` footer. A `BREAKING:` line in the
-  commit body is **ignored** by release-plz — and the `cargo-semver-checks`
-  backstop has demonstrated blind spots: version 0.42 passes return-type
-  changes (`()` → `Result<...>`) without a finding, reproduced in #202.
+  commit body is **ignored** by release-plz — CI's Breaking-Marker Hygiene
+  job fails PRs containing one without a real marker — and the
+  `cargo-semver-checks` backstop has demonstrated blind spots: versions
+  through 0.48.0 pass return-type changes (`()` → `Result<...>`) without a
+  finding, verified in #202.
   Version correctness rests on the commit message. Precedent: the v0.13.2
   wrong bump, corrected by PR #201 before release.
 - Run `cargo fmt --all` **before** committing, not after the CI mirror flags
@@ -377,5 +379,5 @@ When making changes here, remember:
    - The ignored-only suite needs a local SQL Server 2022 container (`just sql-server-start`). `ci-all` and unit tests will NOT catch live-only failures (e.g. bulk temporal, decimal high-scale).
    - **Never open a PR stacked on another feature branch.** CI only triggers on PRs based on `main` (see convention 5), so a stacked PR gets zero CI until it is retargeted to `main`.
    - **Branch protection requires up-to-date-with-`main`.** Merge each green PR before opening the next to minimize the `update-branch` + CI-re-run churn that comes from keeping many PRs in flight at once.
-   - **The Semver Check CI job is advisory** (`continue-on-error: true`), but `gh pr checks --watch` still exits 1 when it fails — a red advisory check is not a blocked PR. Before concluding a PR is stuck, check the required checks / `mergeable` state (`gh api .../pulls/N -q .mergeable_state`). The job's known blind spots are tracked in #202.
+   - **The Semver Check CI job is advisory** (`continue-on-error: true`), but `gh pr checks --watch` still exits 1 when it fails — a red advisory check is not a blocked PR. Before concluding a PR is stuck, check the required checks / `mergeable` state (`gh api .../pulls/N -q .mergeable_state`). The job's known blind spots are documented in #202 (closed: the job stays advisory; return-type blindness verified through semver-checks 0.48.0). On a Release PR this job is always vacuously green — the already-bumped version makes every lint skip — so never read it as confirmation the API diff was checked.
    - The tests excluded from the pre-push command (`azure_sql`, `azure_identity_auth`, `cert_auth`) need a **live Azure SQL environment**, not the local container. One exists (credentials live outside the repo, e.g. a local gitignored `.tmp/azure.env`); run that suite when touching authentication or Azure-path code. The `azure_sql` suite includes live FEDAUTH service-principal login tests (`--features azure-identity`) reading `AZURE_SQL_TENANT_ID`/`AZURE_SQL_CLIENT_ID`/`AZURE_SQL_CLIENT_SECRET` with fallback to the `AZURE_`-prefixed names in the standing env file.


### PR DESCRIPTION
## Summary

Adds a PR-only **Breaking-Marker Hygiene** CI job that fails when any PR commit carries a body line starting with `BREAKING` that release-plz would silently ignore (no `!` marker in the subject and no `BREAKING CHANGE:` / `BREAKING-CHANGE:` footer). This is the exact human error behind the v0.13.2 under-bump. Also stamps the #202 closure findings into ci.yml's blind-spot comment and CLAUDE.md (return-type blindness verified through cargo-semver-checks 0.48.0; Release-PR semver green is vacuous because the bumped version skips every lint).

## Linked issues

Refs #202 (closed today with the advisory-forever decision; this PR is the hardening follow-up promised there).

## Type of change

- [x] Build / CI / tooling

## Test plan

- [x] `cargo test --workspace --all-features` passes (via `just ci-all` / nextest)
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` is clean
- [x] `cargo fmt --all --check` is clean
- [x] For behavioral changes: new or updated tests cover the change — the job's bash was falsification-tested locally against synthetic commits: a body-`BREAKING:`-without-marker commit is flagged (exit 1), while `type!:` subjects, `BREAKING CHANGE:` footers, and innocent commits pass (exit 0)
- [x] For integration-affecting changes: ran against live SQL Server — full ignored-only suite, 243/243 passed

Full pre-push gauntlet ran: `just ci-all && just typos` (typos-cli 1.42.3 confirmed installed) plus the live ignored-only nextest suite. This PR also live-validates the new job by running it on its own commit range (expect green: the commit body deliberately avoids line-start BREAKING).

## Documentation updates

- [x] CLAUDE.md: CI gate list, Commit Standards (blind spot now stamped 'through 0.48.0', new job referenced), and the Semver-Check-is-advisory bullet (Release-PR green is vacuous; #202 closed)
- [ ] CHANGELOG.md — not applicable: no crate files touched; release-plz owns changelog entries (precedent: #208/#209)
- [ ] README.md / rustdoc / ARCHITECTURE.md — not applicable (no public API or architectural change)

## Additional notes

Expected advisory red: the Semver Check's mssql-auth leg flags the intentional `fix(auth)!` break on every regular PR until the baseline moves to v0.15.0 (#211). Unrelated to this change and not blocking.

False-positive surface of the new check is narrow by design: only body lines *starting* with `BREAKING` trigger it, and the error message offers both the fix (real marker) and the escape (rephrase the line). It deliberately does not try to be a conventional-commits parser.