### PR TITLE
docs: correct Always Encrypted write-path claims + tighten two claim-reality tests

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -868,7 +868,7 @@ alongside the response-streaming work.
 
 **Status:** Implemented
 
-**Decision:** Always Encrypted client-side decryption (the read path) is fully implemented with production-ready key providers. The encrypt-before-send write path is not yet implemented (only `NULL` can be written to encrypted columns); see LIMITATIONS.md.
+**Decision:** Always Encrypted client-side decryption (the read path) is fully implemented with production-ready key providers. The encrypt-before-send write path is implemented for the common scalar types — parameters are described via `sp_describe_parameter_encryption` and encrypted client-side; the remaining temporal and fixed-width types are pending (#234). See LIMITATIONS.md.
 
 **Implemented (v0.2.0):**
 - AEAD_AES_256_CBC_HMAC_SHA256 encryption/decryption

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ An async Microsoft SQL Server driver for Rust.
 - **Type-state connections** — invalid operations are compile errors
 - **Pure-Rust TLS** — rustls; no OpenSSL, no system dependencies
 - **Beyond queries** — transactions and savepoints, stored procedures with OUTPUT
-  params, table-valued parameters, bulk insert, Always Encrypted (read),
+  params, table-valued parameters, bulk insert, Always Encrypted (read + write),
   OpenTelemetry
 
 ## Installation
@@ -214,7 +214,8 @@ Known gaps, so you don't have to discover them yourself:
 
 - Kerberos/GSSAPI and FILESTREAM are implemented but not yet validated against
   live infrastructure.
-- Always Encrypted writes support `NULL` only; reads are fully transparent.
+- Always Encrypted reads are fully transparent; writes cover the common scalar
+  types (some temporal and fixed-width types are pending — see LIMITATIONS.md).
 - Rows decode lazily, but the response is buffered in memory — true streaming
   from the socket is planned.
 - Parameterized queries run via `sp_executesql` (the server still reuses

--- a/crates/mssql-auth/src/azure_identity_auth.rs
+++ b/crates/mssql-auth/src/azure_identity_auth.rs
@@ -364,10 +364,24 @@ mod tests {
 
     #[test]
     fn test_debug_redacts_credentials() {
-        // Just verify Debug impl doesn't panic and doesn't expose secrets
         if let Ok(auth) = ManagedIdentityAuth::system_assigned() {
             let debug = format!("{auth:?}");
             assert!(debug.contains("ManagedIdentityAuth"));
         }
+
+        // The client secret must never appear in the Debug output.
+        let secret = "client-secret-must-not-appear-in-debug";
+        let auth = ServicePrincipalAuth::new(
+            "00000000-0000-0000-0000-000000000000",
+            "11111111-1111-1111-1111-111111111111",
+            secret,
+        )
+        .expect("constructing a service principal credential should not fail offline");
+        let debug = format!("{auth:?}");
+        assert!(
+            !debug.contains(secret),
+            "Debug output must not expose the client secret"
+        );
+        assert!(debug.contains("[REDACTED]"));
     }
 }

--- a/crates/mssql-auth/tests/ae_interop.rs
+++ b/crates/mssql-auth/tests/ae_interop.rs
@@ -9,11 +9,14 @@
 //! with data encrypted by .NET/SSMS/JDBC. Self-roundtrip tests cannot catch
 //! a derivation that is internally consistent but non-conformant.
 //!
-//! The fixture is cross-validated against Microsoft's shipped binary:
-//! Microsoft.Data.SqlClient 5.2.2 (`SqlAeadAes256CbcHmac256Algorithm`,
-//! invoked via reflection) produces this exact blob for the same
-//! CEK/plaintext and decrypts it back. End-to-end validation against a
-//! live server (the wire-metadata path) is tracked in issue #87.
+//! The blob was additionally cross-checked out-of-band against Microsoft's
+//! shipped binary — Microsoft.Data.SqlClient 5.2.2
+//! (`SqlAeadAes256CbcHmac256Algorithm`, invoked via reflection) produced the
+//! same bytes for this CEK/plaintext and decrypted it back. That harness is not
+//! committed, so the in-repo guarantee rests on the transcription above; the
+//! reflection check is a manual, out-of-band confirmation. End-to-end
+//! validation against a live server (the wire-metadata path) is tracked in
+//! issue #87.
 
 #![cfg(feature = "always-encrypted")]
 #![allow(clippy::expect_used)]


### PR DESCRIPTION
## Summary

Remediation of the actionable findings from two independent repo reviews. Both reviewed `main` *before* PR #235 merged, so the decimal finding and most doc drift were already addressed there; this PR closes the remainder.

## Changes

**Doc accuracy (under-claim of the shipped AE write path — the reviews' top finding):**
- `README.md`: "writes support `NULL` only" → writes cover the common scalar types (temporal/fixed-width pending, #234); feature list now says "Always Encrypted (read + write)".
- `ARCHITECTURE.md` ADR-013: decision text no longer says "write path is not yet implemented" (it contradicted its own `Status: Implemented`).
- (`encryption.rs` module doc, `LIMITATIONS.md`, `CLAUDE.md` were already corrected in #235; `crates/` rustdoc was already accurate.)

**Claim-reality test fixes:**
- `ae_interop.rs`: the reflection cross-check against `Microsoft.Data.SqlClient` is out-of-band (harness not committed); the comment now says so, pointing the in-repo guarantee at the committed transcription.
- `test_debug_redacts_credentials`: previously only checked the secret-less `ManagedIdentityAuth` and asserted the type name. Now asserts a `ServicePrincipalAuth` Debug omits a sentinel secret.

## Not included (reported separately for decision)

- The v0.16.0 changelog dropped `c75e7a2` (a docs-only commit) via release-plz path-attribution — a real omission (my earlier release verification missed it).
- Low-severity refinements (panicking-but-unreachable date arithmetic, a few assertion-free connection-string tests, stale doc-version markers, mega-function size) — candidates for a tracked issue.

## Validation

`just ci-all`, `just typos`, `just check-feature-flags` all green. The redaction test passes offline (`cargo nextest -p mssql-auth --features azure-identity`).