### PR TITLE
docs: correct Always Encrypted write-path and version validation claims

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1987,6 +1987,14 @@ gaps and planned work toward 1.0 are tracked in [LIMITATIONS.md](LIMITATIONS.md)
 | Azure SQL Database | Yes | All authentication methods |
 | Azure SQL Managed Instance | Yes | All authentication methods |
 
+**How each version is validated:** the **Supported** column reflects protocol
+capability, not test cadence. Only **SQL Server 2022 is CI-verified** — the
+integration suite runs against it on every change. SQL Server 2017/2019 are
+validated locally against Docker but not yet in CI ([#85](https://github.com/praxiomlabs/rust-mssql-driver/issues/85)).
+SQL Server 2008–2016 and Azure SQL are validated manually against real servers,
+not in CI. SQL Server 2025 is forward-looking — protocol-compatible but not yet
+validated.
+
 ### 8.3 Feature Flag Matrix
 
 Features are defined on `mssql-client` and forwarded to internal crates as needed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,7 @@ Refer to `ARCHITECTURE.md` (v1.9.0) for complete details. Critical decisions:
 | DBA Access | Cannot see plaintext | Can see plaintext |
 | Threat Model | Protects FROM server | Protects ON server |
 
-Always Encrypted is fully implemented via the `always-encrypted` feature with production-ready key providers:
+Always Encrypted **decryption (the read path)** is fully implemented via the `always-encrypted` feature with production-ready key providers. The encrypt-before-send **write path is not yet implemented** — only `NULL` can be written to encrypted columns (see the `mssql-client::encryption` module docs and LIMITATIONS.md). The key providers:
 1. **`InMemoryKeyStore`** - For development/testing
 2. **`AzureKeyVaultProvider`** - For Azure Key Vault (`azure-identity` feature)
 3. **`WindowsCertStoreProvider`** - For Windows Certificate Store (`windows-certstore` feature, Windows only)
@@ -291,8 +291,8 @@ tracing-opentelemetry = "0.33"
 ## Testing Strategy
 
 1. **Unit tests** - Protocol encoding/decoding, type conversions
-2. **Integration tests** - Against SQL Server (Docker)
-3. **Compatibility tests** - TDS 7.4, 8.0; SQL Server 2017-2022
+2. **Integration tests** - Against SQL Server 2022 in CI (Docker), on every change
+3. **Compatibility tests** - TDS 7.3–8.0. **Only SQL Server 2022 is CI-verified**; 2008–2019 are validated manually by the maintainer (not in CI). Multi-version CI for 2017/2019 is tracked in #85.
 4. **Fuzzing** - Protocol parser with cargo-fuzz
 
 ## Migration Guide (from Tiberius)

--- a/README.md
+++ b/README.md
@@ -191,6 +191,13 @@ cargo add mssql-auth --features sspi-auth
 | SQL Server 2022+ | TDS 7.4 or 8.0 strict mode |
 | Azure SQL Database / Managed Instance | Including automatic gateway redirects |
 
+**How each version is validated:** SQL Server 2022 is **CI-verified** — the
+integration suite runs against it on every change. SQL Server 2017/2019 are
+validated locally against Docker but **not yet in CI**
+([#85](https://github.com/praxiomlabs/rust-mssql-driver/issues/85)). SQL Server
+2008–2016 and Azure SQL are **validated manually** against real servers, not in
+CI.
+
 Known quirks: SQL Server 2014 RTM reports `ProductMajorVersion` as NULL (the
 driver falls back to parsing `ProductVersion`), and legacy servers negotiating
 TLS 1.0/1.1 fail with "TLS handshake eof" under `Encrypt=true` — use

--- a/STABILITY.md
+++ b/STABILITY.md
@@ -238,4 +238,11 @@ We take backwards compatibility seriously and will work to resolve issues prompt
 | Azure SQL Database | Full |
 | Azure SQL Managed Instance | Full |
 
+**How each version is validated:** "Full"/"Supported"/"Legacy" describe protocol
+capability, not test cadence. Only **SQL Server 2022 is CI-verified** — the
+integration suite runs against it on every change. SQL Server 2017/2019 are
+validated locally against Docker but not yet in CI
+([#85](https://github.com/praxiomlabs/rust-mssql-driver/issues/85)). SQL Server
+2008–2016 and Azure SQL are validated manually against real servers, not in CI.
+
 SQL Server compatibility is considered part of our stability guarantee. Dropping support for a SQL Server version requires a major version bump (post-1.0).


### PR DESCRIPTION
## Summary

Two claim-reality corrections from the test-coverage audit.

**Always Encrypted (CLAUDE.md):** CLAUDE.md claimed AE is "fully implemented". The parameter (write) path is **not** implemented — only `NULL` can be written to encrypted columns (per the `mssql-client::encryption` module docs). ARCHITECTURE.md (ADR) and README.md already state this correctly; this aligns CLAUDE.md with them. The decryption (read) path *is* fully implemented.

**SQL Server version validation:** no doc distinguished CI-verified from manually-validated versions. Reality: only **2022 is CI-verified** (the integration job); 2017/2019 are validated locally but not yet in CI ([#85](https://github.com/praxiomlabs/rust-mssql-driver/issues/85)); 2008–2016 and Azure SQL are validated manually. Adds a consistent validation note to the compatibility tables in README/ARCHITECTURE/STABILITY and corrects the CLAUDE.md Testing Strategy section. Per the audit, support claims are **not** downgraded — 2008–2016 were validated manually; the docs now say *how* each tier is validated.

## Type of change
- [x] Documentation only

## Test plan
- Full local gauntlet green (`ci-all` + `typos` + `check-feature-flags` + live suite 243/243)
- `scripts/check-doc-consistency.sh`: 25/25 checks pass

## Note
The 2017/2019 annotations will move to "CI-verified" when the multi-version CI matrix lands (Tier 2 / #85).