### PR TITLE
chore(ci): run feature-flag validation in the local pre-push gauntlet

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -366,15 +366,16 @@ When making changes here, remember:
 
 7. **Use issue/PR templates.** They ask the right questions. If you're opening an issue or PR, fill out the template completely — it helps the human reviewer and it helps future AI sessions parse the intent.
 
-8. **Run the full local CI mirror before every push; never trust a subset.** `cargo check` and unit tests do not catch the `-D warnings`-class failures CI rejects. This repo's gate is reproduced by `just ci-all` (fmt + clippy `--all-features --all-targets -D warnings` + nextest all-features + `cargo doc -D warnings` + examples). `ci-all` does NOT compose two gates CI enforces, so the real pre-push command is:
+8. **Run the full local CI mirror before every push; never trust a subset.** `cargo check` and unit tests do not catch the `-D warnings`-class failures CI rejects. This repo's gate is reproduced by `just ci-all` (fmt + clippy `--all-features --all-targets -D warnings` + nextest all-features + `cargo doc -D warnings` + examples). `ci-all` does NOT compose three gates CI enforces (spell-check, feature-flag validation, and the live suite), so the real pre-push command is:
 
    ```bash
-   just ci-all && just typos && \
+   just ci-all && just typos && just check-feature-flags && \
      MSSQL_HOST=localhost MSSQL_PORT=1433 MSSQL_USER=sa MSSQL_PASSWORD='YourStrong@Passw0rd' \
        cargo nextest run --all-features --run-ignored ignored-only --no-fail-fast \
        -E 'not (binary(azure_sql) or test(azure_identity_auth) or test(cert_auth))'
    ```
 
+   - `just check-feature-flags` runs CI's Feature Flag Validation job (`cargo xtask check-features` — cargo-hack `--each-feature` under `-D warnings`). `ci-all` only builds `--all-features`, so it misses the `-D warnings`-class failures (unused imports, dead code) that surface only in `--no-default-features` or single-feature builds — e.g. an item imported at module scope but used only behind a `cfg(feature = "…")` path. Needs cargo-hack (`just setup-tools`). This gate's absence let the v0.15.1 LOGIN7 fix reach CI red once (an import left used only in gated paths).
    - `just typos` runs the same bare `typos` (whole-tree, `typos.toml`-aware) the CI Hygiene job runs. It needs the tool installed at an MSRV-1.88-compatible version: `cargo install typos-cli --version 1.42.3 --locked` (newer requires rustc 1.91). The recipe still prints a WARN and passes if typos is absent, so confirm it is actually installed — a silent skip is how a spell-check failure reaches CI.
    - The ignored-only suite needs a local SQL Server 2022 container (`just sql-server-start`). `ci-all` and unit tests will NOT catch live-only failures (e.g. bulk temporal, decimal high-scale).
    - **Never open a PR stacked on another feature branch.** CI only triggers on PRs based on `main` (see convention 5), so a stacked PR gets zero CI until it is retargeted to `main`.

--- a/Justfile
+++ b/Justfile
@@ -596,36 +596,14 @@ check-feature-flags:
     #!/usr/bin/env bash
     set -euo pipefail
     printf '\n{{bold}}{{blue}}══════ Feature Flag Isolation Check ══════{{reset}}\n\n'
-
-    printf '{{cyan}}[INFO]{{reset}} Testing mssql-client features...\n'
-    {{cargo}} check -p mssql-client --no-default-features
-    {{cargo}} check -p mssql-client --features chrono
-    {{cargo}} check -p mssql-client --features uuid
-    {{cargo}} check -p mssql-client --features decimal
-    {{cargo}} check -p mssql-client --features json
-    {{cargo}} check -p mssql-client --features otel
-    {{cargo}} check -p mssql-client --features zeroize
-    {{cargo}} check -p mssql-client --features always-encrypted
-    {{cargo}} check -p mssql-client --features encoding
-
-    printf '{{cyan}}[INFO]{{reset}} Testing mssql-auth features...\n'
-    {{cargo}} check -p mssql-auth --no-default-features
-    {{cargo}} check -p mssql-auth --features azure-identity
-    if [[ "{{platform}}" == "linux" ]]; then
-        {{cargo}} check -p mssql-auth --features integrated-auth
-    fi
-    {{cargo}} check -p mssql-auth --features zeroize
-    {{cargo}} check -p mssql-auth --features always-encrypted
-    {{cargo}} check -p mssql-auth --features azure-keyvault
-
-    printf '{{cyan}}[INFO]{{reset}} Testing tds-protocol features...\n'
-    # Note: tds-protocol requires std OR alloc (heap allocation needed)
-    # Pure no_std without alloc is not supported - see compile_error in lib.rs
-    {{cargo}} check -p tds-protocol --no-default-features --features alloc
-    {{cargo}} check -p tds-protocol --features encoding
-    {{cargo}} check -p tds-protocol --features alloc
-
-    printf '{{green}}[OK]{{reset}}   All feature flags validated\n'
+    # Delegate to the exact xtask CI's "Feature Flag Validation" job runs
+    # (cargo-hack --each-feature), under -D warnings. Calling the xtask rather
+    # than a hand-listed cargo-check loop keeps this from drifting out of sync
+    # with CI, and -D warnings is what catches the unused-import / dead-code
+    # class of failures that only surfaces in --no-default-features or
+    # single-feature builds. Requires cargo-hack (`just setup-tools`).
+    export RUSTFLAGS="-D warnings"
+    {{cargo}} xtask check-features
 
 [group('test')]
 [doc("Test zeroize feature (security-critical memory wiping)")]


### PR DESCRIPTION
## Summary

CI's **Feature Flag Validation** job (`cargo xtask check-features` — cargo-hack `--each-feature` under `-D warnings`) was not part of the documented local CI mirror. `just ci-all` only builds `--all-features`, so `-D warnings`-class failures that surface only in `--no-default-features` or single-feature builds (unused imports, dead code behind `cfg(feature = "…")`) could pass locally yet fail CI. The v0.15.1 LOGIN7 fix (#213) tripped exactly this — an import left used only in feature-gated paths.

## Linked issues

None — process/tooling fix (follow-up to the #213 round-trip).

## Type of change

- [x] Build / CI / tooling

## Changes

- **CLAUDE.md** convention 8: add `just check-feature-flags` to the pre-push command (it omitted feature-flag validation entirely — now "three gates `ci-all` does not compose": spell-check, feature-flags, live suite); document the gate and the class it catches.
- **Justfile** `check-feature-flags`: delegate to `cargo xtask check-features` under `RUSTFLAGS=-D warnings` (the exact CI command) instead of a hand-listed `cargo check` loop. The old recipe was labeled "mirrors CI feature-flags job" but ran plain `cargo check` (no `-D warnings`), so it would have *passed* the very bug it claims to guard. Delegating to the xtask makes it a faithful mirror, removes drift (cargo-hack `--each-feature` auto-covers new features), and is a net subtraction.

## Test plan

- [x] Ran the **full updated pre-push gauntlet** end-to-end (dogfooding the new command): `just ci-all` (895 tests, clippy `-D warnings`, fmt, doc) + `just typos` + **`just check-feature-flags`** (now → `cargo xtask check-features`, "✅ All feature flag combinations compile") + the live ignored-only suite (243/243) against the local SQL Server 2022 container.
- No library code changed (docs + Justfile only).

## Documentation updates

- [x] CLAUDE.md updated (this PR *is* partly a docs change).
- [ ] CHANGELOG / README / rustdoc — not applicable (no public API or crate-code change; `chore(ci)` drives no version bump).