### PR TITLE
test: cover previously-untested units (uuid decode, json, derive, zeroize)

### DIFF
--- a/crates/mssql-auth/src/credentials.rs
+++ b/crates/mssql-auth/src/credentials.rs
@@ -520,6 +520,23 @@ mod tests {
         }
 
         #[test]
+        fn test_secret_string_zeroize_clears_value() {
+            let mut secret = SecretString::new("super-secret");
+            secret.zeroize();
+            // `zeroize()` is what `ZeroizeOnDrop` runs on drop; it must scrub
+            // the secret. Reading the buffer after the value is dropped would
+            // be UB, so this asserts the scrubbing operation directly.
+            assert!(secret.expose_secret().is_empty());
+        }
+
+        #[test]
+        fn test_secret_string_is_zeroize_on_drop() {
+            // Compile-time guarantee that `SecretString` is scrubbed on drop.
+            fn assert_zeroize_on_drop<T: ZeroizeOnDrop>() {}
+            assert_zeroize_on_drop::<SecretString>();
+        }
+
+        #[test]
         fn test_secret_string_from_string() {
             let secret: SecretString = String::from("password").into();
             assert_eq!(secret.expose_secret(), "password");

--- a/crates/mssql-client/tests/derive_runtime.rs
+++ b/crates/mssql-client/tests/derive_runtime.rs
@@ -1,0 +1,54 @@
+//! Runtime tests for the `#[derive(FromRow)]` and `#[derive(ToParams)]` macros.
+//!
+//! The compile-fail suite proves the macros reject bad input, but nothing
+//! exercised the *generated* code. These build a struct via each derive and run
+//! the generated `from_row` / `to_params` against real values.
+#![allow(clippy::unwrap_used)]
+
+use mssql_client::{Column, FromRow, Row, SqlValue, ToParams};
+
+#[derive(FromRow)]
+struct User {
+    id: i32,
+    name: String,
+}
+
+#[test]
+fn derived_from_row_maps_columns_by_name() {
+    let columns = vec![
+        Column::new("id", 0, "INT".to_string()),
+        Column::new("name", 1, "NVARCHAR".to_string()),
+    ];
+    let row = Row::from_values(
+        columns,
+        vec![SqlValue::Int(7), SqlValue::String("Ada".to_string())],
+    );
+
+    let user = User::from_row(&row).unwrap();
+    assert_eq!(user.id, 7);
+    assert_eq!(user.name, "Ada");
+}
+
+#[derive(ToParams)]
+struct Filter {
+    min_id: i32,
+    name: String,
+}
+
+#[test]
+fn derived_to_params_emits_named_params() {
+    let f = Filter {
+        min_id: 10,
+        name: "Ada".to_string(),
+    };
+
+    let params = f.to_params().unwrap();
+
+    // One NamedParam per field, named after the field (no @ prefix), with the
+    // field's value converted to a SqlValue.
+    assert_eq!(params.len(), 2);
+    assert_eq!(params[0].name, "min_id");
+    assert_eq!(params[0].value, SqlValue::Int(10));
+    assert_eq!(params[1].name, "name");
+    assert_eq!(params[1].value, SqlValue::String("Ada".to_string()));
+}

--- a/crates/mssql-types/src/decode.rs
+++ b/crates/mssql-types/src/decode.rs
@@ -1085,6 +1085,29 @@ mod tests {
         assert_eq!(result, SqlValue::Int(42));
     }
 
+    /// The mixed-endian GUID encoding must round-trip: encode then decode
+    /// returns the original UUID. A UUID with all-distinct bytes catches an
+    /// asymmetric swap. `decode_guid` previously had no unit coverage — only
+    /// live round-trips exercised it.
+    #[cfg(feature = "uuid")]
+    #[test]
+    fn test_guid_encode_decode_roundtrip() {
+        use crate::encode::encode_uuid;
+        use bytes::BufMut;
+
+        let original = uuid::Uuid::parse_str("00112233-4455-6677-8899-aabbccddeeff").unwrap();
+        let mut encoded = bytes::BytesMut::new();
+        encode_uuid(original, &mut encoded);
+        assert_eq!(encoded.len(), 16);
+
+        // `decode_guid` expects a length-prefixed buffer (1-byte length = 16).
+        let mut framed = bytes::BytesMut::new();
+        framed.put_u8(16);
+        framed.put_slice(&encoded);
+        let decoded = decode_guid(&mut framed.freeze()).unwrap();
+        assert_eq!(decoded, SqlValue::Uuid(original));
+    }
+
     #[cfg(feature = "chrono")]
     #[test]
     fn hostile_datetime_days_overflow_is_error_not_panic() {

--- a/crates/mssql-types/src/encode.rs
+++ b/crates/mssql-types/src/encode.rs
@@ -474,6 +474,21 @@ pub fn encode_datetimeoffset(
 mod tests {
     use super::*;
 
+    /// JSON values are sent on the wire as NVARCHAR — the serialized JSON
+    /// string encoded as UTF-16LE. This encode path had no asserting test.
+    #[cfg(feature = "json")]
+    #[test]
+    fn test_json_encodes_as_nvarchar() {
+        let value = serde_json::json!({"name": "Ada", "id": 42});
+
+        let mut got = BytesMut::new();
+        SqlValue::Json(value.clone()).encode(&mut got).unwrap();
+
+        let mut want = BytesMut::new();
+        encode_utf16_string(&value.to_string(), &mut want);
+        assert_eq!(got, want);
+    }
+
     /// Issue #152 regression: the DATETIMEOFFSET wire date/time portion is
     /// the UTC instant per MS-TDS §2.2.5.5.1.9. 12:00 at +02:00 must encode
     /// a 10:00 time portion. The previous encoder wrote the local wall-clock,


### PR DESCRIPTION
## Summary
Behavioral unit tests for paths the audit flagged as having no asserting coverage:
- **uuid**: encode→decode round-trip proves the mixed-endian GUID swap is symmetric (an all-distinct-bytes UUID catches asymmetry). `decode_guid` had only live coverage.
- **json**: `SqlValue::Json` encodes as NVARCHAR (serialized JSON string in UTF-16LE) — previously zero tests.
- **derive runtime**: actually run generated `FromRow`/`ToParams` code (the existing FromRow test used a hand-written impl, so macro output was never executed).
- **zeroize**: `SecretString::zeroize()` scrubs the secret + `SecretString: ZeroizeOnDrop` (the scrub-on-drop guarantee). A true post-drop memory read would be UB, so the scrubbing operation is asserted directly — noted honestly in the test.

This is PR-A of Tier 2 #6. PR-B (SQL Browser UDP `resolve_instance` with a mock responder) follows separately — it needs a small `pub(crate)` testability seam.

## Type of change
- [x] Test-only change

## Test plan
- Full gauntlet green (`ci-all` + `typos` + `check-feature-flags` + live 243/243); the 6 new tests verified to pass for the right reason (each discriminates against the behavior it asserts).