### PR TITLE
test: add type-state compile-fail tests for the Client API

### DIFF
--- a/crates/mssql-client/tests/compile-fail-state/begin_transaction_on_disconnected.rs
+++ b/crates/mssql-client/tests/compile-fail-state/begin_transaction_on_disconnected.rs
@@ -1,0 +1,9 @@
+//! `begin_transaction` is only available on `Client<Ready>`: a disconnected
+//! client has no session to start a transaction on.
+use mssql_client::{Client, Disconnected};
+
+fn use_begin(client: Client<Disconnected>) {
+    let _ = client.begin_transaction();
+}
+
+fn main() {}

--- a/crates/mssql-client/tests/compile-fail-state/begin_transaction_on_disconnected.stderr
+++ b/crates/mssql-client/tests/compile-fail-state/begin_transaction_on_disconnected.stderr
@@ -1,0 +1,8 @@
+error[E0599]: no method named `begin_transaction` found for struct `Client<mssql_client::Disconnected>` in the current scope
+ --> tests/compile-fail-state/begin_transaction_on_disconnected.rs:6:20
+  |
+6 |     let _ = client.begin_transaction();
+  |                    ^^^^^^^^^^^^^^^^^ method not found in `Client<Disconnected>`
+  |
+  = note: the method was found for
+          - `Client<mssql_client::Ready>`

--- a/crates/mssql-client/tests/compile-fail-state/commit_on_ready.rs
+++ b/crates/mssql-client/tests/compile-fail-state/commit_on_ready.rs
@@ -1,0 +1,9 @@
+//! `commit` is only available on `Client<InTransaction>`: a ready (not
+//! in-transaction) client cannot commit.
+use mssql_client::{Client, Ready};
+
+fn use_commit(client: Client<Ready>) {
+    let _ = client.commit();
+}
+
+fn main() {}

--- a/crates/mssql-client/tests/compile-fail-state/commit_on_ready.stderr
+++ b/crates/mssql-client/tests/compile-fail-state/commit_on_ready.stderr
@@ -1,0 +1,8 @@
+error[E0599]: no method named `commit` found for struct `Client<mssql_client::Ready>` in the current scope
+ --> tests/compile-fail-state/commit_on_ready.rs:6:20
+  |
+6 |     let _ = client.commit();
+  |                    ^^^^^^ method not found in `Client<Ready>`
+  |
+  = note: the method was found for
+          - `Client<InTransaction>`

--- a/crates/mssql-client/tests/compile-fail-state/query_on_disconnected.rs
+++ b/crates/mssql-client/tests/compile-fail-state/query_on_disconnected.rs
@@ -1,0 +1,9 @@
+//! `query` is only available on `Client<Ready>` / `Client<InTransaction>`,
+//! never on a disconnected client.
+use mssql_client::{Client, Disconnected};
+
+fn use_query(client: &mut Client<Disconnected>) {
+    let _ = client.query("SELECT 1", &[]);
+}
+
+fn main() {}

--- a/crates/mssql-client/tests/compile-fail-state/query_on_disconnected.stderr
+++ b/crates/mssql-client/tests/compile-fail-state/query_on_disconnected.stderr
@@ -1,0 +1,5 @@
+error[E0599]: no method named `query` found for mutable reference `&mut Client<mssql_client::Disconnected>` in the current scope
+ --> tests/compile-fail-state/query_on_disconnected.rs:6:20
+  |
+6 |     let _ = client.query("SELECT 1", &[]);
+  |                    ^^^^^ method not found in `&mut Client<Disconnected>`

--- a/crates/mssql-client/tests/type_state_compile_tests.rs
+++ b/crates/mssql-client/tests/type_state_compile_tests.rs
@@ -1,0 +1,13 @@
+//! Compile-fail tests for the type-state Client API.
+//!
+//! The driver encodes the connection lifecycle in the type system
+//! (`Client<Disconnected>` / `Client<Ready>` / `Client<InTransaction>`), so a
+//! state-specific method called in the wrong state must fail to compile. These
+//! trybuild cases pin that guarantee — the marquee compile-time-safety claim
+//! was previously never tested.
+
+#[test]
+fn type_state_compile_fail() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/compile-fail-state/*.rs");
+}


### PR DESCRIPTION
## Summary
The type-state lifecycle (`Client<Disconnected/Ready/InTransaction>`) is the driver's marquee compile-time-safety claim, but nothing tested that a state-specific method in the wrong state fails to compile. Adds a trybuild suite pinning three invalid transitions:
- `query()` on `Client<Disconnected>`
- `commit()` on `Client<Ready>` (not in a transaction)
- `begin_transaction()` on `Client<Disconnected>`

Each fixture yields a precise `E0599: no method named ... found for Client<State>` (rustc even notes the method exists on the correct state). If a method ever leaked into the wrong state, the fixture would compile and trybuild would fail — so this genuinely guards the guarantee.

## Type of change
- [x] Test-only change

## Test plan
- Full gauntlet green (`ci-all` + `typos` + `check-feature-flags` + live 243/243); `type_state_compile_fail` runs under nextest and passes against the committed `.stderr`.
- `.stderr` snapshots generated under the repo-pinned rustc 1.88 (matches CI), and are clean (single E0599 each, no stray warnings).