### PR TITLE
0.16.1: numeric() precision validation, AE decimal docs, Road to 1.0, test/marker polish

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # Architectural Reference: Rust MS SQL Driver
 
 **Version:** 1.9.0
-**Status:** Design Complete
+**Status:** Implemented and maintained (tracks the released `0.x` crates)
 **Target Protocol:** MS-TDS 7.3 – 8.0 (SQL Server 2008 – 2025)
 **Toolchain Standard:** Rust 2024 Edition (v1.85+, released February 20, 2025)
 **MSRV Policy:** Rust 1.88.0 (6-month rolling window aligned with Tokio's policy)

--- a/LIMITATIONS.md
+++ b/LIMITATIONS.md
@@ -237,6 +237,13 @@ parameterized query or `execute` automatically describes its parameters
 client-side, and sends them as encrypted RPC parameters. Both deterministic and
 randomized encryption are supported.
 
+Bind a `decimal` parameter to an encrypted column with `numeric(value, precision,
+scale)`, not a plain `Decimal`. An encrypted `decimal` column requires the declared
+precision and scale to match exactly; a plain `Decimal` carries no precision, so it
+is rejected with `Operand type clash` (Msg 206). `numeric` also rejects, client-side,
+a value whose significant digits exceed the declared precision (the server cannot
+range-check an encrypted value).
+
 Not yet implemented:
 - Parameter encryption for `datetime`, `datetime2`, `time`, `datetimeoffset`,
   `char`, `nchar`, and `binary`: these require a typed-parameter API (the
@@ -396,4 +403,4 @@ If you need a feature not listed here:
 
 ---
 
-*Last updated: April 2026 (v0.10.0)*
+*Last updated: June 2026.*

--- a/STABILITY.md
+++ b/STABILITY.md
@@ -26,6 +26,33 @@ After 1.0.0 is released:
 - Deprecated APIs will remain functional for at least one minor release
 - Security fixes may be backported to supported versions
 
+### Road to 1.0
+
+We are deliberately staying in the `0.x` series until the criteria below hold.
+Pre-1.0, a breaking change is a minor bump (see above) — this is the correct,
+expressive way to evolve an API that is still settling, and a premature 1.0 we
+then break would be worse than honest `0.x`. 1.0 is the *end* of a deliberate
+API-stabilisation process, not a milestone to rush.
+
+Criteria for 1.0:
+
+1. **All public dependencies are themselves ≥1.0.** Per the
+   [Rust API Guidelines](https://rust-lang.github.io/api-guidelines/necessities.html)
+   (C-STABLE), a crate cannot be stable while a type from a pre-1.0 dependency
+   appears in its public API. This is currently the hard blocker (tracked under
+   the `1.0-blocker` label).
+2. **The public API surface is frozen and future-proofed** — error enums
+   `#[non_exhaustive]` (done), public structs with private fields or
+   `#[non_exhaustive]`, sealed extension traits (e.g. the SQL↔Rust type-mapping
+   traits) so methods can be added without a breaking change, `#[must_use]` on
+   builders and futures.
+3. **A published support pledge** — once 1.0 ships we commit to maintaining the
+   1.0 line and a minimum interval before any 2.0, paired with the existing
+   rolling MSRV policy. We will not declare 1.0 until we can make and honour
+   such a pledge.
+
+Progress toward these is tracked in the **Road to 1.0** milestone.
+
 ### Security Support
 
 The latest released minor version receives security fixes. Pre-1.0, older minor

--- a/crates/mssql-client/src/encryption.rs
+++ b/crates/mssql-client/src/encryption.rs
@@ -66,8 +66,15 @@
 //! driver describes the parameters (`sp_describe_parameter_encryption`),
 //! encrypts those bound to encrypted columns client-side, and sends them as
 //! encrypted RPC parameters (deterministic and randomized). The remaining
-//! temporal and fixed-width types are not yet supported and return an error
-//! rather than sending plaintext.
+//! temporal types (`datetime`, `datetime2`, `time`, `datetimeoffset`) and the
+//! fixed-width `char`/`nchar`/`binary` types are not yet supported and return an
+//! error rather than sending plaintext.
+//!
+//! Bind a `decimal` parameter with `numeric(value, precision, scale)`, not a
+//! plain `Decimal`: an encrypted `decimal` column requires the declared
+//! precision and scale to match the column exactly, and a plain `Decimal` does
+//! not carry a precision — so it is rejected by the server with `Operand type
+//! clash` (Msg 206) at the describe step.
 //!
 //! ## Security Model
 //!

--- a/crates/mssql-client/tests/edge_cases.rs
+++ b/crates/mssql-client/tests/edge_cases.rs
@@ -349,10 +349,10 @@ fn test_connection_string_with_special_characters_in_password() {
 
 #[test]
 fn test_connection_string_empty_values() {
-    // Empty database (should use default)
-    let result = Config::from_connection_string("Server=localhost;Database=;User Id=sa;Password=x");
-    // Should parse without error
-    let _ = result;
+    // An empty database value still parses; the rest of the config is unaffected.
+    let config = Config::from_connection_string("Server=localhost;Database=;User Id=sa;Password=x")
+        .expect("empty database value should parse");
+    assert_eq!(config.host, "localhost");
 }
 
 #[test]
@@ -382,22 +382,23 @@ fn test_connection_string_case_insensitivity() {
 
 #[test]
 fn test_connection_string_whitespace_handling() {
-    // Whitespace around separators
-    let result = Config::from_connection_string(
+    // Whitespace around keys and values is trimmed (ADO.NET conformance).
+    let config = Config::from_connection_string(
         "Server = localhost ; Database = test ; User Id = sa ; Password = x",
-    );
-    // Whitespace may or may not be trimmed depending on implementation
-    let _ = result;
+    )
+    .expect("whitespace-padded connection string should parse");
+    assert_eq!(config.host, "localhost");
+    assert_eq!(config.database.as_deref(), Some("test"));
 }
 
 #[test]
 fn test_connection_string_duplicate_keywords() {
-    // Last value should win for duplicate keywords
-    let result = Config::from_connection_string(
+    // Last value wins for duplicate keywords (ADO.NET conformance).
+    let config = Config::from_connection_string(
         "Server=first;Server=second;Database=test;User Id=sa;Password=x",
-    );
-    // Should parse without error
-    let _ = result;
+    )
+    .expect("duplicate keywords should parse");
+    assert_eq!(config.host, "second");
 }
 
 // =============================================================================

--- a/crates/mssql-types/src/to_sql.rs
+++ b/crates/mssql-types/src/to_sql.rs
@@ -297,8 +297,14 @@ pub struct Numeric {
 /// Create a `decimal`/`numeric` parameter with explicit precision and scale.
 ///
 /// Required when binding to an Always Encrypted `decimal` column, whose declared
-/// `decimal(precision, scale)` must match the column exactly. The value is
-/// rescaled to `scale`.
+/// `decimal(precision, scale)` must match the column exactly.
+///
+/// The value is rescaled to `scale`, which **rounds** when the value has more
+/// fractional digits than `scale` (e.g. `numeric(dec!(12.999), 18, 2)` stores
+/// `13.00`). If the rescaled value has more significant digits than `precision`,
+/// [`ToSql::to_sql`] returns an error rather than silently storing a value
+/// outside the column's domain — the server cannot range-check an encrypted
+/// value, so the client enforces it.
 #[cfg(feature = "decimal")]
 #[must_use]
 pub fn numeric(value: rust_decimal::Decimal, precision: u8, scale: u8) -> Numeric {
@@ -314,6 +320,24 @@ impl ToSql for Numeric {
     fn to_sql(&self) -> Result<SqlValue, TypeError> {
         let mut value = self.value;
         value.rescale(u32::from(self.scale));
+        // The server cannot range-check an encrypted value, so a value that
+        // exceeds the declared precision must be rejected client-side rather
+        // than silently stored out of the column's domain (matches the
+        // Always Encrypted behaviour of Microsoft.Data.SqlClient). After
+        // rescaling, the magnitude bound `|mantissa| < 10^precision` is exactly
+        // the `decimal(precision, scale)` domain.
+        let mantissa = value.mantissa().unsigned_abs();
+        let digits = if mantissa == 0 {
+            0
+        } else {
+            mantissa.ilog10() + 1
+        };
+        if digits > u32::from(self.precision) {
+            return Err(TypeError::InvalidDecimal(format!(
+                "value has {digits} significant digits, which exceeds the declared precision {}",
+                self.precision
+            )));
+        }
         Ok(SqlValue::Decimal(value))
     }
 
@@ -470,5 +494,27 @@ mod tests {
 
         let none: Option<i32> = None;
         assert_eq!(none.to_sql().unwrap(), SqlValue::Null);
+    }
+
+    #[cfg(feature = "decimal")]
+    #[test]
+    fn test_numeric_precision_validation() {
+        use rust_decimal::Decimal;
+
+        // Fits: a scale-2 value declared decimal(18,4) rescales without loss.
+        assert!(numeric(Decimal::new(1_234_567, 2), 18, 4).to_sql().is_ok());
+
+        // Exceeds declared precision: 6 significant digits into decimal(4,0).
+        assert!(
+            numeric(Decimal::new(123_456, 0), 4, 0).to_sql().is_err(),
+            "value exceeding the declared precision must error"
+        );
+
+        // Rounds (does not error) when the value scale exceeds the declared scale.
+        let rounded = numeric(Decimal::new(12_999, 3), 18, 2).to_sql().unwrap();
+        assert_eq!(rounded, SqlValue::Decimal(Decimal::new(1_300, 2)));
+
+        // Zero fits any precision.
+        assert!(numeric(Decimal::ZERO, 1, 0).to_sql().is_ok());
     }
 }


### PR DESCRIPTION
Cuts **v0.16.1** (correctness & polish) and lands the planning scaffolding.

## Correctness (#238)
- `fix(types)`: `numeric(value, precision, scale)` now rejects a value whose significant digits exceed the declared precision. The server can't range-check an *encrypted* value, so this is enforced client-side (matches `Microsoft.Data.SqlClient`). Unit test added; live AE decimal/money round-trips still green.
- Docs: bind encrypted decimals with `numeric()`, not a plain `Decimal` (which errors with Msg 206); precise unsupported-type list (temporal + `char`/`nchar`/`binary`).

## Planning scaffolding
- `STABILITY.md`: new **Road to 1.0** section (C-STABLE gate, frozen API surface, support pledge, rationale for staying 0.x). Pairs with the new `Road to 1.0` milestone + `1.0-blocker` label.
- (GitHub side, already applied: 6 release milestones with issues assigned, area labels.)

## Polish (#237)
- Three assertion-free connection-string tests now assert what their comments promised (parses / whitespace trimmed / last-duplicate-wins).
- Stale markers refreshed: ARCHITECTURE status, LIMITATIONS footer date.

## Deferred (kept in their issues)
- `#237`: the date-arithmetic consistency swap and the mega-function decomposition both touch the hot `column_parser`; folding them into the decode-stack convergence (#204, milestone 0.18.0) is the right time.
- `#184` (changelog-drop CI guard): moved to a later milestone.

## Validation
`just ci-all`, `just typos`, `just check-feature-flags` all green; live AE decimal/money round-trips pass against the local SQL Server 2022 container.