### PR TITLE
feat(encryption): Always Encrypted write/read for fixed-width numeric types

### DIFF
--- a/crates/mssql-client/src/column_parser.rs
+++ b/crates/mssql-client/src/column_parser.rs
@@ -227,16 +227,46 @@ fn decrypt_column(
 #[cfg(feature = "always-encrypted")]
 fn denormalize_decrypted(plaintext: Vec<u8>, base_col: &ColumnData) -> Result<SqlValue> {
     match base_col.type_id {
-        // INT normalizes to 8-byte little-endian (sign-extended).
-        TypeId::IntN | TypeId::Int4 => {
-            let bytes: [u8; 8] = plaintext.as_slice().try_into().map_err(|_| {
-                Error::Encryption(format!(
-                    "decrypted INT has {} bytes, expected 8",
-                    plaintext.len()
-                ))
-            })?;
-            Ok(SqlValue::Int(i64::from_le_bytes(bytes) as i32))
+        // Integer family and bit normalize to 8-byte little-endian (every width,
+        // tinyint/smallint included). The base type's width picks the variant.
+        TypeId::Bit
+        | TypeId::BitN
+        | TypeId::Int1
+        | TypeId::Int2
+        | TypeId::Int4
+        | TypeId::Int8
+        | TypeId::IntN => {
+            let v = i64::from_le_bytes(decrypted_array::<8>(&plaintext, "integer")?);
+            Ok(match base_col.type_id {
+                TypeId::Bit | TypeId::BitN => SqlValue::Bool(v != 0),
+                TypeId::Int1 => SqlValue::TinyInt(v as u8),
+                TypeId::Int2 => SqlValue::SmallInt(v as i16),
+                TypeId::Int8 => SqlValue::BigInt(v),
+                // IntN carries the width in max_length; default to INT.
+                TypeId::IntN => match base_col.type_info.max_length {
+                    Some(1) => SqlValue::TinyInt(v as u8),
+                    Some(2) => SqlValue::SmallInt(v as i16),
+                    Some(8) => SqlValue::BigInt(v),
+                    _ => SqlValue::Int(v as i32),
+                },
+                _ => SqlValue::Int(v as i32),
+            })
         }
+        // REAL/FLOAT normalize to their IEEE-754 bits, little-endian.
+        TypeId::Float4 => Ok(SqlValue::Float(f32::from_le_bytes(decrypted_array::<4>(
+            &plaintext, "REAL",
+        )?))),
+        TypeId::Float8 => Ok(SqlValue::Double(f64::from_le_bytes(decrypted_array::<8>(
+            &plaintext, "FLOAT",
+        )?))),
+        TypeId::FloatN => match base_col.type_info.max_length {
+            Some(4) => Ok(SqlValue::Float(f32::from_le_bytes(decrypted_array::<4>(
+                &plaintext, "REAL",
+            )?))),
+            _ => Ok(SqlValue::Double(f64::from_le_bytes(decrypted_array::<8>(
+                &plaintext, "FLOAT",
+            )?))),
+        },
         // NVARCHAR/NCHAR normalize to UTF-16LE code units, no length prefix.
         TypeId::NVarChar | TypeId::NChar => {
             if plaintext.len() % 2 != 0 {
@@ -262,6 +292,18 @@ fn denormalize_decrypted(plaintext: Vec<u8>, base_col: &ColumnData) -> Result<Sq
             "Always Encrypted read is not yet implemented for base type {other:?}"
         ))),
     }
+}
+
+/// Convert decrypted plaintext into a fixed-size array, erroring on a length
+/// mismatch rather than panicking.
+#[cfg(feature = "always-encrypted")]
+fn decrypted_array<const N: usize>(plaintext: &[u8], what: &str) -> Result<[u8; N]> {
+    plaintext.try_into().map_err(|_| {
+        Error::Encryption(format!(
+            "decrypted {what} has {} bytes, expected {N}",
+            plaintext.len()
+        ))
+    })
 }
 
 /// Parse money value from buffer and convert to appropriate type.

--- a/crates/mssql-client/src/encryption.rs
+++ b/crates/mssql-client/src/encryption.rs
@@ -658,8 +658,17 @@ fn describe_type_error(col: &str, idx: usize, expected: &str, got: Option<&SqlVa
 #[cfg(feature = "always-encrypted")]
 pub fn normalize_for_encryption(value: &SqlValue) -> Result<Vec<u8>, EncryptionError> {
     match value {
-        // Signed integer types normalize to 8-byte little-endian (sign-extended).
+        // All integer types AND bit normalize to 8-byte little-endian (the value
+        // widened to i64). Validated against .NET: tinyint/smallint are 8 bytes,
+        // not their native 1/2 — a spec-reading would get this wrong.
+        SqlValue::Bool(v) => Ok(i64::from(*v).to_le_bytes().to_vec()),
+        SqlValue::TinyInt(v) => Ok(i64::from(*v).to_le_bytes().to_vec()),
+        SqlValue::SmallInt(v) => Ok(i64::from(*v).to_le_bytes().to_vec()),
         SqlValue::Int(v) => Ok(i64::from(*v).to_le_bytes().to_vec()),
+        SqlValue::BigInt(v) => Ok(v.to_le_bytes().to_vec()),
+        // REAL/FLOAT: the IEEE-754 bits, little-endian (4 and 8 bytes).
+        SqlValue::Float(v) => Ok(v.to_le_bytes().to_vec()),
+        SqlValue::Double(v) => Ok(v.to_le_bytes().to_vec()),
         // NVARCHAR: UTF-16LE code units, no length prefix.
         SqlValue::String(s) => Ok(s.encode_utf16().flat_map(u16::to_le_bytes).collect()),
         // VARBINARY: the raw bytes, no length prefix.
@@ -723,10 +732,71 @@ mod tests {
         }
     }
 
+    /// `normalize_for_encryption` rejects values it has no normalization for
+    /// rather than silently producing wrong bytes. NULL is never normalized
+    /// (it is handled as a NULL parameter upstream), so it exercises the
+    /// catch-all rejection arm and stays unsupported as more types are added.
     #[cfg(feature = "always-encrypted")]
     #[test]
-    fn ae_normalization_rejects_unsupported_type() {
-        assert!(normalize_for_encryption(&SqlValue::Bool(true)).is_err());
+    fn ae_normalization_rejects_unnormalizable_value() {
+        assert!(normalize_for_encryption(&SqlValue::Null).is_err());
+    }
+
+    /// Numeric-scalar normalization, validated byte-for-byte against
+    /// Microsoft.Data.SqlClient (same method as [`ae_normalization_matches_dotnet`],
+    /// captured with a fresh CEK). This is the interop guarantee: a value the
+    /// driver encrypts is the value .NET would encrypt. Notable: every integer
+    /// width and bit normalize to 8 bytes, real to 4, float to 8.
+    #[cfg(feature = "always-encrypted")]
+    #[test]
+    fn ae_normalization_matches_dotnet_numeric() {
+        fn unhex(s: &str) -> Vec<u8> {
+            (0..s.len())
+                .step_by(2)
+                .map(|i| u8::from_str_radix(&s[i..i + 2], 16).unwrap())
+                .collect()
+        }
+
+        let cek = unhex("9590E42A8A6C8F13B5D09B8D5A128EF8B3A4A10301C7AF24AFC62ED0E02342F7");
+        let enc = AeadEncryptor::new(&cek).unwrap();
+
+        for (value, reference) in [
+            (
+                SqlValue::BigInt(0x0102030405060708),
+                "01E765FC4696660028BFD48FCAEAED81E0EB423CFF433CA97F1B2FF02F70744E7265C2AE73CAA562FFA98AF98CB1D3EF6A4649B3640359E1DB7D170C80E639DA68",
+            ),
+            (
+                SqlValue::SmallInt(258),
+                "012545AB817E1AEBDCEE1C00AEBFF3A013CAD20E0377BEFDD9186C263F8D1A909C313A753996F1B5E4A4AE17E901F6F781DCA707544766995D339601CA414063A0",
+            ),
+            (
+                SqlValue::TinyInt(200),
+                "01A97C33480277D16FFAEDA9068173D4173378542F2887EBCD31CDEEEB116BD59D48F9D459BDDCABAE469E891B4F82AA3D283440CA1B5E9FFC150F9D0AE54EC21E",
+            ),
+            (
+                SqlValue::Bool(true),
+                "01DDE18564051D630EE026331BCCAFC8F4122CC3919F81459F37D9C0E0C64A5317FCA08660FE5FC855917B97B72013F25B85ADD14ADDD7D5ED022EB1297FF29A7E",
+            ),
+            (
+                SqlValue::Float(3.5),
+                "017A452760E7BA7AA6A716F6707F55D9C3A81683C04A6B561B13AC1D8A848E93E239BB922EE3EE628B6D0081A590BB11747CC25D216240FB10171A0FA3B99A2DB3",
+            ),
+            (
+                SqlValue::Double(3.5),
+                "0171611557351FBC4561EBF0B9C98E0DC38AD2BD3E2C1D1E82F185D7E67D0425E506D11DD67BA3EB38F34FB01A8FCEF7E4B9A7256944334A521526613CFF6C8C5F",
+            ),
+        ] {
+            let norm = normalize_for_encryption(&value).unwrap();
+            let cipher = enc
+                .encrypt(&norm, mssql_auth::EncryptionType::Deterministic)
+                .unwrap();
+            assert_eq!(
+                cipher,
+                unhex(reference),
+                "ciphertext for {} must match Microsoft.Data.SqlClient",
+                value.type_name()
+            );
+        }
     }
 
     #[test]

--- a/crates/mssql-client/tests/always_encrypted.rs
+++ b/crates/mssql-client/tests/always_encrypted.rs
@@ -931,6 +931,100 @@ mod live_server {
         );
     }
 
+    /// Write→read round-trip for the fixed-width numeric types: bigint,
+    /// smallint, tinyint, bit, real, and float. Each is encrypted on INSERT and
+    /// decrypted back on SELECT, exercising both the 8-byte integer
+    /// normalization and the 4/8-byte IEEE float forms through the live server.
+    #[tokio::test]
+    #[ignore = "Requires SQL Server with Always Encrypted"]
+    async fn test_numeric_parameter_encryption_round_trip() {
+        let admin_cfg = match admin_config() {
+            Some(c) => c,
+            None => return,
+        };
+        let mut admin = Client::connect(admin_cfg).await.expect("admin connect");
+
+        let (rsa_key, pem) = fresh_rsa_keypair();
+        let cek = fresh_cek();
+
+        let enc = "ENCRYPTED WITH (COLUMN_ENCRYPTION_KEY = [{CEK}], \
+                   ENCRYPTION_TYPE = DETERMINISTIC, ALGORITHM = 'AEAD_AES_256_CBC_HMAC_SHA_256')";
+        let ddl = format!(
+            "CREATE TABLE [{{TABLE}}] ( \
+             Id INT NOT NULL PRIMARY KEY, \
+             EncBig BIGINT {enc} NULL, \
+             EncSmall SMALLINT {enc} NULL, \
+             EncTiny TINYINT {enc} NULL, \
+             EncBit BIT {enc} NULL, \
+             EncReal REAL {enc} NULL, \
+             EncFloat FLOAT {enc} NULL )"
+        );
+        let fx = setup(&mut admin, &cek, &rsa_key, &ddl).await;
+        drop(admin);
+
+        let mut client = Client::connect(encrypted_config(&pem).expect("cfg"))
+            .await
+            .expect("ae connect");
+
+        let big = 0x0102_0304_0506_0708_i64;
+        let insert = format!(
+            "INSERT INTO [{}] (Id, EncBig, EncSmall, EncTiny, EncBit, EncReal, EncFloat) \
+             VALUES (@p1, @p2, @p3, @p4, @p5, @p6, @p7)",
+            fx.table_name
+        );
+        let inserted = client
+            .execute(
+                &insert,
+                &[&1i32, &big, &258i16, &200u8, &true, &3.5f32, &3.5f64],
+            )
+            .await;
+
+        let round_trip: Result<(i64, i16, u8, bool, f32, f64), String> = if inserted.is_ok() {
+            let select = format!(
+                "SELECT EncBig, EncSmall, EncTiny, EncBit, EncReal, EncFloat FROM [{}] WHERE Id = @p1",
+                fx.table_name
+            );
+            async {
+                let rows = client
+                    .query(&select, &[&1i32])
+                    .await
+                    .map_err(|e| format!("select: {e}"))?;
+                let mut found = None;
+                for r in rows {
+                    let r = r.map_err(|e| format!("row: {e}"))?;
+                    found = Some((
+                        r.get::<i64>(0).map_err(|e| format!("EncBig: {e}"))?,
+                        r.get::<i16>(1).map_err(|e| format!("EncSmall: {e}"))?,
+                        r.get::<u8>(2).map_err(|e| format!("EncTiny: {e}"))?,
+                        r.get::<bool>(3).map_err(|e| format!("EncBit: {e}"))?,
+                        r.get::<f32>(4).map_err(|e| format!("EncReal: {e}"))?,
+                        r.get::<f64>(5).map_err(|e| format!("EncFloat: {e}"))?,
+                    ));
+                }
+                found.ok_or_else(|| "no row returned".to_string())
+            }
+            .await
+        } else {
+            Err("insert failed".to_string())
+        };
+
+        let mut admin = Client::connect(admin_config().expect("cfg"))
+            .await
+            .expect("admin reconnect");
+        teardown(&mut admin, &fx).await;
+
+        let inserted = inserted.expect("encrypted numeric INSERT should succeed");
+        assert_eq!(inserted, 1, "one row inserted");
+        let (g_big, g_small, g_tiny, g_bit, g_real, g_float) =
+            round_trip.expect("decrypt round-trip");
+        assert_eq!(g_big, big, "BIGINT round-trips");
+        assert_eq!(g_small, 258, "SMALLINT round-trips");
+        assert_eq!(g_tiny, 200, "TINYINT round-trips");
+        assert!(g_bit, "BIT round-trips");
+        assert_eq!(g_real, 3.5, "REAL round-trips");
+        assert_eq!(g_float, 3.5, "FLOAT round-trips");
+    }
+
     /// Validate the Always Encrypted metadata path end-to-end against a live
     /// server. A row with NULL in the encrypted column is the only value we
     /// can populate without parameter encryption (any non-NULL plaintext


### PR DESCRIPTION
## Summary

Phase 3b, batch 1: parameter encryption + decryption for **bigint, smallint, tinyint, bit, real, float** (on top of the existing int), toward the complete AE write path before 0.16.0 ships.

## Type of change

- [x] New feature (more AE-encryptable types), non-breaking

## How each normalization was determined

Not guessed — captured from a live `Microsoft.Data.SqlClient` deterministic INSERT and decrypted to reveal the exact normalized bytes. The surprises that a spec-reading would miss:
- **Every integer type and bit normalize to 8-byte little-endian** (tinyint/smallint included, not their native 1/2 bytes).
- **real → 4-byte IEEE-754 LE**, **float → 8-byte LE**.

## Validation (both interop directions)

- **Write**: `ae_normalization_matches_dotnet_numeric` asserts my normalize+encrypt reproduces .NET's ciphertext byte-for-byte. This is the interop guarantee on write.
- **Read**: `test_numeric_parameter_encryption_round_trip` (live, runs in the 2017/2019/2022 matrix) encrypts each type on INSERT and decrypts it back on SELECT.
- Together these prove both directions: my normalize equals .NET's (byte-exact), and my denormalize inverts it (round-trip), so .NET can read driver-written data and vice versa.

## Test plan

- [x] `just ci-all`, `just typos`, `just check-feature-flags` — green
- [x] Live ignored-only suite vs SQL 2022: **246/246**

## Documentation

- The `encryption` module limitation text already lists the supported types; it will be updated to the full set as the remaining batches land (uuid/date next, then decimal/money, date/time, and the remaining string/binary types).

## Known gap (separate follow-up, not in this PR)

Inserting **NULL into an encrypted column via a typed parameter** does not yet work: the orchestration calls `normalize` on the NULL value (which errors), and value-inferred typing can't know a NULL param's target column type. This is a pre-existing 3a.4 edge case; it deserves its own focused fix (typed NULL params). Flagging it here for visibility.

## Breaking changes

None.