### PR TITLE
fix(client): split LOGIN7 at the 4096-byte TDS default for large FEDAUTH tokens

### DIFF
--- a/crates/mssql-client/src/client/connect.rs
+++ b/crates/mssql-client/src/client/connect.rs
@@ -11,7 +11,7 @@ use mssql_codec::connection::Connection;
 #[cfg(feature = "tls")]
 use mssql_tls::{TlsConfig, TlsConnector, TlsNegotiationMode};
 use tds_protocol::login7::Login7;
-use tds_protocol::packet::MAX_PACKET_SIZE;
+use tds_protocol::packet::DEFAULT_PACKET_SIZE;
 use tds_protocol::packet::PacketType;
 use tds_protocol::prelogin::{EncryptionLevel, PreLogin};
 use tds_protocol::token::{EnvChange, EnvChangeType, Token, TokenParser};
@@ -731,8 +731,12 @@ impl Client<Disconnected> {
                 let login = Self::build_login7(config, sspi_token, fed_auth);
                 let login_payload = login.encode();
 
-                // Create TDS packet manually for Login7
-                let max_packet = MAX_PACKET_SIZE;
+                // Create TDS packet manually for Login7. LOGIN7 is sent before
+                // packet-size negotiation completes, so it MUST be split at the
+                // 4096-byte TDS default — large FEDAUTH tokens (managed identity,
+                // AAD tokens with many claims) push LOGIN7 over 4096 and the
+                // server resets a single oversized packet.
+                let max_packet = DEFAULT_PACKET_SIZE;
                 let max_payload = max_packet - PACKET_HEADER_SIZE;
                 let chunks: Vec<_> = login_payload.chunks(max_payload).collect();
                 let total_chunks = chunks.len();
@@ -1252,7 +1256,10 @@ impl Client<Disconnected> {
         T: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
     {
         let payload = prelogin.encode();
-        let max_packet = MAX_PACKET_SIZE;
+        // PRELOGIN is tiny and never approaches the packet limit; keep the
+        // pre-fix behavior here (fully-qualified so the import stays lean for
+        // no-default-features builds, matching the SSPI send site below).
+        let max_packet = tds_protocol::packet::MAX_PACKET_SIZE;
 
         connection
             .send_message(PacketType::PreLogin, payload, max_packet)
@@ -1280,7 +1287,11 @@ impl Client<Disconnected> {
         T: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
     {
         let payload = login.encode();
-        let max_packet = MAX_PACKET_SIZE;
+        // LOGIN7 precedes packet-size negotiation, so it must be split at the
+        // 4096-byte TDS default, not MAX_PACKET_SIZE: a large FEDAUTH token
+        // makes LOGIN7 exceed 4096 and a single oversized packet is reset by
+        // the server (a managed-identity token is ~1900 chars → ~4100 bytes).
+        let max_packet = DEFAULT_PACKET_SIZE;
 
         connection
             .send_message(PacketType::Tds7Login, payload, max_packet)
@@ -1682,5 +1693,76 @@ mod fed_auth_login_tests {
         let sql = Config::new().credentials(mssql_auth::Credentials::sql_server("u", "p"));
         let prelogin = Client::<Disconnected>::build_prelogin(&sql, EncryptionLevel::On);
         assert!(!prelogin.fed_auth_required);
+    }
+
+    /// Regression: a LOGIN7 carrying a large FEDAUTH token exceeds the 4096-byte
+    /// TDS default packet size and MUST be split across multiple packets, each
+    /// within 4096 bytes. Before the fix, `send_login7` passed MAX_PACKET_SIZE
+    /// (65535) to `send_message` and emitted a single oversized packet, which
+    /// Azure SQL reset — a managed-identity token (~1900 chars → ~4100-byte
+    /// LOGIN7) tripped this every time, while smaller service-principal tokens
+    /// stayed under 4096 and masked the bug. Verified live against Azure SQL.
+    #[tokio::test]
+    async fn login7_large_fed_auth_token_is_split_at_default_packet_size() {
+        use tds_protocol::packet::PACKET_HEADER_SIZE;
+        use tokio::io::AsyncReadExt;
+
+        // ~2000-char token -> LOGIN7 comfortably over the 4096 default.
+        let token = "A".repeat(2000);
+        let config = azure_config(&token);
+        let login = Client::<Disconnected>::build_login7(
+            &config,
+            None,
+            Some(FedAuthLogin {
+                token: &token,
+                echo: true,
+            }),
+        );
+        let encoded = login.encode();
+        assert!(
+            encoded.len() > DEFAULT_PACKET_SIZE,
+            "precondition: LOGIN7 ({}) must exceed the default packet size to exercise splitting",
+            encoded.len()
+        );
+
+        // Capture exactly what send_login7 writes to the transport.
+        let (client_io, mut server_io) = tokio::io::duplex(64 * 1024);
+        let mut connection = Connection::new(client_io);
+        Client::<Disconnected>::send_login7(&mut connection, &login)
+            .await
+            .unwrap();
+        drop(connection); // close the write half so read_to_end observes EOF
+        let mut raw = Vec::new();
+        server_io.read_to_end(&mut raw).await.unwrap();
+
+        // Walk the TDS packets: 8-byte header, status at [1] (EOM = 0x01),
+        // total length (incl. header) at [2..4] big-endian.
+        let mut offset = 0;
+        let mut packets = 0;
+        let mut reassembled = Vec::new();
+        let mut saw_eom = false;
+        while offset < raw.len() {
+            let status = raw[offset + 1];
+            let len = u16::from_be_bytes([raw[offset + 2], raw[offset + 3]]) as usize;
+            assert!(
+                len <= DEFAULT_PACKET_SIZE,
+                "packet {packets} length {len} exceeds the 4096-byte default"
+            );
+            assert!(!saw_eom, "no packet may follow the END_OF_MESSAGE packet");
+            saw_eom = status & 0x01 == 0x01;
+            reassembled.extend_from_slice(&raw[offset + PACKET_HEADER_SIZE..offset + len]);
+            offset += len;
+            packets += 1;
+        }
+        assert!(
+            packets >= 2,
+            "an oversized LOGIN7 must span multiple packets, got {packets}"
+        );
+        assert!(saw_eom, "the final packet must carry END_OF_MESSAGE");
+        assert_eq!(
+            reassembled,
+            encoded.as_ref(),
+            "reassembled packet payloads must equal the LOGIN7 encoding"
+        );
     }
 }

--- a/crates/mssql-client/tests/azure_sql.rs
+++ b/crates/mssql-client/tests/azure_sql.rs
@@ -617,3 +617,35 @@ async fn test_azure_ad_connection_string_service_principal() {
 
     client.close().await.expect("Close failed");
 }
+
+/// End-to-end FEDAUTH login with a system-assigned managed identity.
+///
+/// Unlike the service-principal tests, this can only pass when run on Azure
+/// compute (VM/container) whose identity has been granted a contained DB user:
+/// the token is acquired from the local IMDS endpoint, which does not exist
+/// outside Azure. Run it from inside the target compute with `--ignored`.
+#[cfg(feature = "azure-identity")]
+#[tokio::test]
+#[ignore = "Requires running on Azure compute with a managed identity granted DB access"]
+async fn test_azure_ad_managed_identity_login() {
+    use mssql_client::Client;
+
+    let (host, database) = get_azure_host_db().expect("AZURE_SQL_HOST/DATABASE required");
+
+    // client_id = None selects the system-assigned identity.
+    let config = Config::new()
+        .host(host)
+        .database(database)
+        .credentials(mssql_client::Credentials::AzureManagedIdentity { client_id: None });
+
+    let mut client = Client::connect(config).await.expect("FEDAUTH login failed");
+
+    let (principal, auth_type) = current_principal(&mut client).await;
+    println!("managed identity login: principal={principal}, auth_type={auth_type}");
+    assert_eq!(
+        auth_type, "EXTERNAL",
+        "managed identity must authenticate as an EXTERNAL (Entra) principal"
+    );
+
+    client.close().await.expect("Close failed");
+}


### PR DESCRIPTION
## Summary

LOGIN7 is sent before TDS packet-size negotiation completes, so it must be split into 4096-byte packets (the TDS default). `send_login7` and the strict-mode manual send path passed `MAX_PACKET_SIZE` (65535) to `send_message`, so any LOGIN7 larger than 4096 bytes went out as a **single oversized packet and the server reset the connection** (`Codec(Io(ConnectionReset))`).

Managed-identity access tokens (~1900 chars → ~4100-byte LOGIN7) trip this on **every** login; service-principal tokens (~1300 chars) stay under 4096, which is exactly why #155 Phase 1's SP-only validation never caught it. AAD user tokens with many group claims hit the same wall. Correctness bug in shipped v0.15.0.

Fix: split LOGIN7 at `DEFAULT_PACKET_SIZE`. The `send_message` machinery already splits correctly (EOM on the last packet only) — both LOGIN7 paths were just handing it the wrong max.

## Linked issues

Refs #155 (managed-identity validation surfaced this).

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Test plan

- [x] **Live, end-to-end against Azure SQL**: ran `test_azure_ad_managed_identity_login` from an in-Azure VM with a system-assigned managed identity. Before the fix: `ConnectionReset`, 3/3. After: `auth_type=EXTERNAL`, login succeeds. (This is how the bug was found — Phase 1 MI was wired but never live-exercised.)
- [x] **Unit regression test** (`login7_large_fed_auth_token_is_split_at_default_packet_size`): builds a LOGIN7 with a ~2000-char FEDAUTH token, drives `send_login7` over an in-memory transport, and asserts the bytes split into multiple packets each ≤4096 with EOM only on the last and a byte-exact reassembly. Falsification-checked: reverting the constant turns it red.
- [x] Full local gauntlet on this branch: `just ci-all` (895 all-features tests, clippy `-D warnings`, fmt, doc) + `just typos` + the live ignored-only nextest suite (243/243) against the local SQL Server 2022 container.

## Documentation updates

- [ ] CHANGELOG.md — not hand-edited; release-plz owns the entry (the `fix(client):` commit drives the v0.15.1 patch bump).
- [ ] README / rustdoc / ARCHITECTURE — not applicable (no public API or architectural change).

## Additional notes

**Related latent item (not fixed here, deliberately):** the SSPI-response send (`connect.rs:1363`, `PacketType::Sspi`) is also pre-negotiation and uses `MAX_PACKET_SIZE`, so a large Kerberos PAC could hit the same single-oversized-packet reset (the `cbSSPILong` concern from #167). Left out of this hotfix because integrated-auth is currently untested end-to-end — it should be fixed and verified together when that path gets a test environment. The PRELOGIN send shares the constant too but PRELOGIN can't exceed 4096 in practice.