### PR TITLE
feat(encryption): Always Encrypted write/read for decimal and money

### DIFF
--- a/crates/mssql-client/src/column_parser.rs
+++ b/crates/mssql-client/src/column_parser.rs
@@ -309,6 +309,31 @@ fn denormalize_decrypted(plaintext: Vec<u8>, base_col: &ColumnData) -> Result<Sq
                     Error::Encryption(format!("decrypted DATE day count {days} is out of range"))
                 })
         }
+        // DECIMAL/NUMERIC: 1 sign byte + 16-byte little-endian magnitude; the
+        // base type's scale rescales the unscaled integer.
+        #[cfg(feature = "decimal")]
+        TypeId::Decimal | TypeId::Numeric | TypeId::DecimalN | TypeId::NumericN => {
+            let b = decrypted_array::<17>(&plaintext, "decimal")?;
+            let mut mag = [0u8; 16];
+            mag.copy_from_slice(&b[1..17]);
+            let magnitude = u128::from_le_bytes(mag) as i128;
+            let signed = if b[0] == 0 { -magnitude } else { magnitude };
+            let scale = u32::from(base_col.type_info.scale.unwrap_or(0));
+            rust_decimal::Decimal::try_from_i128_with_scale(signed, scale)
+                .map(SqlValue::Decimal)
+                .map_err(|e| Error::Encryption(format!("decrypted DECIMAL out of range: {e}")))
+        }
+        // MONEY/SMALLMONEY both normalize to the 8-byte MONEY form.
+        #[cfg(feature = "decimal")]
+        TypeId::Money | TypeId::Money4 | TypeId::MoneyN => {
+            if plaintext.len() != 8 {
+                return Err(Error::Encryption(format!(
+                    "decrypted MONEY has {} bytes, expected 8",
+                    plaintext.len()
+                )));
+            }
+            parse_money_value(&mut plaintext.as_slice(), 8)
+        }
         other => Err(Error::Encryption(format!(
             "Always Encrypted read is not yet implemented for base type {other:?}"
         ))),

--- a/crates/mssql-client/src/encryption.rs
+++ b/crates/mssql-client/src/encryption.rs
@@ -691,11 +691,48 @@ pub fn normalize_for_encryption(value: &SqlValue) -> Result<Vec<u8>, EncryptionE
             let days = (d.num_days_from_ce() - 1) as u32;
             Ok(days.to_le_bytes()[..3].to_vec())
         }
+        // DECIMAL/NUMERIC: 1 sign byte (0 negative, 1 positive) + 16-byte
+        // little-endian unscaled magnitude. Uses the value's own scale.
+        #[cfg(feature = "decimal")]
+        SqlValue::Decimal(d) => {
+            let mut out = Vec::with_capacity(17);
+            out.push(u8::from(!d.is_sign_negative()));
+            out.extend_from_slice(&d.mantissa().unsigned_abs().to_le_bytes());
+            Ok(out)
+        }
+        // MONEY and SMALLMONEY both normalize to the 8-byte MONEY form: the
+        // value scaled by 10_000 as an i64, high 32 bits then low 32 bits.
+        #[cfg(feature = "decimal")]
+        SqlValue::Money(d) | SqlValue::SmallMoney(d) => {
+            let cents = money_cents(d)?;
+            let mut out = ((cents >> 32) as i32).to_le_bytes().to_vec();
+            out.extend_from_slice(&(cents as u32).to_le_bytes());
+            Ok(out)
+        }
         other => Err(EncryptionError::UnsupportedOperation(format!(
             "Always Encrypted parameter encryption is not yet implemented for {}",
             other.type_name()
         ))),
     }
+}
+
+/// The MONEY fixed-point value (`value * 10_000`) as an `i64`, rounding excess
+/// precision toward zero. Used by both MONEY and SMALLMONEY normalization.
+#[cfg(all(feature = "always-encrypted", feature = "decimal"))]
+fn money_cents(value: &rust_decimal::Decimal) -> Result<i64, EncryptionError> {
+    let mantissa = value.mantissa();
+    let scale = value.scale();
+    let cents: i128 = if scale <= 4 {
+        mantissa
+            .checked_mul(10_i128.pow(4 - scale))
+            .ok_or_else(|| {
+                EncryptionError::UnsupportedOperation("MONEY value out of range".into())
+            })?
+    } else {
+        mantissa / 10_i128.pow(scale - 4)
+    };
+    i64::try_from(cents)
+        .map_err(|_| EncryptionError::UnsupportedOperation("MONEY value out of range".into()))
 }
 
 #[cfg(test)]
@@ -843,6 +880,52 @@ mod tests {
             (
                 SqlValue::Date(chrono::NaiveDate::from_ymd_opt(2024, 3, 15).unwrap()),
                 "0188B4F75A1F4BDA53C9CDDC1918C09CB57F68E13F5560F1F1D7168FE70707337B1156A97915B244F3C03D3E7352882A599511BD243471FD03683F371CF44E4B76",
+            ),
+        ] {
+            let norm = normalize_for_encryption(&value).unwrap();
+            let cipher = enc
+                .encrypt(&norm, mssql_auth::EncryptionType::Deterministic)
+                .unwrap();
+            assert_eq!(
+                cipher,
+                unhex(reference),
+                "ciphertext for {} must match Microsoft.Data.SqlClient",
+                value.type_name()
+            );
+        }
+    }
+
+    /// DECIMAL and MONEY/SMALLMONEY normalization, validated byte-for-byte
+    /// against Microsoft.Data.SqlClient: decimal is a sign byte plus a 16-byte
+    /// little-endian unscaled magnitude; money and smallmoney both use the
+    /// 8-byte MONEY form (value × 10_000, high then low 32 bits).
+    #[cfg(all(feature = "always-encrypted", feature = "decimal"))]
+    #[test]
+    fn ae_normalization_matches_dotnet_decimal_money() {
+        fn unhex(s: &str) -> Vec<u8> {
+            (0..s.len())
+                .step_by(2)
+                .map(|i| u8::from_str_radix(&s[i..i + 2], 16).unwrap())
+                .collect()
+        }
+
+        let cek = unhex("CBFB5AE21FB517C65DA0C6E8E11969C630798E473EF5827A70398012DF1D4B9E");
+        let enc = AeadEncryptor::new(&cek).unwrap();
+        let dec = rust_decimal::Decimal::new(123_456_789, 4); // 12345.6789
+        let money = rust_decimal::Decimal::new(123_400, 4); // 12.3400
+
+        for (value, reference) in [
+            (
+                SqlValue::Decimal(dec),
+                "018FAE46024B9B406C23600E6A9C694F9A9B39B785A995689EBE19437BA7E75768011A035A5B54B5E495512EBB46AE1146130940A0D0D834D61AA89B5AD9F71FFAF6EEEAE77E4856BA2AA5E016E2950A8D",
+            ),
+            (
+                SqlValue::Money(money),
+                "01B4CE4CAD8D6B241A1555C377A0ADD4C79424DD5162F710D116594F725C1BAB015169A0C7716076EEC90E013519B961DEF427BFC32462D9E45D166C791B73F793",
+            ),
+            (
+                SqlValue::SmallMoney(money),
+                "01B4CE4CAD8D6B241A1555C377A0ADD4C79424DD5162F710D116594F725C1BAB015169A0C7716076EEC90E013519B961DEF427BFC32462D9E45D166C791B73F793",
             ),
         ] {
             let norm = normalize_for_encryption(&value).unwrap();

--- a/crates/mssql-client/tests/always_encrypted.rs
+++ b/crates/mssql-client/tests/always_encrypted.rs
@@ -1098,6 +1098,91 @@ mod live_server {
         assert_eq!(g_date, date_val, "DATE round-trips");
     }
 
+    /// Write→read round-trip for MONEY and SMALLMONEY: each is encrypted on
+    /// INSERT and decrypted back on SELECT as a scale-4 decimal. (DECIMAL value
+    /// encryption is implemented and byte-exact-validated, but binding a decimal
+    /// parameter to an encrypted column also needs its precision/scale to match
+    /// the column — a typed-parameter follow-up — so it is not round-tripped
+    /// here yet.)
+    #[cfg(feature = "decimal")]
+    #[tokio::test]
+    #[ignore = "Requires SQL Server with Always Encrypted"]
+    async fn test_money_parameter_encryption_round_trip() {
+        let admin_cfg = match admin_config() {
+            Some(c) => c,
+            None => return,
+        };
+        let mut admin = Client::connect(admin_cfg).await.expect("admin connect");
+        let (rsa_key, pem) = fresh_rsa_keypair();
+        let cek = fresh_cek();
+        let enc = "ENCRYPTED WITH (COLUMN_ENCRYPTION_KEY = [{CEK}], \
+                   ENCRYPTION_TYPE = DETERMINISTIC, ALGORITHM = 'AEAD_AES_256_CBC_HMAC_SHA_256')";
+        let ddl = format!(
+            "CREATE TABLE [{{TABLE}}] ( Id INT NOT NULL PRIMARY KEY, \
+             EncMoney MONEY {enc} NULL, \
+             EncSmallMoney SMALLMONEY {enc} NULL )"
+        );
+        let fx = setup(&mut admin, &cek, &rsa_key, &ddl).await;
+        drop(admin);
+        let mut client = Client::connect(encrypted_config(&pem).expect("cfg"))
+            .await
+            .expect("ae connect");
+
+        let money = rust_decimal::Decimal::new(123_400, 4); // 12.3400
+        let sql = format!(
+            "INSERT INTO [{}] (Id, EncMoney, EncSmallMoney) VALUES (@p1, @p2, @p3)",
+            fx.table_name
+        );
+        let inserted = client
+            .execute(
+                &sql,
+                &[
+                    &1i32,
+                    &mssql_client::Money(money),
+                    &mssql_client::SmallMoney(money),
+                ],
+            )
+            .await;
+
+        let read: Result<(rust_decimal::Decimal, rust_decimal::Decimal), String> =
+            if inserted.is_ok() {
+                let select = format!(
+                    "SELECT EncMoney, EncSmallMoney FROM [{}] WHERE Id = @p1",
+                    fx.table_name
+                );
+                async {
+                    let rows = client
+                        .query(&select, &[&1i32])
+                        .await
+                        .map_err(|e| format!("select: {e}"))?;
+                    let mut found = None;
+                    for r in rows {
+                        let r = r.map_err(|e| format!("row: {e}"))?;
+                        found = Some((
+                            r.get::<rust_decimal::Decimal>(0)
+                                .map_err(|e| format!("EncMoney: {e}"))?,
+                            r.get::<rust_decimal::Decimal>(1)
+                                .map_err(|e| format!("EncSmallMoney: {e}"))?,
+                        ));
+                    }
+                    found.ok_or_else(|| "no row".to_string())
+                }
+                .await
+            } else {
+                Err("insert failed".to_string())
+            };
+
+        let mut admin = Client::connect(admin_config().expect("cfg"))
+            .await
+            .expect("admin reconnect");
+        teardown(&mut admin, &fx).await;
+
+        assert_eq!(inserted.expect("money insert"), 1, "one row inserted");
+        let (g_money, g_smallmoney) = read.expect("read back");
+        assert_eq!(g_money, money, "MONEY round-trips");
+        assert_eq!(g_smallmoney, money, "SMALLMONEY round-trips");
+    }
+
     /// Typed NULL (`null::<T>()`) into encrypted columns of several types: the
     /// typed NULL carries its SQL type, so the server accepts it against the
     /// target column (an untyped `Option::None` would be declared `nvarchar(1)`


### PR DESCRIPTION
## Summary

Phase 3b, batch 3: parameter encryption + decryption for **decimal/numeric, money, smallmoney**.

## Type of change

- [x] New feature, non-breaking

## Normalizations (captured from live .NET, decrypted to reveal the bytes)

- **decimal** → 1 sign byte (`01` positive / `00` negative) + 16-byte little-endian unscaled magnitude (`value × 10^scale`).
- **money / smallmoney** → identical 8-byte MONEY form (`value × 10000` as i64, high 32 bits then low 32 bits). Smallmoney normalizes as money.

## Validation

- **Byte-exact vs .NET** for all three (`ae_normalization_matches_dotnet_decimal_money`).
- **Live round-trip** for money/smallmoney (read back as a scale-4 decimal).

## Decimal caveat (and the next step)

decimal value encryption is implemented and byte-exact-validated, but a live decimal round-trip is **deferred to a follow-up**. AE requires a parameter's declared `decimal(p,s)` to match the encrypted column **exactly**, and a `rust_decimal::Decimal` value can't carry the column's *precision* (only its scale) — so the driver declares `decimal(38, scale)`, which the server rejects against, say, `decimal(18,4)`. This is the same class of issue as the typed-NULL gap, and needs a precision/scale-aware decimal parameter API. **This is the decision I'd like your input on next** (see the report). It's all unreleased (0.16.0), so decimal lands complete before release.

## Test plan

- [x] `just ci-all`, `just typos`, `just check-feature-flags` — green
- [x] Live ignored-only suite vs SQL 2022: **249/249**

## Breaking changes

None.