### PR TITLE
test: replace vacuous and silent-green tests with real assertions

### DIFF
--- a/crates/mssql-auth/src/cert_auth.rs
+++ b/crates/mssql-auth/src/cert_auth.rs
@@ -374,13 +374,6 @@ mod tests {
         assert!(!is_base64(&[0x00, 0x01, 0x02, 0x03])); // Binary data
     }
 
-    #[test]
-    fn test_debug_redacts_credentials() {
-        // We can't easily create a CertificateAuth without valid creds,
-        // but we can verify the Debug implementation is defined
-        // and would redact credentials
-    }
-
     #[tokio::test]
     #[ignore = "Requires Azure Service Principal with certificate"]
     async fn test_certificate_auth() {

--- a/crates/mssql-client/tests/integration.rs
+++ b/crates/mssql-client/tests/integration.rs
@@ -102,14 +102,16 @@ async fn test_connection_to_nonexistent_database() {
     );
 
     let config = Config::from_connection_string(&conn_str).expect("Config should parse");
-    let result = Client::connect(config).await;
 
-    // Should either fail or connect to master (depending on server config)
-    // Either way, the connection attempt should not panic
-    if let Err(e) = result {
-        // Expected: database doesn't exist error
-        println!("Expected error: {e:?}");
-    }
+    // Connecting with a nonexistent default database must fail at login with
+    // SQL Server error 4060 ("Cannot open database ... requested by the login").
+    let err = Client::connect(config)
+        .await
+        .expect_err("connecting to a nonexistent database must fail at login");
+    assert!(
+        err.is_server_error(4060),
+        "expected SQL Server error 4060 (cannot open database), got: {err:?}"
+    );
 }
 
 // =============================================================================
@@ -1627,30 +1629,36 @@ async fn test_connection_with_encryption_false() {
 
 #[tokio::test]
 #[ignore = "Requires SQL Server 2022+ with TDS 8.0 support"]
-async fn test_tds_8_strict_mode() {
-    // TDS 8.0 strict mode - TLS handshake before any TDS traffic
-    // This requires SQL Server 2022+ configured for strict encryption
-    let config = get_config_with_encrypt("strict").expect("SQL Server config required");
+async fn test_tds_8_strict_mode_rejects_untrusted_certificate() {
+    // TDS 8.0 strict mode does the TLS handshake before any TDS traffic and,
+    // unlike Encrypt=true, forbids TrustServerCertificate: the server cert MUST
+    // validate against a trusted root. The test/CI container presents a
+    // self-signed cert that is in no trust store, so a strict connection must be
+    // rejected with a TLS certificate-validation error — proving the strict path
+    // performs real validation rather than silently downgrading. (A *successful*
+    // strict handshake is covered at the wire level by the TDS 8.0 ALPN test in
+    // mssql-testing's mock_fidelity suite.)
+    let host = std::env::var("MSSQL_HOST").expect("SQL Server config required");
+    let port = std::env::var("MSSQL_PORT")
+        .ok()
+        .and_then(|p| p.parse::<u16>().ok())
+        .unwrap_or(1433);
+    let user = std::env::var("MSSQL_USER").unwrap_or_else(|_| "sa".into());
+    let password = std::env::var("MSSQL_PASSWORD").unwrap_or_else(|_| "MyStrongPassw0rd".into());
 
-    // Note: This test may fail if SQL Server is not configured for TDS 8.0
-    // TDS 8.0 requires server-side configuration changes
-    match Client::connect(config).await {
-        Ok(client) => {
-            // If connection succeeds, TDS 8.0 is working
-            let mut client = client;
-            let rows = client
-                .query("SELECT 'TDS 8.0' AS protocol_mode", &[])
-                .await
-                .expect("Query failed in TDS 8.0 mode");
-            assert_eq!(rows.len(), 1);
-            client.close().await.expect("Failed to close");
-        }
-        Err(e) => {
-            // Expected if server doesn't support TDS 8.0 strict mode
-            // The connection may fail with "strict encryption mode required"
-            println!("TDS 8.0 strict mode not available: {e:?}");
-        }
-    }
+    // Encrypt=strict WITHOUT TrustServerCertificate forces real cert validation.
+    let conn_str = format!(
+        "Server={host},{port};Database=master;User Id={user};Password={password};Encrypt=strict"
+    );
+    let config = Config::from_connection_string(&conn_str).expect("config parses");
+
+    let err = Client::connect(config)
+        .await
+        .expect_err("strict mode must reject the untrusted self-signed server certificate");
+    assert!(
+        err.is_tls_error(),
+        "strict mode against an untrusted cert must fail with a TLS error, got: {err:?}"
+    );
 }
 
 #[tokio::test]

--- a/crates/mssql-client/tests/stored_procedure.rs
+++ b/crates/mssql-client/tests/stored_procedure.rs
@@ -472,18 +472,6 @@ async fn test_call_nonexistent_procedure() {
     client.close().await.unwrap();
 }
 
-#[test]
-fn test_procedure_name_validation() {
-    // This doesn't need SQL Server — it's just validation
-    // We can't call client.procedure() without a connection, but we can
-    // test that validate_qualified_identifier works for procedure names.
-    // The validation is tested in validation.rs, but let's verify the
-    // error surfaces through the public API.
-
-    // Invalid names should be caught at compile time (before any network call)
-    // This is tested via the validation module's unit tests.
-}
-
 #[tokio::test]
 #[ignore = "Requires SQL Server"]
 async fn test_call_procedure_schema_qualified() {

--- a/crates/mssql-testing/tests/multi_subnet.rs
+++ b/crates/mssql-testing/tests/multi_subnet.rs
@@ -7,8 +7,9 @@
 //! port and counting how many TCP connections each listener receives when
 //! the client connects to `localhost`.
 //!
-//! These run in normal CI; no live SQL Server required. They self-skip when
-//! `localhost` does not resolve dual-stack or IPv6 loopback is unavailable.
+//! These run in normal CI; no live SQL Server required. They require a
+//! dual-stack loopback (`127.0.0.1` + `[::1]`) and fail loudly if the
+//! environment lacks one, rather than passing silently.
 
 #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 
@@ -50,10 +51,10 @@ fn localhost_config(port: u16, multi_subnet: bool) -> Config {
 /// address (the race), not walk them sequentially.
 #[tokio::test]
 async fn test_multi_subnet_failover_races_all_resolved_addresses() {
-    let Some((v4, v6)) = dual_stack_mocks().await else {
-        eprintln!("skipping: localhost is not dual-stack in this environment");
-        return;
-    };
+    let (v4, v6) = dual_stack_mocks().await.expect(
+        "this test requires a dual-stack loopback (127.0.0.1 + [::1]); the \
+         environment does not provide one",
+    );
 
     let client = Client::connect(localhost_config(v4.port(), true))
         .await
@@ -87,10 +88,10 @@ async fn test_multi_subnet_failover_races_all_resolved_addresses() {
 /// no speculative connections to the other stack.
 #[tokio::test]
 async fn test_sequential_connect_uses_single_address() {
-    let Some((v4, v6)) = dual_stack_mocks().await else {
-        eprintln!("skipping: localhost is not dual-stack in this environment");
-        return;
-    };
+    let (v4, v6) = dual_stack_mocks().await.expect(
+        "this test requires a dual-stack loopback (127.0.0.1 + [::1]); the \
+         environment does not provide one",
+    );
 
     let client = Client::connect(localhost_config(v4.port(), false))
         .await

--- a/crates/mssql-types/tests/type_conversions.rs
+++ b/crates/mssql-types/tests/type_conversions.rs
@@ -433,19 +433,24 @@ mod error_cases {
     }
 
     #[test]
-    fn test_int_to_string() {
-        // This should work as a string representation
+    fn test_int_to_string_fails() {
+        // `String::from_sql` accepts only `String`/`Xml` values; an integer is
+        // a type mismatch, not an implicit string coercion.
         let int_val = SqlValue::Int(42);
-        let _result: Result<String, _> = String::from_sql(&int_val);
-        // May succeed or fail depending on implementation
-        // Document expected behavior here
+        let result: Result<String, _> = String::from_sql(&int_val);
+        assert!(
+            result.is_err(),
+            "Int -> String must be a TypeMismatch, not a coercion"
+        );
     }
 
     #[test]
     fn test_binary_to_string_fails() {
         let bin_val = SqlValue::Binary(Bytes::from_static(&[0xFF, 0xFE]));
-        let _result: Result<String, _> = String::from_sql(&bin_val);
-        // Binary to string should fail (or return hex?)
-        // Document expected behavior
+        let result: Result<String, _> = String::from_sql(&bin_val);
+        assert!(
+            result.is_err(),
+            "Binary -> String must fail (no implicit hex/UTF-8 coercion)"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Eliminates the false-green test class the audit surfaced — tests that passed while asserting nothing or swallowing failures (the same shape as the LOGIN7 incident).

**Tightened (real assertions, verified live vs SQL Server 2022):**
- `test_tds_8_strict_mode` → `test_tds_8_strict_mode_rejects_untrusted_certificate`. The old test set `Encrypt=strict` + `TrustServerCertificate=true` (rejected at config time) and swallowed the error in an `Err=>println!` branch — it never reached the server. Now: `Encrypt=strict` *without* trust-cert must reject the container's self-signed cert with a TLS error (`is_tls_error`).
- `test_connection_to_nonexistent_database`: asserted only 'no panic'; now asserts the deterministic SQL Server error 4060 (`is_server_error(4060)`).

**Loud instead of silently green:**
- `multi_subnet`: both tests `return`ed silently (reporting green) when the loopback wasn't dual-stack. Now they fail loudly.

**Real assertions on discard-result unit tests:**
- `type_conversions`: `test_int_to_string`→`test_int_to_string_fails` and `test_binary_to_string_fails` now assert `is_err()` (String::from_sql rejects Int/Binary).

**Removed two empty stubs (asserted nothing):**
- stored_procedure `test_procedure_name_validation` — `validate_qualified_identifier` is already covered in validation.rs (incl. injection).
- cert_auth `test_debug_redacts_credentials` — the Debug impl hardcodes `[REDACTED]`; constructing a `CertificateAuth` needs a real cert, so there's nothing to meaningfully unit-test without new infra.

## Type of change
- [x] Test-only change

## Test plan
- Full local gauntlet green (`ci-all` + `typos` + `check-feature-flags` + live suite 243/243).
- The two tightened live tests verified to pass for the *right* reason: `is_tls_error()`/`is_server_error(4060)` are clean variant matches (error.rs:408/429), and the strict+trustcert path produces a *Config* error (not TLS), so the assertions discriminate.

## Watch point
The `multi_subnet` change makes a missing dual-stack loopback a hard failure rather than a silent pass. It runs on all three OS legs; it passes locally on Linux (dual-stack present). If a Windows/macOS runner lacks dual-stack loopback, that leg will now fail **loudly** — which is the intended signal (it was previously passing without testing anything). I'll address per-platform if CI surfaces it.