### PR TITLE
feat(encryption): encrypt parameters end-to-end (AE write path 3a.4)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,7 @@ Refer to `ARCHITECTURE.md` (v1.9.0) for complete details. Critical decisions:
 | DBA Access | Cannot see plaintext | Can see plaintext |
 | Threat Model | Protects FROM server | Protects ON server |
 
-Always Encrypted **decryption (the read path)** is fully implemented via the `always-encrypted` feature with production-ready key providers. The encrypt-before-send **write path is not yet implemented** — only `NULL` can be written to encrypted columns (see the `mssql-client::encryption` module docs and LIMITATIONS.md). The key providers:
+Always Encrypted **decryption (the read path)** is fully implemented via the `always-encrypted` feature with production-ready key providers. **Parameter (write) encryption is implemented for `int`/`nvarchar`/`varbinary`**: with `Column Encryption Setting=Enabled`, parameterized queries and `execute` describe their parameters via `sp_describe_parameter_encryption`, encrypt those bound to encrypted columns client-side, and send encrypted RPC parameters (deterministic and randomized). Other column types are not yet supported and error rather than sending plaintext (see the `mssql-client::encryption` module docs and LIMITATIONS.md). The key providers:
 1. **`InMemoryKeyStore`** - For development/testing
 2. **`AzureKeyVaultProvider`** - For Azure Key Vault (`azure-identity` feature)
 3. **`WindowsCertStoreProvider`** - For Windows Certificate Store (`windows-certstore` feature, Windows only)

--- a/LIMITATIONS.md
+++ b/LIMITATIONS.md
@@ -220,24 +220,29 @@ within range, to `FLOAT` if approximate semantics are acceptable, or to
 
 ### Always Encrypted Parameter Encryption (Write Path)
 
-**Status:** Read path fully supported; write path supports `NULL` only
+**Status:** Read path fully supported; parameter (write) encryption supported
+for `int`, `nvarchar`, and `varbinary`
 
 Transparent decryption of encrypted columns works end-to-end: login-time
 feature negotiation, `ColMetaData` / `CekTable` / `CryptoMetadata` parsing,
 async CEK resolution through key store providers, and AEAD_AES_256_CBC_HMAC_SHA256
-decryption in the row hot path. Writing `NULL` into a nullable encrypted
-column also works.
+decryption in the row hot path.
 
-What is not yet implemented is the *encrypt-before-send* logic for
-non-`NULL` parameters bound to encrypted columns. Sending plaintext will
-be rejected by SQL Server with *"Operand type clash: varchar is
-incompatible with varchar(n) encrypted with (…)."*
+Parameter (write) encryption is implemented for `int`, `nvarchar`, and
+`varbinary`. With `Column Encryption Setting=Enabled`, a parameterized query or
+`execute` automatically describes its parameters
+(`sp_describe_parameter_encryption`), encrypts those bound to encrypted columns
+client-side, and sends them as encrypted RPC parameters. Both deterministic and
+randomized encryption are supported.
 
-**Workaround:** Pre-encrypt values out-of-band (e.g., via .NET SqlClient
-or `sqlcmd` with Always Encrypted enabled) and insert the resulting
-ciphertext as a `VARBINARY` parameter bound to the base column type.
-Reads are unaffected — queries with `Column Encryption Setting=Enabled`
-decrypt transparently.
+Not yet implemented:
+- Parameter encryption for other column types (e.g. `bigint`, `decimal`,
+  `datetime2`, `uniqueidentifier`): these return a clear "not yet implemented"
+  error rather than sending plaintext.
+- Secure enclave operations.
+- Caching of `sp_describe_parameter_encryption`: each parameterized statement
+  currently incurs one extra describe round-trip when Always Encrypted is
+  enabled (matching the uncached behaviour of other clients).
 
 See the [`mssql-client` `encryption` module docs](https://docs.rs/mssql-client/latest/mssql_client/encryption/) for
 the full rationale.

--- a/crates/mssql-client/src/client.rs
+++ b/crates/mssql-client/src/client.rs
@@ -417,6 +417,116 @@ impl<S: ConnectionState> Client<S> {
         crate::ParameterEncryptionInfo::from_describe_result_sets(&mut result.result_sets)
     }
 
+    /// Build the `sp_executesql` request for a parameterized statement.
+    ///
+    /// When the connection has Always Encrypted enabled, parameters the server
+    /// reports as encrypted are encrypted client-side first (an extra
+    /// `sp_describe_parameter_encryption` round-trip). Otherwise this is the
+    /// plain parameter conversion.
+    pub(crate) async fn build_parameterized_rpc(
+        &mut self,
+        sql: &str,
+        params: &[&(dyn crate::ToSql + Sync)],
+    ) -> Result<RpcRequest> {
+        #[cfg(feature = "always-encrypted")]
+        if self.encryption_context.is_some() {
+            return self.build_encrypted_sql_rpc(sql, params).await;
+        }
+        let rpc_params =
+            Self::convert_params(params, self.send_unicode(), self.server_collation())?;
+        Ok(RpcRequest::execute_sql(sql, rpc_params))
+    }
+
+    /// Encrypt the Always Encrypted parameters of a statement, then build its
+    /// `sp_executesql` request.
+    ///
+    /// Asks the server which parameters are encrypted
+    /// ([`describe_parameter_encryption`](Self::describe_parameter_encryption)),
+    /// then for each one normalizes the value, resolves its column encryption
+    /// key, encrypts, and emits an encrypted RPC parameter. Parameters the
+    /// server reports as plaintext are sent unchanged.
+    #[cfg(feature = "always-encrypted")]
+    async fn build_encrypted_sql_rpc(
+        &mut self,
+        sql: &str,
+        params: &[&(dyn crate::ToSql + Sync)],
+    ) -> Result<RpcRequest> {
+        use tds_protocol::rpc::RpcParam;
+
+        let Some(ctx) = self.encryption_context.clone() else {
+            let rpc_params =
+                Self::convert_params(params, self.send_unicode(), self.server_collation())?;
+            return Ok(RpcRequest::execute_sql(sql, rpc_params));
+        };
+
+        // Resolve each parameter's value once (AE normalization needs the typed
+        // value, not the wire encoding) and build the plaintext RPC params.
+        let send_unicode = self.send_unicode();
+        let collation = self.server_collation().cloned();
+        let mut values: Vec<mssql_types::SqlValue> = Vec::with_capacity(params.len());
+        let mut plaintext: Vec<RpcParam> = Vec::with_capacity(params.len());
+        for (i, p) in params.iter().enumerate() {
+            let name = format!("@p{}", i + 1);
+            let value = p.to_sql()?;
+            plaintext.push(Self::sql_value_to_rpc_param(
+                &name,
+                &value,
+                send_unicode,
+                collation.as_ref(),
+            )?);
+            values.push(value);
+        }
+
+        if plaintext.is_empty() {
+            return Ok(RpcRequest::execute_sql(sql, plaintext));
+        }
+
+        // Ask the server which parameters need encryption.
+        let declarations = RpcRequest::build_param_declarations(&plaintext);
+        let info = self
+            .describe_parameter_encryption(sql, &declarations)
+            .await?;
+        if info.parameters.is_empty() {
+            return Ok(RpcRequest::execute_sql(sql, plaintext));
+        }
+
+        // Encrypt the flagged parameters; pass the rest through untouched.
+        let mut final_params: Vec<RpcParam> = Vec::with_capacity(plaintext.len());
+        for (value, param) in values.into_iter().zip(plaintext) {
+            let Some(crypto) = info.get_parameter(&param.name) else {
+                final_params.push(param);
+                continue;
+            };
+            let entry = info.cek_table.get(crypto.cek_ordinal).ok_or_else(|| {
+                Error::Protocol(format!(
+                    "encrypted parameter {} references missing CEK ordinal {}",
+                    param.name, crypto.cek_ordinal
+                ))
+            })?;
+            let normalized = crate::encryption::normalize_for_encryption(&value)?;
+            let ciphertext = ctx
+                .encrypt_value(&normalized, entry, crypto.encryption_type)
+                .await?;
+            let metadata = tds_protocol::rpc::EncryptedParamMetadata {
+                base_type_info: param.type_info.clone(),
+                algorithm_id: crypto.algorithm_id,
+                encryption_type: crypto.encryption_type,
+                database_id: entry.database_id,
+                cek_id: entry.cek_id,
+                cek_version: entry.cek_version,
+                cek_md_version: entry.cek_md_version,
+                normalization_rule_version: crypto.normalization_rule_version,
+            };
+            final_params.push(RpcParam::encrypted(
+                param.name,
+                bytes::Bytes::from(ciphertext),
+                metadata,
+            ));
+        }
+
+        Ok(RpcRequest::execute_sql(sql, final_params))
+    }
+
     /// Start a bulk insert operation for the specified table.
     ///
     /// Sends the `INSERT BULK` statement to the server and returns a
@@ -869,10 +979,8 @@ impl Client<Ready> {
                     // Simple query without parameters - use SQL batch
                     self.send_sql_batch(sql).await?;
                 } else {
-                    // Parameterized query - use sp_executesql via RPC
-                    let rpc_params =
-                        Self::convert_params(params, self.send_unicode(), self.server_collation())?;
-                    let rpc = RpcRequest::execute_sql(sql, rpc_params);
+                    // Parameterized query - sp_executesql (encrypts Always Encrypted params).
+                    let rpc = self.build_parameterized_rpc(sql, params).await?;
                     self.send_rpc(&rpc).await?;
                 }
 
@@ -1005,10 +1113,8 @@ impl Client<Ready> {
                     // Simple batch without parameters - use SQL batch
                     self.send_sql_batch(sql).await?;
                 } else {
-                    // Parameterized query - use sp_executesql via RPC
-                    let rpc_params =
-                        Self::convert_params(params, self.send_unicode(), self.server_collation())?;
-                    let rpc = RpcRequest::execute_sql(sql, rpc_params);
+                    // Parameterized query - sp_executesql (encrypts Always Encrypted params).
+                    let rpc = self.build_parameterized_rpc(sql, params).await?;
                     self.send_rpc(&rpc).await?;
                 }
 
@@ -1063,10 +1169,8 @@ impl Client<Ready> {
                     // Simple statement without parameters - use SQL batch
                     self.send_sql_batch(sql).await?;
                 } else {
-                    // Parameterized statement - use sp_executesql via RPC
-                    let rpc_params =
-                        Self::convert_params(params, self.send_unicode(), self.server_collation())?;
-                    let rpc = RpcRequest::execute_sql(sql, rpc_params);
+                    // Parameterized statement - sp_executesql (encrypts Always Encrypted params).
+                    let rpc = self.build_parameterized_rpc(sql, params).await?;
                     self.send_rpc(&rpc).await?;
                 }
 
@@ -1455,10 +1559,8 @@ impl Client<InTransaction> {
                     // Simple query without parameters - use SQL batch
                     self.send_sql_batch(sql).await?;
                 } else {
-                    // Parameterized query - use sp_executesql via RPC
-                    let rpc_params =
-                        Self::convert_params(params, self.send_unicode(), self.server_collation())?;
-                    let rpc = RpcRequest::execute_sql(sql, rpc_params);
+                    // Parameterized query - sp_executesql (encrypts Always Encrypted params).
+                    let rpc = self.build_parameterized_rpc(sql, params).await?;
                     self.send_rpc(&rpc).await?;
                 }
 
@@ -1543,10 +1645,8 @@ impl Client<InTransaction> {
                     // Simple statement without parameters - use SQL batch
                     self.send_sql_batch(sql).await?;
                 } else {
-                    // Parameterized statement - use sp_executesql via RPC
-                    let rpc_params =
-                        Self::convert_params(params, self.send_unicode(), self.server_collation())?;
-                    let rpc = RpcRequest::execute_sql(sql, rpc_params);
+                    // Parameterized statement - sp_executesql (encrypts Always Encrypted params).
+                    let rpc = self.build_parameterized_rpc(sql, params).await?;
                     self.send_rpc(&rpc).await?;
                 }
 

--- a/crates/mssql-client/src/column_parser.rs
+++ b/crates/mssql-client/src/column_parser.rs
@@ -213,9 +213,55 @@ fn decrypt_column(
     // Decrypt and get the base column metadata
     let (plaintext, base_col) = decryptor.decrypt_column_value(ordinal, ciphertext)?;
 
-    // Re-parse the decrypted plaintext using the base column's type info
-    let mut pt_buf: &[u8] = &plaintext;
-    parse_column_value(&mut pt_buf, base_col)
+    // The decrypted plaintext is Always Encrypted's *normalized* form (see
+    // `encryption::normalize_for_encryption`), which is not the TDS wire form,
+    // so it is denormalized directly rather than run through the wire parser.
+    denormalize_decrypted(plaintext, base_col)
+}
+
+/// Denormalize Always Encrypted plaintext (the inverse of
+/// `encryption::normalize_for_encryption`) into a [`SqlValue`].
+///
+/// Only the base types the encryption path supports are handled; anything else
+/// is rejected rather than silently misparsed.
+#[cfg(feature = "always-encrypted")]
+fn denormalize_decrypted(plaintext: Vec<u8>, base_col: &ColumnData) -> Result<SqlValue> {
+    match base_col.type_id {
+        // INT normalizes to 8-byte little-endian (sign-extended).
+        TypeId::IntN | TypeId::Int4 => {
+            let bytes: [u8; 8] = plaintext.as_slice().try_into().map_err(|_| {
+                Error::Encryption(format!(
+                    "decrypted INT has {} bytes, expected 8",
+                    plaintext.len()
+                ))
+            })?;
+            Ok(SqlValue::Int(i64::from_le_bytes(bytes) as i32))
+        }
+        // NVARCHAR/NCHAR normalize to UTF-16LE code units, no length prefix.
+        TypeId::NVarChar | TypeId::NChar => {
+            if plaintext.len() % 2 != 0 {
+                return Err(Error::Encryption(format!(
+                    "decrypted NVARCHAR has an odd byte length ({})",
+                    plaintext.len()
+                )));
+            }
+            let units: Vec<u16> = plaintext
+                .chunks_exact(2)
+                .map(|c| u16::from_le_bytes([c[0], c[1]]))
+                .collect();
+            let s = String::from_utf16(&units).map_err(|_| {
+                Error::Encryption("decrypted NVARCHAR is not valid UTF-16".to_string())
+            })?;
+            Ok(SqlValue::String(s))
+        }
+        // VARBINARY/BINARY normalize to the raw bytes.
+        TypeId::BigVarBinary | TypeId::BigBinary | TypeId::VarBinary | TypeId::Binary => {
+            Ok(SqlValue::Binary(bytes::Bytes::from(plaintext)))
+        }
+        other => Err(Error::Encryption(format!(
+            "Always Encrypted read is not yet implemented for base type {other:?}"
+        ))),
+    }
 }
 
 /// Parse money value from buffer and convert to appropriate type.

--- a/crates/mssql-client/src/encryption.rs
+++ b/crates/mssql-client/src/encryption.rs
@@ -57,9 +57,13 @@
 //!    AEAD_AES_256_CBC_HMAC_SHA256, with the HMAC verified before decryption.
 //!
 //! Reads are transparent across `query`, `call_procedure`, the procedure
-//! builder, and multi-result queries. **Limitation:** the parameter (write) path
-//! only supports `NULL`; encrypting outbound parameter values is not yet
-//! implemented.
+//! builder, and multi-result queries. Parameter (write) encryption is wired
+//! into parameterized `query`/`execute` for `int`, `nvarchar`, and `varbinary`
+//! parameters: with `Column Encryption Setting=Enabled` the driver describes
+//! the parameters (`sp_describe_parameter_encryption`), encrypts those bound to
+//! encrypted columns client-side, and sends them as encrypted RPC parameters
+//! (deterministic and randomized). Other parameter types are not yet supported
+//! and return an error rather than sending plaintext.
 //!
 //! ## Security Model
 //!

--- a/crates/mssql-client/tests/always_encrypted.rs
+++ b/crates/mssql-client/tests/always_encrypted.rs
@@ -460,39 +460,30 @@ mod key_store_tests {
 //
 // ## Scope note
 //
-// Populating encrypted columns with ciphertext requires the driver to send
-// encrypted RPC parameters (parameter encryption). That path is NOT yet
-// implemented — see the `encryption` module rustdoc (Limitations). A naïve
-// `INSERT ... VALUES (CONVERT(varbinary(max), 0x...))` is rejected by
-// SQL Server with "Operand type clash: varbinary is incompatible with
-// varbinary(N) encrypted with (...)" because the server strictly separates
-// plain varbinary from its encrypted-column type, even for literals.
+// Parameter (write) encryption is implemented for int/nvarchar/varbinary, so
+// `test_parameter_encryption_round_trip` populates encrypted columns through the
+// driver (encrypt on INSERT, decrypt on SELECT) and confirms the stored value is
+// opaque ciphertext to a non-AE connection.
 //
-// Until parameter encryption lands, these live tests exercise the reachable
-// slice of the pipeline end-to-end against a real server:
+// `test_always_encrypted_metadata_and_null_roundtrip` remains a focused check of
+// the metadata + NULL path: it inserts NULL into the encrypted column (a naïve
+// plaintext literal is still rejected with "Operand type clash: varbinary is
+// incompatible with varbinary(N) encrypted with (...)") and asserts:
+//   - the driver parses `CekTable` and per-column `CryptoMetadata`,
+//   - the encryptor is async-resolved via the key-store provider (the path the
+//     `from_arc` bug in `EncryptionContext` broke — see commit history),
+//   - NULL encrypted values surface as `SqlValue::Null`,
+//   - the plaintext base-type re-parse machinery is wired (via an unencrypted
+//     companion column).
 //
+// All live tests provision their own keys per the standard envelope flow:
 //   1. Generate an RSA-2048 keypair in the test.
-//   2. Wrap a random 32-byte CEK with RSA-OAEP-SHA1 (what `RSA_OAEP` means in
-//      AE metadata) and build the canonical signed envelope
-//      (`mssql_auth::cek_envelope`): `0x01 || u16le(path_len)
-//      || u16le(cipher_len) || utf16le(path) || cipher || signature`.
-//   3. `CREATE COLUMN MASTER KEY`, `CREATE COLUMN ENCRYPTION KEY`, and a
-//      table with at least one encrypted column.
-//   4. Populate rows through the only server-allowed path without parameter
-//      encryption: INSERT leaving the encrypted column NULL.
-//   5. Connect WITH `Column Encryption Setting=Enabled` + registered
-//      `InMemoryKeyStore`, SELECT the row, and assert:
-//       - the driver parses `CekTable` and per-column `CryptoMetadata`
-//       - the driver async-resolves the encryptor via the key-store provider
-//         (this is the path the `from_arc` bug in `EncryptionContext` broke —
-//          see commit history for the fix)
-//       - NULL encrypted values are surfaced as `SqlValue::Null`
-//       - the plaintext base-type re-parse machinery is wired up (verified
-//         by reading an unencrypted companion column from the same row)
-//
-// The full ciphertext round-trip through RPC parameters is tracked as a
-// separate work item and will be added here once parameter encryption is
-// implemented. See item 2.8 in .tmp/work-items.md.
+//   2. Wrap a random 32-byte CEK with RSA-OAEP-SHA1 (what `RSA_OAEP` means in AE
+//      metadata) and build the canonical signed envelope
+//      (`mssql_auth::cek_envelope`): `0x01 || u16le(path_len) || u16le(cipher_len)
+//      || utf16le(path) || cipher || signature`.
+//   3. `CREATE COLUMN MASTER KEY`, `CREATE COLUMN ENCRYPTION KEY`, and a table
+//      with at least one encrypted column.
 
 #[cfg(feature = "always-encrypted")]
 mod live_server {
@@ -514,10 +505,9 @@ mod live_server {
 
     /// Bundle everything a test needs after per-test setup completes.
     struct Fixture {
-        /// The randomly-generated CEK. Unused today — parameter encryption
-        /// (NYI) will pre-encrypt row values with it so INSERT tests can
-        /// round-trip ciphertext. Kept on the fixture so the helpers remain
-        /// wired once that feature lands.
+        /// The randomly-generated CEK. The round-trip test encrypts through the
+        /// driver's registered key store rather than reading the raw key here,
+        /// so this stays unread; retained for symmetry with `setup`.
         #[allow(dead_code)]
         cek_bytes: [u8; 32],
         /// CMK name in SQL Server (random per test to avoid collisions).
@@ -787,6 +777,140 @@ mod live_server {
         let p1 = info.get_parameter("@p1").expect("@p1 directive");
         assert_eq!(p1.encryption_type, EncryptionTypeWire::Randomized);
         assert_eq!(p1.cek_ordinal, 0);
+    }
+
+    /// Full Always Encrypted write→read round-trip: the driver encrypts INT,
+    /// NVARCHAR, and VARBINARY parameters on INSERT, then decrypts them back on
+    /// SELECT. Also confirms the stored value is real ciphertext (opaque to a
+    /// connection without Always Encrypted) — proving the encryption happens
+    /// client-side, not on the server.
+    #[tokio::test]
+    #[ignore = "Requires SQL Server with Always Encrypted"]
+    async fn test_parameter_encryption_round_trip() {
+        let admin_cfg = match admin_config() {
+            Some(c) => c,
+            None => return,
+        };
+        let mut admin = Client::connect(admin_cfg).await.expect("admin connect");
+
+        let (rsa_key, pem) = fresh_rsa_keypair();
+        let cek = fresh_cek();
+
+        let fx = setup(
+            &mut admin,
+            &cek,
+            &rsa_key,
+            "CREATE TABLE [{TABLE}] ( \
+             Id INT NOT NULL PRIMARY KEY, \
+             EncInt INT ENCRYPTED WITH ( \
+             COLUMN_ENCRYPTION_KEY = [{CEK}], \
+             ENCRYPTION_TYPE = DETERMINISTIC, \
+             ALGORITHM = 'AEAD_AES_256_CBC_HMAC_SHA_256' ) NULL, \
+             EncName NVARCHAR(50) COLLATE Latin1_General_BIN2 ENCRYPTED WITH ( \
+             COLUMN_ENCRYPTION_KEY = [{CEK}], \
+             ENCRYPTION_TYPE = DETERMINISTIC, \
+             ALGORITHM = 'AEAD_AES_256_CBC_HMAC_SHA_256' ) NULL, \
+             EncData VARBINARY(50) ENCRYPTED WITH ( \
+             COLUMN_ENCRYPTION_KEY = [{CEK}], \
+             ENCRYPTION_TYPE = DETERMINISTIC, \
+             ALGORITHM = 'AEAD_AES_256_CBC_HMAC_SHA_256' ) NULL )",
+        )
+        .await;
+        drop(admin);
+
+        let mut client = Client::connect(encrypted_config(&pem).expect("cfg"))
+            .await
+            .expect("ae connect");
+
+        let blob: Vec<u8> = vec![0xDE, 0xAD, 0xBE, 0xEF];
+        let insert = format!(
+            "INSERT INTO [{}] (Id, EncInt, EncName, EncData) VALUES (@p1, @p2, @p3, @p4)",
+            fx.table_name
+        );
+        // The driver encrypts @p2/@p3/@p4 client-side; @p1 (Id) stays plaintext.
+        let inserted = client
+            .execute(&insert, &[&1i32, &42i32, &"Ada Lovelace", &blob])
+            .await;
+
+        // Read the encrypted columns back; the driver decrypts transparently.
+        let round_trip: Result<(i32, String, Vec<u8>), String> = if inserted.is_ok() {
+            let select = format!(
+                "SELECT EncInt, EncName, EncData FROM [{}] WHERE Id = @p1",
+                fx.table_name
+            );
+            async {
+                let rows = client
+                    .query(&select, &[&1i32])
+                    .await
+                    .map_err(|e| format!("select: {e}"))?;
+                let mut found = None;
+                for r in rows {
+                    let r = r.map_err(|e| format!("row: {e}"))?;
+                    found = Some((
+                        r.get::<i32>(0).map_err(|e| format!("EncInt: {e}"))?,
+                        r.get::<String>(1).map_err(|e| format!("EncName: {e}"))?,
+                        r.get::<Vec<u8>>(2).map_err(|e| format!("EncData: {e}"))?,
+                    ));
+                }
+                found.ok_or_else(|| "no row returned".to_string())
+            }
+            .await
+        } else {
+            Err("insert failed".to_string())
+        };
+
+        // A connection WITHOUT Always Encrypted sees only ciphertext.
+        let opaque: Result<Vec<u8>, String> = {
+            let mut plain = Client::connect(admin_config().expect("cfg"))
+                .await
+                .expect("plain connect");
+            let sql = format!("SELECT EncInt FROM [{}] WHERE Id = 1", fx.table_name);
+            async {
+                let rows = plain
+                    .query(&sql, &[])
+                    .await
+                    .map_err(|e| format!("plain select: {e}"))?;
+                let mut bytes = None;
+                for r in rows {
+                    let r = r.map_err(|e| format!("row: {e}"))?;
+                    bytes = Some(r.get::<Vec<u8>>(0).map_err(|e| format!("raw: {e}"))?);
+                }
+                bytes.ok_or_else(|| "no row".to_string())
+            }
+            .await
+        };
+
+        // Teardown before asserting so a failure never leaks server objects.
+        let mut admin = Client::connect(admin_config().expect("cfg"))
+            .await
+            .expect("admin reconnect");
+        teardown(&mut admin, &fx).await;
+
+        let inserted = inserted.expect("encrypted INSERT should succeed");
+        assert_eq!(inserted, 1, "exactly one row inserted");
+
+        let (got_int, got_name, got_data) = round_trip.expect("decrypt round-trip");
+        assert_eq!(got_int, 42, "INT decrypts to the inserted value");
+        assert_eq!(
+            got_name, "Ada Lovelace",
+            "NVARCHAR decrypts to the inserted value"
+        );
+        assert_eq!(
+            got_data,
+            vec![0xDE, 0xAD, 0xBE, 0xEF],
+            "VARBINARY decrypts to the inserted value"
+        );
+
+        let ciphertext = opaque.expect("read raw ciphertext");
+        assert!(
+            ciphertext.len() > 4,
+            "stored value is an AEAD blob, not a 4-byte int"
+        );
+        assert_ne!(
+            ciphertext,
+            42i32.to_le_bytes().to_vec(),
+            "stored value must not be the plaintext int"
+        );
     }
 
     /// Validate the Always Encrypted metadata path end-to-end against a live

--- a/crates/tds-protocol/src/rpc.rs
+++ b/crates/tds-protocol/src/rpc.rs
@@ -879,7 +879,13 @@ impl RpcRequest {
     }
 
     /// Build parameter declaration string for sp_executesql.
-    fn build_param_declarations(params: &[RpcParam]) -> String {
+    /// Build the `sp_executesql` `@params` declaration string for `params`.
+    ///
+    /// An Always Encrypted parameter declares its plaintext column type (its
+    /// [`EncryptedParamMetadata::base_type_info`]), not the `BIGVARBINARY`
+    /// transport type its value is carried as, so the declaration matches what
+    /// `sp_describe_parameter_encryption` was asked about.
+    pub fn build_param_declarations(params: &[RpcParam]) -> String {
         params
             .iter()
             .map(|p| {
@@ -895,8 +901,16 @@ impl RpcRequest {
                     format!("@{}", p.name)
                 };
 
-                let type_name: String = match p.type_info.type_id {
-                    0x26 => match p.type_info.max_length {
+                // Encrypted parameters declare their plaintext type, not the
+                // BIGVARBINARY their ciphertext rides in.
+                let ti = p
+                    .crypto_metadata
+                    .as_ref()
+                    .map(|m| &m.base_type_info)
+                    .unwrap_or(&p.type_info);
+
+                let type_name: String = match ti.type_id {
+                    0x26 => match ti.max_length {
                         Some(1) => "tinyint".to_string(),
                         Some(2) => "smallint".to_string(),
                         Some(4) => "int".to_string(),
@@ -904,65 +918,65 @@ impl RpcRequest {
                         _ => "int".to_string(),
                     },
                     0x68 => "bit".to_string(),
-                    0x6D => match p.type_info.max_length {
+                    0x6D => match ti.max_length {
                         Some(4) => "real".to_string(),
                         _ => "float".to_string(),
                     },
                     0xE7 => {
-                        if p.type_info.max_length == Some(0xFFFF) {
+                        if ti.max_length == Some(0xFFFF) {
                             "nvarchar(max)".to_string()
                         } else {
-                            let len = p.type_info.max_length.unwrap_or(4000) / 2;
+                            let len = ti.max_length.unwrap_or(4000) / 2;
                             format!("nvarchar({len})")
                         }
                     }
                     0xA7 => {
-                        if p.type_info.max_length == Some(0xFFFF) {
+                        if ti.max_length == Some(0xFFFF) {
                             "varchar(max)".to_string()
                         } else {
-                            let len = p.type_info.max_length.unwrap_or(8000);
+                            let len = ti.max_length.unwrap_or(8000);
                             format!("varchar({len})")
                         }
                     }
                     0xA5 => {
-                        if p.type_info.max_length == Some(0xFFFF) {
+                        if ti.max_length == Some(0xFFFF) {
                             "varbinary(max)".to_string()
                         } else {
-                            let len = p.type_info.max_length.unwrap_or(8000);
+                            let len = ti.max_length.unwrap_or(8000);
                             format!("varbinary({len})")
                         }
                     }
                     0x24 => "uniqueidentifier".to_string(),
                     0x28 => "date".to_string(),
                     0x29 => {
-                        let scale = p.type_info.scale.unwrap_or(7);
+                        let scale = ti.scale.unwrap_or(7);
                         format!("time({scale})")
                     }
                     0x2A => {
-                        let scale = p.type_info.scale.unwrap_or(7);
+                        let scale = ti.scale.unwrap_or(7);
                         format!("datetime2({scale})")
                     }
                     0x2B => {
-                        let scale = p.type_info.scale.unwrap_or(7);
+                        let scale = ti.scale.unwrap_or(7);
                         format!("datetimeoffset({scale})")
                     }
                     0x6C => {
-                        let precision = p.type_info.precision.unwrap_or(18);
-                        let scale = p.type_info.scale.unwrap_or(0);
+                        let precision = ti.precision.unwrap_or(18);
+                        let scale = ti.scale.unwrap_or(0);
                         format!("decimal({precision}, {scale})")
                     }
-                    0x6E => match p.type_info.max_length {
+                    0x6E => match ti.max_length {
                         Some(4) => "smallmoney".to_string(),
                         _ => "money".to_string(),
                     },
-                    0x6F => match p.type_info.max_length {
+                    0x6F => match ti.max_length {
                         Some(4) => "smalldatetime".to_string(),
                         _ => "datetime".to_string(),
                     },
                     0xF3 => {
                         // TVP - Table-Valued Parameter
                         // Must be declared with the table type name and READONLY
-                        if let Some(ref tvp_name) = p.type_info.tvp_type_name {
+                        if let Some(ref tvp_name) = ti.tvp_type_name {
                             format!("{tvp_name} READONLY")
                         } else {
                             // Fallback if type name is missing (shouldn't happen)


### PR DESCRIPTION
## Summary

Wire Always Encrypted **parameter encryption** end-to-end (Phase 3a.4). With `Column Encryption Setting=Enabled`, a parameterized query/execute now: describes its parameters, resolves each encrypted parameter's CEK, normalizes + encrypts the value, and sends it as an encrypted RPC parameter. The driver can finally **write** encrypted values, not just `NULL`. Also fixes the read path for non-NULL encrypted values.

## Linked issues

Refs #86 — completes the AE write-path slice (int/nvarchar/varbinary).

## Type of change

- [x] New feature (AE parameter encryption is now wired into query/execute)
- [x] Bug fix (read path mis-handled non-NULL decrypted values)

## What it does

- **Orchestration** (`mssql-client`): `build_parameterized_rpc` / `build_encrypted_sql_rpc`, wired into all five parameterized query/execute sites. Flow: `describe_parameter_encryption` (3a.2) → resolve CEK via the read-path `EncryptionContext::get_encryptor` → `normalize_for_encryption` (3a.1) → `AeadEncryptor::encrypt` → `RpcParam::encrypted` (3a.3). Plaintext params pass through; non-AE connections are unchanged (no describe round-trip).
- **Read-path fix** (`mssql-client`): the decrypted plaintext is AE's *normalized* form, not the TDS wire form. The decrypt path now denormalizes it directly (inverse of `normalize_for_encryption`) instead of running it through the wire parser — which misread an 8-byte normalized INT as a length-prefixed value. **This was a latent bug**: only NULL had ever been exercised through the decrypt path.
- **tds-protocol**: `build_param_declarations` is now public (the orchestration needs the `@params` declaration to describe with) and declares an encrypted parameter by its plaintext base type, not the `BIGVARBINARY` transport type. The `@params` declaration using original types was confirmed against the captured `.NET` bytes (`@i int,@s nvarchar(50),@b varbinary(50)`).

## How it was validated

A **live write→read round-trip** test (runs in the 2017/2019/2022 CI matrix):
- The driver encrypts INT (`42`), NVARCHAR (`"Ada Lovelace"`), and VARBINARY (`[DE AD BE EF]`) parameters on INSERT — the server **accepts** them, proving the full write path (describe + CEK + normalize + encrypt + wire + `@params`).
- The driver decrypts them back on SELECT — all three values match.
- A connection **without** Always Encrypted sees only ciphertext (`> 4` bytes, not the plaintext int), proving the encryption happens client-side.

The read-path fix was confirmed **red→green** on this test (the INSERT always succeeded; the read failed with `unexpected EOF reading IntN data` until the denormalization landed).

## Test plan

- [x] `just ci-all` (fmt, clippy `--all-features --all-targets -D warnings`, nextest all-features, `doc -D warnings`, examples) — green
- [x] `just typos`, `just check-feature-flags` — green
- [x] Live ignored-only suite vs SQL 2022: **245/245** (new round-trip + describe + the existing NULL-roundtrip / provider tests — no regressions)

## Documentation updates

- [x] rustdoc on the new methods and `build_param_declarations`
- CHANGELOG.md: left to release-plz (repo convention). The `encryption` module's limitation text (write path = NULL-only) is updated to reflect that int/nvarchar/varbinary parameter encryption now works.

## Notes / scope

- **No describe-result caching yet** (correctness first): every AE-on parameterized query does one extra `sp_describe_parameter_encryption` round-trip, matching `Microsoft.Data.SqlClient`'s uncached path. Caching is a clean follow-up.
- **Cross-client interop** is already proven at the cell level (3a.1: byte-identical AEAD vs .NET) and the wire level (3a.3: byte-identical RPC framing vs captured .NET). A live driver↔.NET coordination test would add operational confidence but no correctness beyond the byte-exact proofs; recommend as a follow-up.
- Read decryption now supports the same types as the write path (int/nvarchar/varbinary); other base types return a clear "not yet implemented" error instead of mis-parsing.

## Breaking changes

None. `build_param_declarations` becoming public is additive. The new orchestration methods are `pub(crate)`. Query/execute signatures are unchanged.
