### PR TITLE
feat(encryption): Always Encrypted write/read for uuid and date

### DIFF
--- a/crates/mssql-client/src/client.rs
+++ b/crates/mssql-client/src/client.rs
@@ -170,6 +170,8 @@ fn null_param_type_info(sql_type: &str) -> Option<tds_protocol::rpc::TypeInfo> {
         "FLOAT" => TypeInfo::float(),
         "NVARCHAR" => TypeInfo::nvarchar(1),
         "VARBINARY" => TypeInfo::varbinary(1),
+        "UNIQUEIDENTIFIER" => TypeInfo::uuid(),
+        "DATE" => TypeInfo::date(),
         _ => return None,
     })
 }

--- a/crates/mssql-client/src/column_parser.rs
+++ b/crates/mssql-client/src/column_parser.rs
@@ -288,6 +288,27 @@ fn denormalize_decrypted(plaintext: Vec<u8>, base_col: &ColumnData) -> Result<Sq
         TypeId::BigVarBinary | TypeId::BigBinary | TypeId::VarBinary | TypeId::Binary => {
             Ok(SqlValue::Binary(bytes::Bytes::from(plaintext)))
         }
+        // UNIQUEIDENTIFIER: 16 bytes in SQL Server's mixed-endian order; swap
+        // the first three groups back to the RFC layout.
+        #[cfg(feature = "uuid")]
+        TypeId::Guid => {
+            let b = decrypted_array::<16>(&plaintext, "uniqueidentifier")?;
+            Ok(SqlValue::Uuid(uuid::Uuid::from_bytes([
+                b[3], b[2], b[1], b[0], b[5], b[4], b[7], b[6], b[8], b[9], b[10], b[11], b[12],
+                b[13], b[14], b[15],
+            ])))
+        }
+        // DATE: 3-byte little-endian days since 0001-01-01 (CE day 1).
+        #[cfg(feature = "chrono")]
+        TypeId::Date => {
+            let b = decrypted_array::<3>(&plaintext, "date")?;
+            let days = u32::from(b[0]) | (u32::from(b[1]) << 8) | (u32::from(b[2]) << 16);
+            chrono::NaiveDate::from_num_days_from_ce_opt(days as i32 + 1)
+                .map(SqlValue::Date)
+                .ok_or_else(|| {
+                    Error::Encryption(format!("decrypted DATE day count {days} is out of range"))
+                })
+        }
         other => Err(Error::Encryption(format!(
             "Always Encrypted read is not yet implemented for base type {other:?}"
         ))),

--- a/crates/mssql-client/src/encryption.rs
+++ b/crates/mssql-client/src/encryption.rs
@@ -673,6 +673,24 @@ pub fn normalize_for_encryption(value: &SqlValue) -> Result<Vec<u8>, EncryptionE
         SqlValue::String(s) => Ok(s.encode_utf16().flat_map(u16::to_le_bytes).collect()),
         // VARBINARY: the raw bytes, no length prefix.
         SqlValue::Binary(b) => Ok(b.to_vec()),
+        // UNIQUEIDENTIFIER: SQL Server's 16-byte mixed-endian GUID order (first
+        // three groups byte-reversed from the RFC layout, last 8 as-is).
+        #[cfg(feature = "uuid")]
+        SqlValue::Uuid(u) => {
+            let b = u.as_bytes();
+            Ok(vec![
+                b[3], b[2], b[1], b[0], b[5], b[4], b[7], b[6], b[8], b[9], b[10], b[11], b[12],
+                b[13], b[14], b[15],
+            ])
+        }
+        // DATE: 3-byte little-endian count of days since 0001-01-01.
+        // `num_days_from_ce` counts from day 1, so subtract 1.
+        #[cfg(feature = "chrono")]
+        SqlValue::Date(d) => {
+            use chrono::Datelike;
+            let days = (d.num_days_from_ce() - 1) as u32;
+            Ok(days.to_le_bytes()[..3].to_vec())
+        }
         other => Err(EncryptionError::UnsupportedOperation(format!(
             "Always Encrypted parameter encryption is not yet implemented for {}",
             other.type_name()
@@ -784,6 +802,47 @@ mod tests {
             (
                 SqlValue::Double(3.5),
                 "0171611557351FBC4561EBF0B9C98E0DC38AD2BD3E2C1D1E82F185D7E67D0425E506D11DD67BA3EB38F34FB01A8FCEF7E4B9A7256944334A521526613CFF6C8C5F",
+            ),
+        ] {
+            let norm = normalize_for_encryption(&value).unwrap();
+            let cipher = enc
+                .encrypt(&norm, mssql_auth::EncryptionType::Deterministic)
+                .unwrap();
+            assert_eq!(
+                cipher,
+                unhex(reference),
+                "ciphertext for {} must match Microsoft.Data.SqlClient",
+                value.type_name()
+            );
+        }
+    }
+
+    /// UUID and DATE normalization, validated byte-for-byte against
+    /// Microsoft.Data.SqlClient: uuid uses SQL Server's mixed-endian GUID byte
+    /// order, date is a 3-byte little-endian day count since 0001-01-01.
+    #[cfg(all(feature = "always-encrypted", feature = "uuid", feature = "chrono"))]
+    #[test]
+    fn ae_normalization_matches_dotnet_uuid_date() {
+        fn unhex(s: &str) -> Vec<u8> {
+            (0..s.len())
+                .step_by(2)
+                .map(|i| u8::from_str_radix(&s[i..i + 2], 16).unwrap())
+                .collect()
+        }
+
+        let cek = unhex("9590E42A8A6C8F13B5D09B8D5A128EF8B3A4A10301C7AF24AFC62ED0E02342F7");
+        let enc = AeadEncryptor::new(&cek).unwrap();
+
+        for (value, reference) in [
+            (
+                SqlValue::Uuid(
+                    uuid::Uuid::parse_str("01020304-0506-0708-090a-0b0c0d0e0f10").unwrap(),
+                ),
+                "01F58635AA18692D68BDF551ECDD7AC3A56682D3F91F111F8D8F36D5425C405A8F6AB3ED3C3666444478476BD65FF40DC83F6831F502826AFEEC3116F71A7A2020CCD254F4BA28FCDC0F96BA2E5264AE9E",
+            ),
+            (
+                SqlValue::Date(chrono::NaiveDate::from_ymd_opt(2024, 3, 15).unwrap()),
+                "0188B4F75A1F4BDA53C9CDDC1918C09CB57F68E13F5560F1F1D7168FE70707337B1156A97915B244F3C03D3E7352882A599511BD243471FD03683F371CF44E4B76",
             ),
         ] {
             let norm = normalize_for_encryption(&value).unwrap();

--- a/crates/mssql-client/tests/always_encrypted.rs
+++ b/crates/mssql-client/tests/always_encrypted.rs
@@ -1025,6 +1025,79 @@ mod live_server {
         assert_eq!(g_float, 3.5, "FLOAT round-trips");
     }
 
+    /// Write→read round-trip for UNIQUEIDENTIFIER and DATE: each is encrypted on
+    /// INSERT and decrypted back on SELECT, exercising the mixed-endian GUID
+    /// byte order and the 3-byte day-count date form through the live server.
+    #[cfg(all(feature = "uuid", feature = "chrono"))]
+    #[tokio::test]
+    #[ignore = "Requires SQL Server with Always Encrypted"]
+    async fn test_uuid_date_parameter_encryption_round_trip() {
+        let admin_cfg = match admin_config() {
+            Some(c) => c,
+            None => return,
+        };
+        let mut admin = Client::connect(admin_cfg).await.expect("admin connect");
+        let (rsa_key, pem) = fresh_rsa_keypair();
+        let cek = fresh_cek();
+        let enc = "ENCRYPTED WITH (COLUMN_ENCRYPTION_KEY = [{CEK}], \
+                   ENCRYPTION_TYPE = DETERMINISTIC, ALGORITHM = 'AEAD_AES_256_CBC_HMAC_SHA_256')";
+        let ddl = format!(
+            "CREATE TABLE [{{TABLE}}] ( Id INT NOT NULL PRIMARY KEY, \
+             EncUuid UNIQUEIDENTIFIER {enc} NULL, \
+             EncDate DATE {enc} NULL )"
+        );
+        let fx = setup(&mut admin, &cek, &rsa_key, &ddl).await;
+        drop(admin);
+        let mut client = Client::connect(encrypted_config(&pem).expect("cfg"))
+            .await
+            .expect("ae connect");
+
+        let uuid_val = uuid::Uuid::parse_str("01020304-0506-0708-090a-0b0c0d0e0f10").unwrap();
+        let date_val = chrono::NaiveDate::from_ymd_opt(2024, 3, 15).unwrap();
+        let sql = format!(
+            "INSERT INTO [{}] (Id, EncUuid, EncDate) VALUES (@p1, @p2, @p3)",
+            fx.table_name
+        );
+        let inserted = client.execute(&sql, &[&1i32, &uuid_val, &date_val]).await;
+
+        let read: Result<(uuid::Uuid, chrono::NaiveDate), String> = if inserted.is_ok() {
+            let select = format!(
+                "SELECT EncUuid, EncDate FROM [{}] WHERE Id = @p1",
+                fx.table_name
+            );
+            async {
+                let rows = client
+                    .query(&select, &[&1i32])
+                    .await
+                    .map_err(|e| format!("select: {e}"))?;
+                let mut found = None;
+                for r in rows {
+                    let r = r.map_err(|e| format!("row: {e}"))?;
+                    found = Some((
+                        r.get::<uuid::Uuid>(0)
+                            .map_err(|e| format!("EncUuid: {e}"))?,
+                        r.get::<chrono::NaiveDate>(1)
+                            .map_err(|e| format!("EncDate: {e}"))?,
+                    ));
+                }
+                found.ok_or_else(|| "no row".to_string())
+            }
+            .await
+        } else {
+            Err("insert failed".to_string())
+        };
+
+        let mut admin = Client::connect(admin_config().expect("cfg"))
+            .await
+            .expect("admin reconnect");
+        teardown(&mut admin, &fx).await;
+
+        assert_eq!(inserted.expect("uuid/date insert"), 1, "one row inserted");
+        let (g_uuid, g_date) = read.expect("read back");
+        assert_eq!(g_uuid, uuid_val, "UNIQUEIDENTIFIER round-trips");
+        assert_eq!(g_date, date_val, "DATE round-trips");
+    }
+
     /// Typed NULL (`null::<T>()`) into encrypted columns of several types: the
     /// typed NULL carries its SQL type, so the server accepts it against the
     /// target column (an untyped `Option::None` would be declared `nvarchar(1)`

--- a/crates/mssql-types/src/to_sql.rs
+++ b/crates/mssql-types/src/to_sql.rs
@@ -165,6 +165,14 @@ impl SqlTyped for String {
 impl SqlTyped for Vec<u8> {
     const SQL_TYPE: &'static str = "VARBINARY";
 }
+#[cfg(feature = "uuid")]
+impl SqlTyped for uuid::Uuid {
+    const SQL_TYPE: &'static str = "UNIQUEIDENTIFIER";
+}
+#[cfg(feature = "chrono")]
+impl SqlTyped for chrono::NaiveDate {
+    const SQL_TYPE: &'static str = "DATE";
+}
 
 /// A typed NULL parameter, created with [`null`].
 ///

--- a/crates/tds-protocol/src/rpc.rs
+++ b/crates/tds-protocol/src/rpc.rs
@@ -350,6 +350,18 @@ impl TypeInfo {
         }
     }
 
+    /// Create type info for UNIQUEIDENTIFIER.
+    pub fn uuid() -> Self {
+        Self {
+            type_id: 0x24, // GUIDTYPE
+            max_length: Some(16),
+            precision: None,
+            scale: None,
+            collation: None,
+            tvp_type_name: None,
+        }
+    }
+
     /// Create type info for DATE.
     pub fn date() -> Self {
         Self {


### PR DESCRIPTION
## Summary

Phase 3b, batch 2: parameter encryption + decryption for **uniqueidentifier** and **date** (gated on the `uuid`/`chrono` features), continuing toward the complete AE write path before 0.16.0.

## Type of change

- [x] New feature, non-breaking

## How each normalization was determined

Captured from a live `Microsoft.Data.SqlClient` deterministic INSERT and decrypted to reveal the exact normalized bytes:
- **uuid → 16 bytes in SQL Server's mixed-endian GUID order** (first three groups byte-reversed from the RFC layout).
- **date → 3-byte little-endian day count since 0001-01-01**.

Both mirror the existing read-path byte order, so decryption denormalizes consistently.

## Validation (both interop directions)

- **Write**: `ae_normalization_matches_dotnet_uuid_date` asserts normalize+encrypt reproduces .NET's ciphertext byte-for-byte.
- **Read**: `test_uuid_date_parameter_encryption_round_trip` (live, 2017/2019/2022 matrix) encrypts a uuid and a date on INSERT and decrypts them back on SELECT.

## Also

- `null::<Uuid>()` / `null::<NaiveDate>()` now work into encrypted columns (`SqlTyped` impls + the declaration mapping + a new `TypeInfo::uuid()`).

## Test plan

- [x] `just ci-all`, `just typos`, `just check-feature-flags` — green
- [x] Live ignored-only suite vs SQL 2022: **248/248**

## Remaining 3b

decimal/money (scale-dependent — `normalize` signature will likely need precision/scale) → the date/time family (time, datetime2, datetimeoffset, datetime, smalldatetime) → char/varchar/nchar/binary → describe caching → live cross-client interop.

## Breaking changes

None.