### PR TITLE
feat(streaming): Stage 3 RowStream cancellation + abandoned-stream recovery

### DIFF
--- a/STABILITY.md
+++ b/STABILITY.md
@@ -70,7 +70,7 @@ The following APIs are considered stable and covered by semver guarantees:
 | `Client::connect()` | Stable |
 | `Client::query()` | Stable |
 | `Client::query_stream()` | Stable |
-| `RowStream` (`try_next` / `collect_all` / `columns`) | Stable |
+| `RowStream` (`try_next` / `collect_all` / `cancel` / `columns`) | Stable |
 | `Client::execute()` | Stable |
 | `Client::close()` | Stable |
 | `Client::begin_transaction()` | Stable |

--- a/crates/mssql-client/src/client.rs
+++ b/crates/mssql-client/src/client.rs
@@ -238,6 +238,47 @@ impl<S: ConnectionState> Client<S> {
         }
     }
 
+    /// Cancel an in-flight response that was abandoned without being drained —
+    /// e.g. a [`RowStream`](crate::RowStream) dropped or cancelled mid-result.
+    ///
+    /// Sends an Attention and drains to the server's DONE_ATTN acknowledgement so
+    /// the socket is clean and the connection reusable. A no-op when nothing is
+    /// in flight. Bounded by [`ATTENTION_ACK_TIMEOUT`]: if the acknowledgement
+    /// never arrives the connection is left marked in-flight (so the pool
+    /// discards it on return) and an error is returned.
+    pub(crate) async fn cancel_in_flight_response(&mut self) -> Result<()> {
+        if !self.in_flight {
+            return Ok(());
+        }
+        let canceller = self.connection_cancel_handle();
+        let drain = async {
+            canceller.cancel().await?;
+            // With the cancelling flag set, `read_response_message` routes through
+            // the codec's drain-after-cancel path and returns `Err(Cancelled)`
+            // once the DONE_ATTN acknowledgement is consumed (clearing
+            // `in_flight`). Any full messages that arrive before the ack are
+            // discarded.
+            loop {
+                match self.read_response_message().await {
+                    Err(Error::Cancelled) => return Ok(()),
+                    Ok(_) => continue,
+                    Err(e) => return Err(e),
+                }
+            }
+        };
+        match tokio::time::timeout(ATTENTION_ACK_TIMEOUT, drain).await {
+            Ok(result) => result,
+            Err(_) => {
+                tracing::warn!(
+                    timeout = ?ATTENTION_ACK_TIMEOUT,
+                    "attention acknowledgement not received while cancelling an \
+                     abandoned response; connection left dirty"
+                );
+                Err(Error::Cancelled)
+            }
+        }
+    }
+
     /// Process transaction-related EnvChange tokens.
     ///
     /// This handles BeginTransaction, CommitTransaction, and RollbackTransaction
@@ -280,6 +321,11 @@ impl<S: ConnectionState> Client<S> {
     /// If `needs_reset` is set (from pool return), the RESETCONNECTION flag
     /// is included in the first packet to reset connection state.
     async fn send_sql_batch(&mut self, sql: &str) -> Result<()> {
+        // If a previous streamed response was abandoned (a RowStream dropped
+        // mid-result), drain it before issuing a new request so the next read
+        // does not pick up the old response's bytes.
+        self.cancel_in_flight_response().await?;
+
         let payload =
             tds_protocol::encode_sql_batch_with_transaction(sql, self.transaction_descriptor);
         let max_packet = self.config.packet_size as usize;
@@ -321,6 +367,10 @@ impl<S: ConnectionState> Client<S> {
     /// If `needs_reset` is set (from pool return), the RESETCONNECTION flag
     /// is included in the first packet to reset connection state.
     pub(crate) async fn send_rpc(&mut self, rpc: &RpcRequest) -> Result<()> {
+        // Drain an abandoned streamed response (see `send_sql_batch`) before
+        // issuing this request.
+        self.cancel_in_flight_response().await?;
+
         let payload = rpc.encode_with_transaction(self.transaction_descriptor);
         let max_packet = self.config.packet_size as usize;
 

--- a/crates/mssql-client/src/row_stream.rs
+++ b/crates/mssql-client/src/row_stream.rs
@@ -172,6 +172,25 @@ impl<'a> RowStream<'a> {
         Ok(out)
     }
 
+    /// Stop the stream early and leave the connection reusable.
+    ///
+    /// Sends an Attention to the server and drains to its acknowledgement so the
+    /// connection is clean for the next request — the correct way to abandon a
+    /// large result set you no longer need.
+    ///
+    /// Calling this is optional: simply **dropping** a partially-read stream is
+    /// safe but leaves the connection marked in-flight, so a pooled connection
+    /// is discarded on return and a directly reused client recovers it (with an
+    /// Attention/drain) on its next request. `cancel` avoids that discard and
+    /// reports any error from the cancellation.
+    pub async fn cancel(mut self) -> Result<()> {
+        if self.finished {
+            return Ok(());
+        }
+        self.finished = true;
+        self.client.cancel_in_flight_response().await
+    }
+
     /// Mark the stream finished and the connection clean for the next request.
     fn finish(&mut self) {
         self.finished = true;

--- a/crates/mssql-client/tests/query_stream.rs
+++ b/crates/mssql-client/tests/query_stream.rs
@@ -149,6 +149,99 @@ async fn query_stream_surfaces_server_error() {
     );
 }
 
+/// A large result set whose response spans many packets — used so that
+/// stopping early genuinely leaves unsent rows on the wire.
+const BIG_QUERY: &str = "\
+    WITH n AS (SELECT 1 AS i UNION ALL SELECT i + 1 FROM n WHERE i < 100000) \
+    SELECT i FROM n OPTION (MAXRECURSION 0)";
+
+/// `cancel()` mid-stream leaves the connection reusable for the next request.
+#[tokio::test]
+#[ignore = "Requires SQL Server"]
+async fn cancel_mid_stream_then_reuse() {
+    let Some(cfg) = get_test_config() else {
+        return;
+    };
+    let mut client = Client::connect(cfg).await.expect("connect");
+
+    {
+        let mut stream = client.query_stream(BIG_QUERY, &[]).await.expect("stream");
+        // Pull a few rows, then abandon the rest (100k rows still pending).
+        for _ in 0..5 {
+            stream.try_next().await.expect("row").expect("a row");
+        }
+        stream.cancel().await.expect("cancel must succeed");
+    }
+
+    // The connection must be clean: a fresh query returns the right answer.
+    let rows = client
+        .query("SELECT 7 AS v", &[])
+        .await
+        .expect("reuse after cancel")
+        .collect_all()
+        .await
+        .expect("collect");
+    assert_eq!(rows[0].get_by_name::<i32>("v").unwrap(), 7);
+}
+
+/// Dropping a stream mid-result leaves the connection in-flight; a directly
+/// reused client recovers it (Attention/drain) on the next request.
+#[tokio::test]
+#[ignore = "Requires SQL Server"]
+async fn drop_mid_stream_then_reuse() {
+    let Some(cfg) = get_test_config() else {
+        return;
+    };
+    let mut client = Client::connect(cfg).await.expect("connect");
+
+    {
+        let mut stream = client.query_stream(BIG_QUERY, &[]).await.expect("stream");
+        for _ in 0..5 {
+            stream.try_next().await.expect("row").expect("a row");
+        }
+        // Drop without cancel/drain — 100k rows still pending on the wire.
+    }
+
+    // The next request must recover the abandoned response, not read its bytes.
+    let rows = client
+        .query("SELECT 11 AS v", &[])
+        .await
+        .expect("reuse after drop")
+        .collect_all()
+        .await
+        .expect("collect");
+    assert_eq!(rows[0].get_by_name::<i32>("v").unwrap(), 11);
+}
+
+/// `cancel()` on a fully drained stream is a no-op.
+#[tokio::test]
+#[ignore = "Requires SQL Server"]
+async fn cancel_after_full_drain_is_noop() {
+    let Some(cfg) = get_test_config() else {
+        return;
+    };
+    let mut client = Client::connect(cfg).await.expect("connect");
+
+    let mut stream = client
+        .query_stream("SELECT TOP 2 object_id FROM sys.objects", &[])
+        .await
+        .expect("stream");
+    while stream.try_next().await.expect("row").is_some() {}
+    stream
+        .cancel()
+        .await
+        .expect("cancel after drain is a no-op");
+
+    let rows = client
+        .query("SELECT 1 AS v", &[])
+        .await
+        .expect("reuse")
+        .collect_all()
+        .await
+        .expect("collect");
+    assert_eq!(rows[0].get_by_name::<i32>("v").unwrap(), 1);
+}
+
 /// Parameterized streaming works (sp_executesql path).
 #[tokio::test]
 #[ignore = "Requires SQL Server"]

--- a/public-api/mssql-client.txt
+++ b/public-api/mssql-client.txt
@@ -2195,6 +2195,7 @@ pub fn mssql_client::row::RowIter<'a>::vzip(self) -> V
 pub mod mssql_client::row_stream
 pub struct mssql_client::row_stream::RowStream<'a>
 impl<'a> mssql_client::row_stream::RowStream<'a>
+pub async fn mssql_client::row_stream::RowStream<'a>::cancel(self) -> mssql_client::error::Result<()>
 pub async fn mssql_client::row_stream::RowStream<'a>::collect_all(self) -> mssql_client::error::Result<alloc::vec::Vec<mssql_client::row::Row>>
 pub fn mssql_client::row_stream::RowStream<'a>::columns(&self) -> &[mssql_client::row::Column]
 pub fn mssql_client::row_stream::RowStream<'a>::is_finished(&self) -> bool
@@ -5582,6 +5583,7 @@ impl<V, T> ppv_lite86::types::VZip<V> for mssql_client::row::Row where V: ppv_li
 pub fn mssql_client::row::Row::vzip(self) -> V
 pub struct mssql_client::RowStream<'a>
 impl<'a> mssql_client::row_stream::RowStream<'a>
+pub async fn mssql_client::row_stream::RowStream<'a>::cancel(self) -> mssql_client::error::Result<()>
 pub async fn mssql_client::row_stream::RowStream<'a>::collect_all(self) -> mssql_client::error::Result<alloc::vec::Vec<mssql_client::row::Row>>
 pub fn mssql_client::row_stream::RowStream<'a>::columns(&self) -> &[mssql_client::row::Column]
 pub fn mssql_client::row_stream::RowStream<'a>::is_finished(&self) -> bool


### PR DESCRIPTION
## Summary

Stage 3 of the streaming redesign (follows #252 / Stage 2). Makes early termination of a `RowStream` safe and explicit.

- **`RowStream::cancel(self).await`** — sends an Attention and drains to the server's DONE_ATTN acknowledgement, leaving the connection reusable. The correct way to abandon a large result set you no longer need.
- **Dropping** a partially-read stream is also safe. It leaves the connection marked in-flight; the pool already discards in-flight connections on return (unchanged), and a **directly reused client now recovers** the abandoned response automatically: `send_sql_batch` / `send_rpc` first drain any in-flight response (shared `Client::cancel_in_flight_response`, bounded by `ATTENTION_ACK_TIMEOUT`) before issuing the next request.

Reuses the existing split-I/O Attention path (ADR-005) — no protocol changes.

## Why the recovery guard matters (falsification)

Without the guard, dropping a stream mid-result and running another query on the same client reads the *abandoned* rows as the new response. Proven: with the guard removed, `drop_mid_stream_then_reuse` fails with

```
ProtocolError(StringEncoding("Row token requires column metadata"))
```

i.e. the next `SELECT` parsed stale row bytes. With the guard, it passes.

## Testing

Live-verified vs SQL Server 2022 (`tests/query_stream.rs`):
- `cancel_mid_stream_then_reuse` — cancel after 5 of 100k rows, reuse client.
- `drop_mid_stream_then_reuse` — drop after 5 of 100k rows, reuse client (auto-recovers).
- `cancel_after_full_drain_is_noop` — cancel after End is a no-op.

Full local gauntlet green (`just ci-all && just typos && just check-feature-flags && just public-api` + live ignored suite). Public API additive (`RowStream::cancel`).

## Scope / follow-ups (v0.18.0 milestone)

- Stage 4: PLP/BLOB sub-streaming (the remaining single-giant-cell OOM case).
- Stage 5: multi-result-set boundary introspection in the streaming path.
- Stage 6: cleanup / benchmarks / docs.