### PR TITLE
feat(encryption): typed NULL parameters for encrypted columns

### DIFF
--- a/crates/mssql-client/src/client.rs
+++ b/crates/mssql-client/src/client.rs
@@ -154,6 +154,26 @@ enum ConnectionHandle {
     Plain(Connection<TcpStream>),
 }
 
+/// The parameter `TypeInfo` to declare a typed NULL ([`crate::null`]) with, from
+/// its [`crate::ToSql::sql_type`] name. Returns `None` for an untyped NULL
+/// (`Option::None`, type `"NULL"`), which falls back to the default param type.
+#[cfg(feature = "always-encrypted")]
+fn null_param_type_info(sql_type: &str) -> Option<tds_protocol::rpc::TypeInfo> {
+    use tds_protocol::rpc::TypeInfo;
+    Some(match sql_type {
+        "BIT" => TypeInfo::bit(),
+        "TINYINT" => TypeInfo::tinyint(),
+        "SMALLINT" => TypeInfo::smallint(),
+        "INT" => TypeInfo::int(),
+        "BIGINT" => TypeInfo::bigint(),
+        "REAL" => TypeInfo::real(),
+        "FLOAT" => TypeInfo::float(),
+        "NVARCHAR" => TypeInfo::nvarchar(1),
+        "VARBINARY" => TypeInfo::varbinary(1),
+        _ => return None,
+    })
+}
+
 // Private helper methods available to all connection states
 impl<S: ConnectionState> Client<S> {
     /// The default per-command deadline from `command_timeout`.
@@ -468,12 +488,14 @@ impl<S: ConnectionState> Client<S> {
         for (i, p) in params.iter().enumerate() {
             let name = format!("@p{}", i + 1);
             let value = p.to_sql()?;
-            plaintext.push(Self::sql_value_to_rpc_param(
-                &name,
-                &value,
-                send_unicode,
-                collation.as_ref(),
-            )?);
+            // A typed NULL (e.g. `null::<i32>()`) is declared by its SQL type so
+            // describe accepts it against the target encrypted column; an untyped
+            // NULL falls back to the default in `sql_value_to_rpc_param`.
+            let rpc_param = match (&value, null_param_type_info(p.sql_type())) {
+                (mssql_types::SqlValue::Null, Some(type_info)) => RpcParam::null(&name, type_info),
+                _ => Self::sql_value_to_rpc_param(&name, &value, send_unicode, collation.as_ref())?,
+            };
+            plaintext.push(rpc_param);
             values.push(value);
         }
 
@@ -503,10 +525,6 @@ impl<S: ConnectionState> Client<S> {
                     param.name, crypto.cek_ordinal
                 ))
             })?;
-            let normalized = crate::encryption::normalize_for_encryption(&value)?;
-            let ciphertext = ctx
-                .encrypt_value(&normalized, entry, crypto.encryption_type)
-                .await?;
             let metadata = tds_protocol::rpc::EncryptedParamMetadata {
                 base_type_info: param.type_info.clone(),
                 algorithm_id: crypto.algorithm_id,
@@ -517,6 +535,17 @@ impl<S: ConnectionState> Client<S> {
                 cek_md_version: entry.cek_md_version,
                 normalization_rule_version: crypto.normalization_rule_version,
             };
+            // A NULL value bound to an encrypted column is sent as an encrypted
+            // NULL (the server rejects a plaintext parameter for an encrypted
+            // column); there is nothing to encrypt.
+            if matches!(value, mssql_types::SqlValue::Null) {
+                final_params.push(RpcParam::encrypted_null(param.name, metadata));
+                continue;
+            }
+            let normalized = crate::encryption::normalize_for_encryption(&value)?;
+            let ciphertext = ctx
+                .encrypt_value(&normalized, entry, crypto.encryption_type)
+                .await?;
             final_params.push(RpcParam::encrypted(
                 param.name,
                 bytes::Bytes::from(ciphertext),

--- a/crates/mssql-client/src/lib.rs
+++ b/crates/mssql-client/src/lib.rs
@@ -113,7 +113,7 @@ pub use tds_protocol::version::TdsVersion;
 pub use mssql_auth::{SecretString, SecureCredentials};
 #[cfg(feature = "chrono")]
 pub use mssql_types::SmallDateTime;
-pub use mssql_types::{FromSql, SqlValue, ToSql};
+pub use mssql_types::{FromSql, SqlTyped, SqlValue, ToSql, TypedNull, null};
 #[cfg(feature = "decimal")]
 pub use mssql_types::{Money, SmallMoney};
 pub use procedure::ProcedureBuilder;

--- a/crates/mssql-client/tests/always_encrypted.rs
+++ b/crates/mssql-client/tests/always_encrypted.rs
@@ -1025,6 +1025,105 @@ mod live_server {
         assert_eq!(g_float, 3.5, "FLOAT round-trips");
     }
 
+    /// Typed NULL (`null::<T>()`) into encrypted columns of several types: the
+    /// typed NULL carries its SQL type, so the server accepts it against the
+    /// target column (an untyped `Option::None` would be declared `nvarchar(1)`
+    /// and rejected against, e.g., the `int` or `varbinary` columns). Each
+    /// column reads back as NULL.
+    #[tokio::test]
+    #[ignore = "Requires SQL Server with Always Encrypted"]
+    async fn test_typed_null_encrypted_param_round_trip() {
+        use mssql_client::null;
+
+        let admin_cfg = match admin_config() {
+            Some(c) => c,
+            None => return,
+        };
+        let mut admin = Client::connect(admin_cfg).await.expect("admin connect");
+        let (rsa_key, pem) = fresh_rsa_keypair();
+        let cek = fresh_cek();
+        let enc = "ENCRYPTED WITH (COLUMN_ENCRYPTION_KEY = [{CEK}], \
+                   ENCRYPTION_TYPE = DETERMINISTIC, ALGORITHM = 'AEAD_AES_256_CBC_HMAC_SHA_256')";
+        let ddl = format!(
+            "CREATE TABLE [{{TABLE}}] ( Id INT NOT NULL PRIMARY KEY, \
+             EncInt INT {enc} NULL, \
+             EncBig BIGINT {enc} NULL, \
+             EncData VARBINARY(50) {enc} NULL, \
+             EncName NVARCHAR(50) COLLATE Latin1_General_BIN2 {enc} NULL )"
+        );
+        let fx = setup(&mut admin, &cek, &rsa_key, &ddl).await;
+        drop(admin);
+        let mut client = Client::connect(encrypted_config(&pem).expect("cfg"))
+            .await
+            .expect("ae connect");
+
+        let sql = format!(
+            "INSERT INTO [{}] (Id, EncInt, EncBig, EncData, EncName) \
+             VALUES (@p1, @p2, @p3, @p4, @p5)",
+            fx.table_name
+        );
+        let inserted = client
+            .execute(
+                &sql,
+                &[
+                    &1i32,
+                    &null::<i32>(),
+                    &null::<i64>(),
+                    &null::<Vec<u8>>(),
+                    &null::<String>(),
+                ],
+            )
+            .await;
+
+        // Each flag is whether that column read back as NULL.
+        let read: Result<(bool, bool, bool, bool), String> = if inserted.is_ok() {
+            let select = format!(
+                "SELECT EncInt, EncBig, EncData, EncName FROM [{}] WHERE Id = @p1",
+                fx.table_name
+            );
+            async {
+                let rows = client
+                    .query(&select, &[&1i32])
+                    .await
+                    .map_err(|e| format!("select: {e}"))?;
+                let mut found = None;
+                for r in rows {
+                    let r = r.map_err(|e| format!("row: {e}"))?;
+                    found = Some((
+                        r.try_get::<i32>(0)
+                            .map_err(|e| format!("EncInt: {e}"))?
+                            .is_none(),
+                        r.try_get::<i64>(1)
+                            .map_err(|e| format!("EncBig: {e}"))?
+                            .is_none(),
+                        r.try_get::<Vec<u8>>(2)
+                            .map_err(|e| format!("EncData: {e}"))?
+                            .is_none(),
+                        r.try_get::<String>(3)
+                            .map_err(|e| format!("EncName: {e}"))?
+                            .is_none(),
+                    ));
+                }
+                found.ok_or_else(|| "no row".to_string())
+            }
+            .await
+        } else {
+            Err("insert failed".to_string())
+        };
+
+        let mut admin = Client::connect(admin_config().expect("cfg"))
+            .await
+            .expect("admin reconnect");
+        teardown(&mut admin, &fx).await;
+
+        assert_eq!(inserted.expect("typed-NULL insert"), 1, "one row inserted");
+        let (i, b, d, n) = read.expect("read back");
+        assert!(i, "encrypted INT NULL round-trips");
+        assert!(b, "encrypted BIGINT NULL round-trips");
+        assert!(d, "encrypted VARBINARY NULL round-trips");
+        assert!(n, "encrypted NVARCHAR NULL round-trips");
+    }
+
     /// Validate the Always Encrypted metadata path end-to-end against a live
     /// server. A row with NULL in the encrypted column is the only value we
     /// can populate without parameter encryption (any non-NULL plaintext

--- a/crates/mssql-types/src/lib.rs
+++ b/crates/mssql-types/src/lib.rs
@@ -46,7 +46,7 @@ pub use decode::{Collation, TdsDecode, TypeInfo, decode_utf16_string, decode_val
 pub use encode::{TdsEncode, encode_utf16_string};
 pub use error::TypeError;
 pub use from_sql::FromSql;
-pub use to_sql::ToSql;
+pub use to_sql::{SqlTyped, ToSql, TypedNull, null};
 pub use tvp::{TvpColumnDef, TvpColumnType, TvpData, TvpError};
 #[cfg(feature = "chrono")]
 pub use value::SmallDateTime;

--- a/crates/mssql-types/src/to_sql.rs
+++ b/crates/mssql-types/src/to_sql.rs
@@ -128,6 +128,76 @@ impl ToSql for Vec<u8> {
     }
 }
 
+/// Associates a Rust type with its SQL type name so a typed NULL can be
+/// declared without a value (see [`null`]).
+///
+/// `SQL_TYPE` must match what [`ToSql::sql_type`] returns for a value of the
+/// same type.
+pub trait SqlTyped {
+    /// The SQL type name for this Rust type.
+    const SQL_TYPE: &'static str;
+}
+
+impl SqlTyped for bool {
+    const SQL_TYPE: &'static str = "BIT";
+}
+impl SqlTyped for u8 {
+    const SQL_TYPE: &'static str = "TINYINT";
+}
+impl SqlTyped for i16 {
+    const SQL_TYPE: &'static str = "SMALLINT";
+}
+impl SqlTyped for i32 {
+    const SQL_TYPE: &'static str = "INT";
+}
+impl SqlTyped for i64 {
+    const SQL_TYPE: &'static str = "BIGINT";
+}
+impl SqlTyped for f32 {
+    const SQL_TYPE: &'static str = "REAL";
+}
+impl SqlTyped for f64 {
+    const SQL_TYPE: &'static str = "FLOAT";
+}
+impl SqlTyped for String {
+    const SQL_TYPE: &'static str = "NVARCHAR";
+}
+impl SqlTyped for Vec<u8> {
+    const SQL_TYPE: &'static str = "VARBINARY";
+}
+
+/// A typed NULL parameter, created with [`null`].
+///
+/// Unlike `Option::<T>::None`, which produces an untyped NULL declared as
+/// `nvarchar(1)`, this carries its SQL type. That matters for Always Encrypted
+/// columns, whose strict typing rejects an untyped NULL bound to, for example,
+/// an `int` or `varbinary` column.
+#[derive(Debug, Clone, Copy)]
+pub struct TypedNull {
+    sql_type: &'static str,
+}
+
+impl ToSql for TypedNull {
+    fn to_sql(&self) -> Result<SqlValue, TypeError> {
+        Ok(SqlValue::Null)
+    }
+
+    fn sql_type(&self) -> &'static str {
+        self.sql_type
+    }
+}
+
+/// Create a typed NULL parameter for SQL type `T`, e.g. `null::<i32>()`.
+///
+/// Use this in place of `Option::<T>::None` when binding NULL to a strongly
+/// typed column — required for an Always Encrypted column of a non-string type.
+#[must_use]
+pub fn null<T: SqlTyped>() -> TypedNull {
+    TypedNull {
+        sql_type: T::SQL_TYPE,
+    }
+}
+
 impl<T: ToSql> ToSql for Option<T> {
     fn to_sql(&self) -> Result<SqlValue, TypeError> {
         match self {
@@ -287,6 +357,17 @@ mod tests {
         let value: i32 = 42;
         assert_eq!(value.to_sql().unwrap(), SqlValue::Int(42));
         assert_eq!(value.sql_type(), "INT");
+    }
+
+    #[test]
+    fn test_typed_null_carries_type() {
+        // A typed NULL is a NULL value that still reports its SQL type, and that
+        // type matches what a value of the same Rust type reports.
+        assert_eq!(null::<i32>().to_sql().unwrap(), SqlValue::Null);
+        assert_eq!(null::<i32>().sql_type(), 42i32.sql_type());
+        assert_eq!(null::<i64>().sql_type(), "BIGINT");
+        assert_eq!(null::<Vec<u8>>().sql_type(), "VARBINARY");
+        assert_eq!(null::<String>().sql_type(), "NVARCHAR");
     }
 
     #[test]

--- a/crates/tds-protocol/src/rpc.rs
+++ b/crates/tds-protocol/src/rpc.rs
@@ -619,6 +619,24 @@ impl RpcParam {
         }
     }
 
+    /// Create a NULL Always Encrypted parameter.
+    ///
+    /// The server rejects a plaintext parameter bound to an encrypted column,
+    /// even for NULL, so a NULL value is still sent encrypted: `BIGVARBINARY(max)`
+    /// with the `fEncrypted` status bit, a NULL value, and the cipher metadata.
+    pub fn encrypted_null(name: impl Into<String>, metadata: EncryptedParamMetadata) -> Self {
+        Self {
+            name: name.into(),
+            flags: ParamFlags {
+                encrypted: true,
+                ..ParamFlags::default()
+            },
+            type_info: TypeInfo::varbinary_max(),
+            value: None,
+            crypto_metadata: Some(metadata),
+        }
+    }
+
     /// Create an INT parameter.
     pub fn int(name: impl Into<String>, value: i32) -> Self {
         let mut buf = BytesMut::with_capacity(4);


### PR DESCRIPTION
## Summary

Fixes the NULL gap flagged in #230: inserting NULL into an encrypted column via a parameter. Adds a general typed-NULL API, **`null::<T>()`**, so NULL carries its SQL type, plus the encrypted-NULL wire form and the orchestration plumbing.

## Type of change

- [x] New feature (`null::<T>()`, `SqlTyped`, `TypedNull`, `RpcParam::encrypted_null`), non-breaking

## Why it was needed (two server-side blockers, both confirmed live)

1. **Type loss**: `Option::<i32>::None` produces an untyped `SqlValue::Null`, declared `nvarchar(1)`. The server rejects that against any non-`nvarchar` encrypted column with an `Operand type clash` at the `describe` step (confirmed for int, bigint, varbinary).
2. **Encryption required**: the server rejects a *plaintext* parameter for an encrypted column even for NULL — so a NULL must be sent encrypted.

## What it does

- **`mssql_client::null::<T>()`** returns a `TypedNull` that reports `T`'s SQL type (via a small `SqlTyped` marker trait) while its value is NULL. General-purpose, not AE-specific.
- The AE orchestration declares a typed NULL by its real type (so `describe` accepts it) and emits **`RpcParam::encrypted_null`** (`BIGVARBINARY(max)`, `fEncrypted`, NULL value, cipher metadata).
- `Option::None` is unchanged: still an untyped NULL that works for `nvarchar` columns. Use `null::<T>()` for the rest.

## Validation

- Live round-trip (runs in the 2017/2019/2022 matrix): `null::<i32>()`, `null::<i64>()`, `null::<Vec<u8>>()`, `null::<String>()` inserted into encrypted int / bigint / varbinary / nvarchar columns, each read back as NULL.
- Unit test for the `null()` contract (type carried, value NULL).

## Test plan

- [x] `just ci-all`, `just typos`, `just check-feature-flags` — green
- [x] Live ignored-only suite vs SQL 2022: **247/247**

## Notes

`SqlTyped` is currently implemented for the scalar types supported by AE so far (bool, integers, real/float, String, Vec<u8>); later type batches will add their `SqlTyped` impl alongside their normalization, extending `null::<T>()` coverage automatically.

## Breaking changes

None — all additions.