### PR TITLE
feat(streaming): Stage 4 BLOB sub-streaming via query_stream_blob

### DIFF
--- a/STABILITY.md
+++ b/STABILITY.md
@@ -71,6 +71,8 @@ The following APIs are considered stable and covered by semver guarantees:
 | `Client::query()` | Stable |
 | `Client::query_stream()` | Stable |
 | `RowStream` (`try_next` / `collect_all` / `cancel` / `columns`) | Stable |
+| `Client::query_stream_blob()` | Stable |
+| `BlobStream` (`next` / `read_chunk` / `copy_blob_to` / `columns`) | Stable |
 | `Client::execute()` | Stable |
 | `Client::close()` | Stable |
 | `Client::begin_transaction()` | Stable |

--- a/crates/mssql-client/src/blob_stream.rs
+++ b/crates/mssql-client/src/blob_stream.rs
@@ -1,0 +1,359 @@
+//! Streaming a row's trailing MAX column directly from the socket.
+//!
+//! [`Client::query_stream_blob`](crate::Client::query_stream_blob) targets the
+//! one OOM case the row streaming of [`RowStream`](crate::RowStream) does not
+//! cover: a single MAX cell (`VARBINARY(MAX)`, `NVARCHAR(MAX)`, `VARCHAR(MAX)`,
+//! `XML`) larger than memory. Row streaming bounds peak to ~one row, but a row
+//! holding a 4 GB BLOB is still ~4 GB because the whole PLP value is decoded
+//! into the row.
+//!
+//! [`BlobStream`] decodes each row's **leading scalar columns** into a [`Row`]
+//! (they are small), then exposes the **trailing MAX column** as a chunk stream
+//! pulled from the connection on demand via the `PlpDecoder`. Peak memory is
+//! one packet plus one PLP chunk.
+//!
+//! Because TDS sends columns inline and sequentially, the MAX column must be the
+//! **last** column (anything after it could not be decoded until the BLOB was
+//! consumed). The blob of one row must be consumed before the next row; calling
+//! [`BlobStream::next`] auto-drains an unconsumed blob so the wire stays aligned.
+//!
+//! ```no_run
+//! # async fn ex(client: &mut mssql_client::Client<mssql_client::Ready>) -> Result<(), mssql_client::Error> {
+//! # let mut sink: Vec<u8> = Vec::new();
+//! let mut stream = client
+//!     .query_stream_blob("SELECT id, document FROM files", &[])
+//!     .await?;
+//! while let Some(row) = stream.next().await? {
+//!     let id: i32 = row.get_by_name("id")?;
+//!     let _ = id;
+//!     stream.copy_blob_to(&mut sink).await?; // streamed, never fully buffered
+//! }
+//! # Ok(())
+//! # }
+//! ```
+
+use bytes::{Buf, Bytes, BytesMut};
+use tds_protocol::ProtocolError;
+use tds_protocol::token::{ColMetaData, ColumnData, NbcRow, RawRow, Token, TokenParser};
+use tds_protocol::types::TypeId;
+
+use crate::Client;
+use crate::client::response::server_token_to_error;
+use crate::error::{Error, Result};
+use crate::plp::{PlpDecoder, PlpEvent};
+use crate::row::{Column, Row};
+use crate::state::Ready;
+
+/// Whether a column is a PLP-encoded MAX type that this path can sub-stream.
+pub(crate) fn is_plp_max(col: &ColumnData) -> bool {
+    match col.type_id {
+        TypeId::BigVarChar | TypeId::BigVarBinary | TypeId::NVarChar => {
+            col.type_info.max_length == Some(0xFFFF)
+        }
+        TypeId::Xml => true,
+        _ => false,
+    }
+}
+
+/// A stream of rows whose trailing MAX column is read incrementally from the
+/// socket. See the [module docs](self). Obtain one from
+/// [`Client::query_stream_blob`](crate::Client::query_stream_blob).
+#[must_use = "streams must be consumed; dropping a stream discards remaining rows"]
+pub struct BlobStream<'a> {
+    client: &'a mut Client<Ready>,
+    /// Unconsumed wire bytes (post-metadata), shared by the column decode and
+    /// the PLP chunk streaming.
+    buf: Bytes,
+    /// END_OF_MESSAGE seen — no more packets will arrive.
+    eom: bool,
+    encryption_enabled: bool,
+    /// Full result-set metadata (all columns, including the trailing MAX one).
+    meta: ColMetaData,
+    /// Metadata for just the leading scalar columns (for row decoding).
+    prefix_meta: ColMetaData,
+    /// `Column`s for the leading scalar columns.
+    scalar_columns: Vec<Column>,
+    /// Index of the trailing MAX column.
+    blob_index: usize,
+    /// PLP decoder for the current row's blob; `Some` between `next` and drain.
+    plp: Option<PlpDecoder>,
+    /// The current row's blob is NULL (an NBCROW omitted its value).
+    blob_null: bool,
+    finished: bool,
+}
+
+impl<'a> BlobStream<'a> {
+    pub(crate) fn new(
+        client: &'a mut Client<Ready>,
+        buf: Bytes,
+        eom: bool,
+        encryption_enabled: bool,
+        meta: ColMetaData,
+        blob_index: usize,
+    ) -> Self {
+        let prefix_meta = ColMetaData {
+            columns: meta.columns.iter().take(blob_index).cloned().collect(),
+            cek_table: meta.cek_table.clone(),
+        };
+        let scalar_columns = Client::<Ready>::build_columns(&prefix_meta);
+        Self {
+            client,
+            buf,
+            eom,
+            encryption_enabled,
+            meta,
+            prefix_meta,
+            scalar_columns,
+            blob_index,
+            plp: None,
+            blob_null: false,
+            finished: true, // set false once construction succeeds below
+        }
+        .started()
+    }
+
+    fn started(mut self) -> Self {
+        self.finished = false;
+        self
+    }
+
+    /// The leading (scalar) columns of the result set — everything except the
+    /// trailing MAX column.
+    #[must_use]
+    pub fn columns(&self) -> &[Column] {
+        &self.scalar_columns
+    }
+
+    /// Advance to the next row, returning its scalar columns.
+    ///
+    /// Auto-drains the previous row's blob if it was not fully read, so the wire
+    /// stays aligned. Returns `Ok(None)` at end of stream (connection clean).
+    pub async fn next(&mut self) -> Result<Option<Row>> {
+        if self.finished {
+            return Ok(None);
+        }
+        self.drain_current_blob().await?;
+
+        loop {
+            if self.buf.is_empty() {
+                if !self.pull_packet().await? {
+                    self.finish();
+                    return Ok(None);
+                }
+                continue;
+            }
+            match self.buf[0] {
+                0xD1 => return Ok(Some(self.decode_row().await?)),
+                0xD2 => return Ok(Some(self.decode_nbc_row().await?)),
+                _ => match self.parse_control_token().await? {
+                    Control::Finished => {
+                        self.finish();
+                        return Ok(None);
+                    }
+                    Control::Continue => continue,
+                },
+            }
+        }
+    }
+
+    /// Read the next chunk of the current row's blob, or `None` when it is fully
+    /// read (or NULL). Reads more packets from the socket as needed.
+    pub async fn read_chunk(&mut self) -> Result<Option<Bytes>> {
+        loop {
+            let event = match self.plp.as_mut() {
+                Some(plp) if !plp.is_done() => plp.pull(&mut self.buf)?,
+                _ => return Ok(None),
+            };
+            match event {
+                PlpEvent::Data(d) => return Ok(Some(d)),
+                PlpEvent::End => return Ok(None),
+                PlpEvent::NeedMore => {
+                    if !self.pull_packet().await? {
+                        return Err(Error::ConnectionClosed);
+                    }
+                }
+            }
+        }
+    }
+
+    /// Stream the current row's blob to an async writer, returning bytes written.
+    pub async fn copy_blob_to<W>(&mut self, w: &mut W) -> Result<u64>
+    where
+        W: tokio::io::AsyncWrite + Unpin,
+    {
+        use tokio::io::AsyncWriteExt;
+        let mut total = 0u64;
+        while let Some(chunk) = self.read_chunk().await? {
+            w.write_all(&chunk).await.map_err(Error::from)?;
+            total += chunk.len() as u64;
+        }
+        Ok(total)
+    }
+
+    /// The current row's blob length in bytes, once known (after the first
+    /// chunk is read). `None` before that, for a NULL blob, or for an
+    /// unknown-length value.
+    #[must_use]
+    pub fn blob_len(&self) -> Option<u64> {
+        if self.blob_null {
+            return None;
+        }
+        self.plp.as_ref().and_then(PlpDecoder::total_len)
+    }
+
+    /// Whether the current row's blob is NULL.
+    #[must_use]
+    pub fn blob_is_null(&self) -> bool {
+        self.blob_null
+    }
+
+    fn finish(&mut self) {
+        self.finished = true;
+        self.client.note_response_drained();
+    }
+
+    async fn decode_row(&mut self) -> Result<Row> {
+        loop {
+            let mut view: &[u8] = &self.buf[..];
+            let before = view.len();
+            view.advance(1); // ROW token byte
+            match RawRow::decode_prefix(&mut view, &self.meta, self.blob_index) {
+                Ok(raw) => {
+                    let consumed = before - view.len();
+                    self.buf.advance(consumed);
+                    let row = crate::column_parser::convert_raw_row(
+                        &raw,
+                        &self.prefix_meta,
+                        &self.scalar_columns,
+                    )?;
+                    self.plp = Some(PlpDecoder::new());
+                    self.blob_null = false;
+                    return Ok(row);
+                }
+                Err(ProtocolError::UnexpectedEof) if !self.eom => {
+                    self.pull_packet().await?;
+                }
+                Err(e) => return Err(e.into()),
+            }
+        }
+    }
+
+    async fn decode_nbc_row(&mut self) -> Result<Row> {
+        loop {
+            let mut view: &[u8] = &self.buf[..];
+            let before = view.len();
+            view.advance(1); // NBCROW token byte
+            match NbcRow::decode_prefix(&mut view, &self.meta, self.blob_index) {
+                Ok(nbc) => {
+                    let consumed = before - view.len();
+                    self.buf.advance(consumed);
+                    let blob_null = nbc.is_null(self.blob_index);
+                    let row = crate::column_parser::convert_nbc_row(
+                        &nbc,
+                        &self.prefix_meta,
+                        &self.scalar_columns,
+                    )?;
+                    self.blob_null = blob_null;
+                    self.plp = if blob_null {
+                        None
+                    } else {
+                        Some(PlpDecoder::new())
+                    };
+                    return Ok(row);
+                }
+                Err(ProtocolError::UnexpectedEof) if !self.eom => {
+                    self.pull_packet().await?;
+                }
+                Err(e) => return Err(e.into()),
+            }
+        }
+    }
+
+    /// Parse a single non-row token (Done / Error / Info / …) and decide whether
+    /// the stream continues or has finished.
+    async fn parse_control_token(&mut self) -> Result<Control> {
+        loop {
+            let mut parser =
+                TokenParser::new(self.buf.clone()).with_encryption(self.encryption_enabled);
+            match parser.next_token_with_metadata(Some(&self.meta)) {
+                Ok(Some(token)) => {
+                    let consumed = self.buf.len() - parser.remaining();
+                    self.buf.advance(consumed);
+                    return self.classify(token);
+                }
+                Ok(None) => {
+                    if self.eom {
+                        return Ok(Control::Finished);
+                    }
+                    self.pull_packet().await?;
+                }
+                Err(ProtocolError::UnexpectedEof | ProtocolError::IncompletePacket { .. })
+                    if !self.eom =>
+                {
+                    self.pull_packet().await?;
+                }
+                Err(e) => return Err(e.into()),
+            }
+        }
+    }
+
+    fn classify(&mut self, token: Token) -> Result<Control> {
+        match token {
+            Token::Done(d) => {
+                if d.status.error {
+                    return Err(Error::Query(
+                        "query failed (server set error flag in DONE token)".to_string(),
+                    ));
+                }
+                Ok(if d.status.more {
+                    Control::Continue
+                } else {
+                    Control::Finished
+                })
+            }
+            Token::Error(e) => Err(server_token_to_error(&e)),
+            Token::ColMetaData(_) => Err(Error::Protocol(
+                "query_stream_blob does not support multiple result sets".to_string(),
+            )),
+            // DoneProc / DoneInProc / Info / Order / EnvChange / etc.
+            _ => Ok(Control::Continue),
+        }
+    }
+
+    async fn drain_current_blob(&mut self) -> Result<()> {
+        if self.plp.is_some() && !self.blob_null {
+            while self.read_chunk().await?.is_some() {}
+        }
+        self.plp = None;
+        self.blob_null = false;
+        Ok(())
+    }
+
+    /// Pull one packet onto the rolling buffer. Returns `false` at EOF.
+    async fn pull_packet(&mut self) -> Result<bool> {
+        match self.client.read_response_packet().await? {
+            Some((payload, is_eom)) => {
+                if self.buf.is_empty() {
+                    self.buf = payload;
+                } else {
+                    let mut joined = BytesMut::with_capacity(self.buf.len() + payload.len());
+                    joined.extend_from_slice(&self.buf);
+                    joined.extend_from_slice(&payload);
+                    self.buf = joined.freeze();
+                }
+                self.eom |= is_eom;
+                Ok(true)
+            }
+            None => {
+                self.eom = true;
+                Ok(false)
+            }
+        }
+    }
+}
+
+/// Outcome of parsing a non-row control token.
+enum Control {
+    Continue,
+    Finished,
+}

--- a/crates/mssql-client/src/client.rs
+++ b/crates/mssql-client/src/client.rs
@@ -1264,6 +1264,121 @@ impl Client<Ready> {
         }
     }
 
+    /// Execute a query and stream a row's trailing MAX column from the network.
+    ///
+    /// For result sets whose last column is a single MAX type
+    /// (`VARBINARY(MAX)`, `NVARCHAR(MAX)`, `VARCHAR(MAX)`, `XML`), this reads
+    /// that column's bytes incrementally from the socket instead of
+    /// materializing the cell — so a multi-GB BLOB can be streamed to a sink in
+    /// bounded memory. The leading (scalar) columns are decoded eagerly into the
+    /// per-row [`Row`](crate::Row).
+    ///
+    /// The MAX column must be the **last** column. The returned
+    /// [`BlobStream`](crate::BlobStream) yields scalar [`Row`](crate::Row)s via
+    /// [`next`](crate::BlobStream::next); read each row's blob with
+    /// [`read_chunk`](crate::BlobStream::read_chunk) /
+    /// [`copy_blob_to`](crate::BlobStream::copy_blob_to) before advancing.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the result set has no trailing MAX column, has more
+    /// than one MAX column, the MAX column is not last, or the result set uses
+    /// Always Encrypted (not yet supported on this path).
+    pub async fn query_stream_blob<'a>(
+        &'a mut self,
+        sql: &str,
+        params: &[&(dyn crate::ToSql + Sync)],
+    ) -> Result<crate::blob_stream::BlobStream<'a>> {
+        use crate::client::response::server_token_to_error;
+        use crate::row_source::{Pull, RowSource};
+        use tds_protocol::token::Token;
+
+        if params.is_empty() {
+            self.send_sql_batch(sql).await?;
+        } else {
+            let rpc = self.build_parameterized_rpc(sql, params).await?;
+            self.send_rpc(&rpc).await?;
+        }
+        self.in_flight = true;
+
+        #[cfg(feature = "always-encrypted")]
+        let encryption_enabled = self.encryption_context.is_some();
+        #[cfg(not(feature = "always-encrypted"))]
+        let encryption_enabled = false;
+
+        let mut source = RowSource::new(encryption_enabled);
+
+        loop {
+            match source.pull()? {
+                Pull::Token(Token::ColMetaData(meta)) => {
+                    let blob_index = Self::validate_blob_result_set(&meta)?;
+                    let (buf, eom) = source.into_parts();
+                    return Ok(crate::blob_stream::BlobStream::new(
+                        self,
+                        buf,
+                        eom,
+                        encryption_enabled,
+                        meta,
+                        blob_index,
+                    ));
+                }
+                Pull::Token(Token::Error(err)) => {
+                    self.in_flight = false;
+                    return Err(server_token_to_error(&err));
+                }
+                Pull::Token(Token::Done(_)) => {
+                    self.in_flight = false;
+                    return Err(Error::Protocol(
+                        "query_stream_blob: query produced no result set".to_string(),
+                    ));
+                }
+                Pull::Token(_) => {}
+                Pull::NeedMore => match self.read_response_packet().await? {
+                    Some((payload, is_eom)) => source.push_packet(payload, is_eom),
+                    None => {
+                        self.in_flight = false;
+                        return Err(Error::ConnectionClosed);
+                    }
+                },
+                Pull::End => {
+                    self.in_flight = false;
+                    return Err(Error::Protocol(
+                        "query_stream_blob: query produced no result set".to_string(),
+                    ));
+                }
+            }
+        }
+    }
+
+    /// Validate that a result set is shaped for [`query_stream_blob`] and return
+    /// the index of its single trailing MAX column.
+    fn validate_blob_result_set(meta: &tds_protocol::token::ColMetaData) -> Result<usize> {
+        if meta.cek_table.is_some() {
+            return Err(Error::Protocol(
+                "query_stream_blob does not support Always Encrypted result sets".to_string(),
+            ));
+        }
+        let max_cols: Vec<usize> = meta
+            .columns
+            .iter()
+            .enumerate()
+            .filter(|(_, c)| crate::blob_stream::is_plp_max(c))
+            .map(|(i, _)| i)
+            .collect();
+        match max_cols.as_slice() {
+            [] => Err(Error::Protocol(
+                "query_stream_blob: result set has no MAX column — use query_stream".to_string(),
+            )),
+            [idx] if *idx == meta.columns.len() - 1 => Ok(*idx),
+            [_] => Err(Error::Protocol(
+                "query_stream_blob: the MAX column must be the last column".to_string(),
+            )),
+            _ => Err(Error::Protocol(
+                "query_stream_blob: result set has more than one MAX column".to_string(),
+            )),
+        }
+    }
+
     /// Execute a query with a specific timeout.
     ///
     /// This overrides the default `command_timeout` from the connection configuration

--- a/crates/mssql-client/src/lib.rs
+++ b/crates/mssql-client/src/lib.rs
@@ -18,6 +18,7 @@
 //   column_parser ──→ error, mssql_types, tds_protocol
 
 pub mod blob;
+pub mod blob_stream;
 pub(crate) mod browser;
 pub mod bulk;
 pub mod cancel;
@@ -142,6 +143,7 @@ pub use state::{
 pub mod __fuzzing {
     pub use crate::column_parser::parse_column_value;
 }
+pub use blob_stream::BlobStream;
 pub use row_stream::RowStream;
 pub use stream::{
     ExecuteResult, MultiResultStream, OutputParam, ProcedureResult, QueryStream, ResultSet,
@@ -233,6 +235,12 @@ mod auto_trait_tests {
     fn row_stream_is_send_sync() {
         assert_send::<RowStream<'_>>();
         assert_sync::<RowStream<'_>>();
+    }
+
+    #[test]
+    fn blob_stream_is_send_sync() {
+        assert_send::<BlobStream<'_>>();
+        assert_sync::<BlobStream<'_>>();
     }
 
     #[test]

--- a/crates/mssql-client/src/plp.rs
+++ b/crates/mssql-client/src/plp.rs
@@ -17,14 +17,9 @@
 //! Peak memory is one chunk slice, not the whole value.
 //!
 //! This module is sans-IO: it never touches a socket. The async BLOB reader
-//! drives it by reading packets and refilling the buffer, exactly as
-//! [`RowSource`](crate::row_source::RowSource) drives token decoding.
-//!
-//! This is the engine; its socket-backed caller lands in a following step, so
-//! non-test builds currently see it as unused.
-
-// Foundation landed before its caller (same pattern as the Stage 1 row source).
-#![allow(dead_code)]
+//! ([`BlobStream`](crate::BlobStream)) drives it by reading packets and
+//! refilling the buffer, exactly as [`RowSource`](crate::row_source::RowSource)
+//! drives token decoding.
 
 use bytes::{Buf, Bytes};
 

--- a/crates/mssql-client/src/row_source.rs
+++ b/crates/mssql-client/src/row_source.rs
@@ -99,6 +99,13 @@ impl RowSource {
         self.eom
     }
 
+    /// Consume the source, returning its unconsumed buffer and end-of-message
+    /// flag. Used to hand the post-metadata buffer to the BLOB streaming path,
+    /// which decodes rows column-by-column rather than whole-row.
+    pub(crate) fn into_parts(self) -> (Bytes, bool) {
+        (self.buf, self.eom)
+    }
+
     /// Attempt to decode the next token from the buffered bytes.
     ///
     /// Returns [`Pull::Token`] on success (advancing past the consumed bytes),

--- a/crates/mssql-client/tests/blob_stream.rs
+++ b/crates/mssql-client/tests/blob_stream.rs
@@ -1,0 +1,187 @@
+//! Live correctness tests for BLOB sub-streaming
+//! ([`Client::query_stream_blob`]).
+//!
+//! ```text
+//! MSSQL_HOST=localhost MSSQL_PASSWORD='YourStrong@Passw0rd' \
+//!   cargo nextest run -p mssql-client --test blob_stream --run-ignored ignored-only
+//! ```
+
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use mssql_client::{Client, Config, Error};
+
+fn get_test_config() -> Option<Config> {
+    let host = std::env::var("MSSQL_HOST").ok()?;
+    let port = std::env::var("MSSQL_PORT").unwrap_or_else(|_| "1433".into());
+    let user = std::env::var("MSSQL_USER").unwrap_or_else(|_| "sa".into());
+    let password = std::env::var("MSSQL_PASSWORD").unwrap_or_else(|_| "YourStrong@Passw0rd".into());
+    let conn_str = format!(
+        "Server={host},{port};Database=master;User Id={user};Password={password};\
+         TrustServerCertificate=true"
+    );
+    Config::from_connection_string(&conn_str).ok()
+}
+
+/// One row: scalar column + a 100 KB VARBINARY(MAX) blob streamed to a sink.
+#[tokio::test]
+#[ignore = "Requires SQL Server"]
+async fn blob_stream_single_varbinary_max() {
+    let Some(cfg) = get_test_config() else {
+        return;
+    };
+    let mut client = Client::connect(cfg).await.expect("connect");
+
+    // 100_000 bytes of 0x41 ('A') as VARBINARY(MAX).
+    const SQL: &str = "SELECT 1 AS id, \
+        CAST(REPLICATE(CAST('A' AS VARCHAR(MAX)), 100000) AS VARBINARY(MAX)) AS doc";
+
+    let mut stream = client.query_stream_blob(SQL, &[]).await.expect("stream");
+    let row = stream.next().await.expect("next").expect("one row");
+    assert_eq!(row.get_by_name::<i32>("id").unwrap(), 1);
+
+    let mut sink: Vec<u8> = Vec::new();
+    let n = stream.copy_blob_to(&mut sink).await.expect("copy blob");
+    assert_eq!(n, 100_000);
+    assert_eq!(sink.len(), 100_000);
+    assert!(sink.iter().all(|&b| b == 0x41), "all bytes must be 'A'");
+
+    assert!(stream.next().await.expect("next").is_none());
+}
+
+/// Multiple rows, each with its own streamed blob, read via read_chunk.
+#[tokio::test]
+#[ignore = "Requires SQL Server"]
+async fn blob_stream_multiple_rows() {
+    let Some(cfg) = get_test_config() else {
+        return;
+    };
+    let mut client = Client::connect(cfg).await.expect("connect");
+
+    // Three rows; row n has a blob of n*10000 bytes of value n.
+    const SQL: &str = "SELECT n AS id, \
+        CAST(REPLICATE(CAST(CHAR(64 + n) AS VARCHAR(MAX)), n * 10000) AS VARBINARY(MAX)) AS doc \
+        FROM (VALUES (1), (2), (3)) v(n)";
+
+    let mut stream = client.query_stream_blob(SQL, &[]).await.expect("stream");
+    let mut seen = Vec::new();
+    while let Some(row) = stream.next().await.expect("next") {
+        let id: i32 = row.get_by_name("id").unwrap();
+        let mut buf = Vec::new();
+        while let Some(chunk) = stream.read_chunk().await.expect("chunk") {
+            buf.extend_from_slice(&chunk);
+        }
+        let expected_byte = 0x40 + id as u8; // 'A' for 1, 'B' for 2, ...
+        assert_eq!(buf.len(), (id as usize) * 10000);
+        assert!(buf.iter().all(|&b| b == expected_byte));
+        seen.push(id);
+    }
+    assert_eq!(seen, vec![1, 2, 3]);
+}
+
+/// Advancing without reading a blob auto-drains it; the next row is intact.
+#[tokio::test]
+#[ignore = "Requires SQL Server"]
+async fn blob_stream_auto_drain_on_advance() {
+    let Some(cfg) = get_test_config() else {
+        return;
+    };
+    let mut client = Client::connect(cfg).await.expect("connect");
+
+    const SQL: &str = "SELECT n AS id, \
+        CAST(REPLICATE(CAST('Z' AS VARCHAR(MAX)), 50000) AS VARBINARY(MAX)) AS doc \
+        FROM (VALUES (1), (2), (3)) v(n)";
+
+    let mut stream = client.query_stream_blob(SQL, &[]).await.expect("stream");
+    let mut ids = Vec::new();
+    // Never read any blob — each next() must auto-drain the previous one.
+    while let Some(row) = stream.next().await.expect("next") {
+        ids.push(row.get_by_name::<i32>("id").unwrap());
+    }
+    assert_eq!(ids, vec![1, 2, 3]);
+
+    // Connection must be clean afterwards.
+    let rows = client
+        .query("SELECT 99 AS v", &[])
+        .await
+        .expect("reuse")
+        .collect_all()
+        .await
+        .expect("collect");
+    assert_eq!(rows[0].get_by_name::<i32>("v").unwrap(), 99);
+}
+
+/// A NULL blob (exercises the NBCROW path) yields no chunks.
+#[tokio::test]
+#[ignore = "Requires SQL Server"]
+async fn blob_stream_null_blob() {
+    let Some(cfg) = get_test_config() else {
+        return;
+    };
+    let mut client = Client::connect(cfg).await.expect("connect");
+
+    const SQL: &str = "SELECT 1 AS id, CAST(NULL AS VARBINARY(MAX)) AS doc";
+
+    let mut stream = client.query_stream_blob(SQL, &[]).await.expect("stream");
+    let row = stream.next().await.expect("next").expect("one row");
+    assert_eq!(row.get_by_name::<i32>("id").unwrap(), 1);
+    assert!(stream.blob_is_null());
+    assert!(stream.read_chunk().await.expect("chunk").is_none());
+    assert!(stream.next().await.expect("next").is_none());
+}
+
+/// An NVARCHAR(MAX) text blob streams its UTF-16LE bytes.
+#[tokio::test]
+#[ignore = "Requires SQL Server"]
+async fn blob_stream_nvarchar_max() {
+    let Some(cfg) = get_test_config() else {
+        return;
+    };
+    let mut client = Client::connect(cfg).await.expect("connect");
+
+    const SQL: &str = "SELECT 1 AS id, \
+        REPLICATE(CAST(N'A' AS NVARCHAR(MAX)), 50000) AS doc";
+
+    let mut stream = client.query_stream_blob(SQL, &[]).await.expect("stream");
+    let _ = stream.next().await.expect("next").expect("one row");
+    let mut buf = Vec::new();
+    while let Some(chunk) = stream.read_chunk().await.expect("chunk") {
+        buf.extend_from_slice(&chunk);
+    }
+    // 50_000 'A' chars in UTF-16LE = 100_000 bytes of (0x41, 0x00).
+    assert_eq!(buf.len(), 100_000);
+    assert!(buf.chunks(2).all(|c| c == [0x41, 0x00]));
+}
+
+/// Validation: a result set with no MAX column is rejected.
+#[tokio::test]
+#[ignore = "Requires SQL Server"]
+async fn blob_stream_rejects_no_max_column() {
+    let Some(cfg) = get_test_config() else {
+        return;
+    };
+    let mut client = Client::connect(cfg).await.expect("connect");
+    let result = client
+        .query_stream_blob("SELECT 1 AS id, 2 AS j", &[])
+        .await;
+    assert!(
+        matches!(result, Err(Error::Protocol(_))),
+        "expected Protocol error for no MAX column"
+    );
+}
+
+/// Validation: the MAX column must be last.
+#[tokio::test]
+#[ignore = "Requires SQL Server"]
+async fn blob_stream_rejects_non_trailing_max() {
+    let Some(cfg) = get_test_config() else {
+        return;
+    };
+    let mut client = Client::connect(cfg).await.expect("connect");
+    let result = client
+        .query_stream_blob("SELECT CAST('x' AS VARCHAR(MAX)) AS doc, 1 AS id", &[])
+        .await;
+    assert!(
+        matches!(result, Err(Error::Protocol(_))),
+        "expected Protocol error for non-trailing MAX column"
+    );
+}

--- a/crates/mssql-client/tests/streaming_memory.rs
+++ b/crates/mssql-client/tests/streaming_memory.rs
@@ -105,3 +105,39 @@ async fn streaming_query_bounds_peak_memory() {
          roughly one row, not the whole ~10 MB response"
     );
 }
+
+/// A single ~30 MB `VARBINARY(MAX)` cell streamed to a sink must keep peak heap
+/// far below the cell size — proving the BLOB is read in chunks from the socket
+/// rather than materialized. The buffered path would hold the whole 30 MB.
+#[tokio::test]
+#[ignore = "Requires a live SQL Server"]
+async fn blob_streaming_bounds_peak_memory() {
+    let Some(cfg) = config() else {
+        return;
+    };
+    let mut client = Client::connect(cfg).await.expect("connect");
+
+    const BIG_BLOB: &str = "SELECT 1 AS id, \
+        CAST(REPLICATE(CAST('A' AS VARCHAR(MAX)), 30000000) AS VARBINARY(MAX)) AS doc";
+
+    let baseline = LIVE.load(Ordering::Relaxed);
+    PEAK.store(baseline, Ordering::Relaxed);
+
+    let mut stream = client
+        .query_stream_blob(BIG_BLOB, &[])
+        .await
+        .expect("stream");
+    let _ = stream.next().await.expect("next").expect("one row");
+    let mut sink = tokio::io::sink();
+    let n = stream.copy_blob_to(&mut sink).await.expect("copy blob");
+
+    let peak_delta = PEAK.load(Ordering::Relaxed).saturating_sub(baseline);
+    eprintln!("blob_bytes={n} peak_delta={peak_delta} bytes");
+
+    assert_eq!(n, 30_000_000, "expected a 30 MB blob");
+    assert!(
+        peak_delta < 2_000_000,
+        "peak heap delta was {peak_delta} bytes — blob streaming should bound \
+         this to ~one chunk, not the whole 30 MB cell"
+    );
+}

--- a/crates/tds-protocol/src/token.rs
+++ b/crates/tds-protocol/src/token.rs
@@ -1047,6 +1047,26 @@ impl RawRow {
         })
     }
 
+    /// Decode only the first `prefix_len` columns of a ROW token, leaving `src`
+    /// positioned at the start of column `prefix_len`.
+    ///
+    /// Used by the BLOB streaming path to decode the leading scalar columns of a
+    /// row and stop at a trailing MAX column, whose PLP value is then streamed
+    /// directly from the socket rather than buffered.
+    pub fn decode_prefix(
+        src: &mut impl Buf,
+        metadata: &ColMetaData,
+        prefix_len: usize,
+    ) -> Result<Self, ProtocolError> {
+        let mut data = bytes::BytesMut::new();
+        for col in metadata.columns.iter().take(prefix_len) {
+            Self::decode_column_value(src, col, &mut data)?;
+        }
+        Ok(Self {
+            data: data.freeze(),
+        })
+    }
+
     /// Decode a single column value and append to the output buffer.
     fn decode_column_value(
         src: &mut impl Buf,
@@ -1439,6 +1459,42 @@ impl NbcRow {
             if !is_null {
                 // Read the value - for NBCROW, we read without the length prefix
                 // for fixed-length types, and with length prefix for variable types
+                RawRow::decode_column_value(src, col, &mut data)?;
+            }
+        }
+
+        Ok(Self {
+            null_bitmap,
+            data: data.freeze(),
+        })
+    }
+
+    /// Decode the null bitmap and the first `prefix_len` columns of an NBCROW,
+    /// leaving `src` positioned at column `prefix_len`'s value (when that column
+    /// is non-NULL per the bitmap). The returned row carries the full bitmap and
+    /// the leading non-NULL values; query the trailing column's nullness with
+    /// [`is_null`](Self::is_null).
+    pub fn decode_prefix(
+        src: &mut impl Buf,
+        metadata: &ColMetaData,
+        prefix_len: usize,
+    ) -> Result<Self, ProtocolError> {
+        let col_count = metadata.columns.len();
+        let bitmap_len = col_count.div_ceil(8);
+
+        if src.remaining() < bitmap_len {
+            return Err(ProtocolError::UnexpectedEof);
+        }
+
+        let mut null_bitmap = vec![0u8; bitmap_len];
+        for byte in &mut null_bitmap {
+            *byte = src.get_u8();
+        }
+
+        let mut data = bytes::BytesMut::new();
+        for (i, col) in metadata.columns.iter().enumerate().take(prefix_len) {
+            let is_null = (null_bitmap[i / 8] & (1 << (i % 8))) != 0;
+            if !is_null {
                 RawRow::decode_column_value(src, col, &mut data)?;
             }
         }

--- a/public-api/mssql-client.txt
+++ b/public-api/mssql-client.txt
@@ -126,6 +126,47 @@ impl<T> typenum::type_operators::Same for mssql_client::blob::BlobReader
 pub type mssql_client::blob::BlobReader::Output = T
 impl<V, T> ppv_lite86::types::VZip<V> for mssql_client::blob::BlobReader where V: ppv_lite86::types::MultiLane<T>
 pub fn mssql_client::blob::BlobReader::vzip(self) -> V
+pub mod mssql_client::blob_stream
+pub struct mssql_client::blob_stream::BlobStream<'a>
+impl<'a> mssql_client::blob_stream::BlobStream<'a>
+pub fn mssql_client::blob_stream::BlobStream<'a>::blob_is_null(&self) -> bool
+pub fn mssql_client::blob_stream::BlobStream<'a>::blob_len(&self) -> core::option::Option<u64>
+pub fn mssql_client::blob_stream::BlobStream<'a>::columns(&self) -> &[mssql_client::row::Column]
+pub async fn mssql_client::blob_stream::BlobStream<'a>::copy_blob_to<W>(&mut self, &mut W) -> mssql_client::error::Result<u64> where W: tokio::io::async_write::AsyncWrite + core::marker::Unpin
+pub async fn mssql_client::blob_stream::BlobStream<'a>::next(&mut self) -> mssql_client::error::Result<core::option::Option<mssql_client::row::Row>>
+pub async fn mssql_client::blob_stream::BlobStream<'a>::read_chunk(&mut self) -> mssql_client::error::Result<core::option::Option<bytes::bytes::Bytes>>
+impl<'a> !core::marker::Freeze for mssql_client::blob_stream::BlobStream<'a>
+impl<'a> core::marker::Send for mssql_client::blob_stream::BlobStream<'a>
+impl<'a> core::marker::Sync for mssql_client::blob_stream::BlobStream<'a>
+impl<'a> core::marker::Unpin for mssql_client::blob_stream::BlobStream<'a>
+impl<'a> !core::panic::unwind_safe::RefUnwindSafe for mssql_client::blob_stream::BlobStream<'a>
+impl<'a> !core::panic::unwind_safe::UnwindSafe for mssql_client::blob_stream::BlobStream<'a>
+impl<T, U> core::convert::Into<U> for mssql_client::blob_stream::BlobStream<'a> where U: core::convert::From<T>
+pub fn mssql_client::blob_stream::BlobStream<'a>::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for mssql_client::blob_stream::BlobStream<'a> where U: core::convert::Into<T>
+pub type mssql_client::blob_stream::BlobStream<'a>::Error = core::convert::Infallible
+pub fn mssql_client::blob_stream::BlobStream<'a>::try_from(U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for mssql_client::blob_stream::BlobStream<'a> where U: core::convert::TryFrom<T>
+pub type mssql_client::blob_stream::BlobStream<'a>::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn mssql_client::blob_stream::BlobStream<'a>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> core::any::Any for mssql_client::blob_stream::BlobStream<'a> where T: 'static + ?core::marker::Sized
+pub fn mssql_client::blob_stream::BlobStream<'a>::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for mssql_client::blob_stream::BlobStream<'a> where T: ?core::marker::Sized
+pub fn mssql_client::blob_stream::BlobStream<'a>::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for mssql_client::blob_stream::BlobStream<'a> where T: ?core::marker::Sized
+pub fn mssql_client::blob_stream::BlobStream<'a>::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for mssql_client::blob_stream::BlobStream<'a>
+pub fn mssql_client::blob_stream::BlobStream<'a>::from(T) -> T
+impl<T> opentelemetry::context::future_ext::FutureExt for mssql_client::blob_stream::BlobStream<'a>
+impl<T> tower_http::follow_redirect::policy::PolicyExt for mssql_client::blob_stream::BlobStream<'a> where T: ?core::marker::Sized
+pub fn mssql_client::blob_stream::BlobStream<'a>::and<P, B, E>(self, P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn mssql_client::blob_stream::BlobStream<'a>::or<P, B, E>(self, P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+impl<T> tracing::instrument::Instrument for mssql_client::blob_stream::BlobStream<'a>
+impl<T> tracing::instrument::WithSubscriber for mssql_client::blob_stream::BlobStream<'a>
+impl<T> typenum::type_operators::Same for mssql_client::blob_stream::BlobStream<'a>
+pub type mssql_client::blob_stream::BlobStream<'a>::Output = T
+impl<V, T> ppv_lite86::types::VZip<V> for mssql_client::blob_stream::BlobStream<'a> where V: ppv_lite86::types::MultiLane<T>
+pub fn mssql_client::blob_stream::BlobStream<'a>::vzip(self) -> V
 pub mod mssql_client::bulk
 pub struct mssql_client::bulk::BulkColumn
 pub mssql_client::bulk::BulkColumn::name: alloc::string::String
@@ -772,6 +813,7 @@ pub fn mssql_client::client::Client<mssql_client::state::Ready>::port(&self) -> 
 pub async fn mssql_client::client::Client<mssql_client::state::Ready>::query<'a>(&'a mut self, &str, &[&(dyn mssql_types::to_sql::ToSql + core::marker::Sync)]) -> mssql_client::error::Result<mssql_client::stream::QueryStream<'a>>
 pub async fn mssql_client::client::Client<mssql_client::state::Ready>::query_multiple<'a>(&'a mut self, &str, &[&(dyn mssql_types::to_sql::ToSql + core::marker::Sync)]) -> mssql_client::error::Result<mssql_client::stream::MultiResultStream<'a>>
 pub async fn mssql_client::client::Client<mssql_client::state::Ready>::query_stream<'a>(&'a mut self, &str, &[&(dyn mssql_types::to_sql::ToSql + core::marker::Sync)]) -> mssql_client::error::Result<mssql_client::row_stream::RowStream<'a>>
+pub async fn mssql_client::client::Client<mssql_client::state::Ready>::query_stream_blob<'a>(&'a mut self, &str, &[&(dyn mssql_types::to_sql::ToSql + core::marker::Sync)]) -> mssql_client::error::Result<mssql_client::blob_stream::BlobStream<'a>>
 pub async fn mssql_client::client::Client<mssql_client::state::Ready>::query_with_timeout<'a>(&'a mut self, &str, &[&(dyn mssql_types::to_sql::ToSql + core::marker::Sync)], core::time::Duration) -> mssql_client::error::Result<mssql_client::stream::QueryStream<'a>>
 pub async fn mssql_client::client::Client<mssql_client::state::Ready>::simple_query(&mut self, &str) -> mssql_client::error::Result<()>
 impl<S: mssql_client::state::ConnectionState> mssql_client::client::Client<S>
@@ -3688,6 +3730,46 @@ impl<T> typenum::type_operators::Same for mssql_client::change_tracking::SyncVer
 pub type mssql_client::change_tracking::SyncVersionStatus::Output = T
 impl<V, T> ppv_lite86::types::VZip<V> for mssql_client::change_tracking::SyncVersionStatus where V: ppv_lite86::types::MultiLane<T>
 pub fn mssql_client::change_tracking::SyncVersionStatus::vzip(self) -> V
+pub struct mssql_client::BlobStream<'a>
+impl<'a> mssql_client::blob_stream::BlobStream<'a>
+pub fn mssql_client::blob_stream::BlobStream<'a>::blob_is_null(&self) -> bool
+pub fn mssql_client::blob_stream::BlobStream<'a>::blob_len(&self) -> core::option::Option<u64>
+pub fn mssql_client::blob_stream::BlobStream<'a>::columns(&self) -> &[mssql_client::row::Column]
+pub async fn mssql_client::blob_stream::BlobStream<'a>::copy_blob_to<W>(&mut self, &mut W) -> mssql_client::error::Result<u64> where W: tokio::io::async_write::AsyncWrite + core::marker::Unpin
+pub async fn mssql_client::blob_stream::BlobStream<'a>::next(&mut self) -> mssql_client::error::Result<core::option::Option<mssql_client::row::Row>>
+pub async fn mssql_client::blob_stream::BlobStream<'a>::read_chunk(&mut self) -> mssql_client::error::Result<core::option::Option<bytes::bytes::Bytes>>
+impl<'a> !core::marker::Freeze for mssql_client::blob_stream::BlobStream<'a>
+impl<'a> core::marker::Send for mssql_client::blob_stream::BlobStream<'a>
+impl<'a> core::marker::Sync for mssql_client::blob_stream::BlobStream<'a>
+impl<'a> core::marker::Unpin for mssql_client::blob_stream::BlobStream<'a>
+impl<'a> !core::panic::unwind_safe::RefUnwindSafe for mssql_client::blob_stream::BlobStream<'a>
+impl<'a> !core::panic::unwind_safe::UnwindSafe for mssql_client::blob_stream::BlobStream<'a>
+impl<T, U> core::convert::Into<U> for mssql_client::blob_stream::BlobStream<'a> where U: core::convert::From<T>
+pub fn mssql_client::blob_stream::BlobStream<'a>::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for mssql_client::blob_stream::BlobStream<'a> where U: core::convert::Into<T>
+pub type mssql_client::blob_stream::BlobStream<'a>::Error = core::convert::Infallible
+pub fn mssql_client::blob_stream::BlobStream<'a>::try_from(U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for mssql_client::blob_stream::BlobStream<'a> where U: core::convert::TryFrom<T>
+pub type mssql_client::blob_stream::BlobStream<'a>::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn mssql_client::blob_stream::BlobStream<'a>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> core::any::Any for mssql_client::blob_stream::BlobStream<'a> where T: 'static + ?core::marker::Sized
+pub fn mssql_client::blob_stream::BlobStream<'a>::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for mssql_client::blob_stream::BlobStream<'a> where T: ?core::marker::Sized
+pub fn mssql_client::blob_stream::BlobStream<'a>::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for mssql_client::blob_stream::BlobStream<'a> where T: ?core::marker::Sized
+pub fn mssql_client::blob_stream::BlobStream<'a>::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for mssql_client::blob_stream::BlobStream<'a>
+pub fn mssql_client::blob_stream::BlobStream<'a>::from(T) -> T
+impl<T> opentelemetry::context::future_ext::FutureExt for mssql_client::blob_stream::BlobStream<'a>
+impl<T> tower_http::follow_redirect::policy::PolicyExt for mssql_client::blob_stream::BlobStream<'a> where T: ?core::marker::Sized
+pub fn mssql_client::blob_stream::BlobStream<'a>::and<P, B, E>(self, P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn mssql_client::blob_stream::BlobStream<'a>::or<P, B, E>(self, P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+impl<T> tracing::instrument::Instrument for mssql_client::blob_stream::BlobStream<'a>
+impl<T> tracing::instrument::WithSubscriber for mssql_client::blob_stream::BlobStream<'a>
+impl<T> typenum::type_operators::Same for mssql_client::blob_stream::BlobStream<'a>
+pub type mssql_client::blob_stream::BlobStream<'a>::Output = T
+impl<V, T> ppv_lite86::types::VZip<V> for mssql_client::blob_stream::BlobStream<'a> where V: ppv_lite86::types::MultiLane<T>
+pub fn mssql_client::blob_stream::BlobStream<'a>::vzip(self) -> V
 pub struct mssql_client::BulkColumn
 pub mssql_client::BulkColumn::name: alloc::string::String
 pub mssql_client::BulkColumn::nullable: bool
@@ -4202,6 +4284,7 @@ pub fn mssql_client::client::Client<mssql_client::state::Ready>::port(&self) -> 
 pub async fn mssql_client::client::Client<mssql_client::state::Ready>::query<'a>(&'a mut self, &str, &[&(dyn mssql_types::to_sql::ToSql + core::marker::Sync)]) -> mssql_client::error::Result<mssql_client::stream::QueryStream<'a>>
 pub async fn mssql_client::client::Client<mssql_client::state::Ready>::query_multiple<'a>(&'a mut self, &str, &[&(dyn mssql_types::to_sql::ToSql + core::marker::Sync)]) -> mssql_client::error::Result<mssql_client::stream::MultiResultStream<'a>>
 pub async fn mssql_client::client::Client<mssql_client::state::Ready>::query_stream<'a>(&'a mut self, &str, &[&(dyn mssql_types::to_sql::ToSql + core::marker::Sync)]) -> mssql_client::error::Result<mssql_client::row_stream::RowStream<'a>>
+pub async fn mssql_client::client::Client<mssql_client::state::Ready>::query_stream_blob<'a>(&'a mut self, &str, &[&(dyn mssql_types::to_sql::ToSql + core::marker::Sync)]) -> mssql_client::error::Result<mssql_client::blob_stream::BlobStream<'a>>
 pub async fn mssql_client::client::Client<mssql_client::state::Ready>::query_with_timeout<'a>(&'a mut self, &str, &[&(dyn mssql_types::to_sql::ToSql + core::marker::Sync)], core::time::Duration) -> mssql_client::error::Result<mssql_client::stream::QueryStream<'a>>
 pub async fn mssql_client::client::Client<mssql_client::state::Ready>::simple_query(&mut self, &str) -> mssql_client::error::Result<()>
 impl<S: mssql_client::state::ConnectionState> mssql_client::client::Client<S>

--- a/public-api/tds-protocol.txt
+++ b/public-api/tds-protocol.txt
@@ -2175,6 +2175,7 @@ pub tds_protocol::token::NbcRow::data: bytes::bytes::Bytes
 pub tds_protocol::token::NbcRow::null_bitmap: alloc::vec::Vec<u8>
 impl tds_protocol::token::NbcRow
 pub fn tds_protocol::token::NbcRow::decode(&mut impl bytes::buf::buf_impl::Buf, &tds_protocol::token::ColMetaData) -> core::result::Result<Self, tds_protocol::error::ProtocolError>
+pub fn tds_protocol::token::NbcRow::decode_prefix(&mut impl bytes::buf::buf_impl::Buf, &tds_protocol::token::ColMetaData, usize) -> core::result::Result<Self, tds_protocol::error::ProtocolError>
 pub fn tds_protocol::token::NbcRow::is_null(&self, usize) -> bool
 impl core::clone::Clone for tds_protocol::token::NbcRow
 pub fn tds_protocol::token::NbcRow::clone(&self) -> tds_protocol::token::NbcRow
@@ -2248,6 +2249,7 @@ pub struct tds_protocol::token::RawRow
 pub tds_protocol::token::RawRow::data: bytes::bytes::Bytes
 impl tds_protocol::token::RawRow
 pub fn tds_protocol::token::RawRow::decode(&mut impl bytes::buf::buf_impl::Buf, &tds_protocol::token::ColMetaData) -> core::result::Result<Self, tds_protocol::error::ProtocolError>
+pub fn tds_protocol::token::RawRow::decode_prefix(&mut impl bytes::buf::buf_impl::Buf, &tds_protocol::token::ColMetaData, usize) -> core::result::Result<Self, tds_protocol::error::ProtocolError>
 impl core::clone::Clone for tds_protocol::token::RawRow
 pub fn tds_protocol::token::RawRow::clone(&self) -> tds_protocol::token::RawRow
 impl core::fmt::Debug for tds_protocol::token::RawRow
@@ -4671,6 +4673,7 @@ pub tds_protocol::NbcRow::data: bytes::bytes::Bytes
 pub tds_protocol::NbcRow::null_bitmap: alloc::vec::Vec<u8>
 impl tds_protocol::token::NbcRow
 pub fn tds_protocol::token::NbcRow::decode(&mut impl bytes::buf::buf_impl::Buf, &tds_protocol::token::ColMetaData) -> core::result::Result<Self, tds_protocol::error::ProtocolError>
+pub fn tds_protocol::token::NbcRow::decode_prefix(&mut impl bytes::buf::buf_impl::Buf, &tds_protocol::token::ColMetaData, usize) -> core::result::Result<Self, tds_protocol::error::ProtocolError>
 pub fn tds_protocol::token::NbcRow::is_null(&self, usize) -> bool
 impl core::clone::Clone for tds_protocol::token::NbcRow
 pub fn tds_protocol::token::NbcRow::clone(&self) -> tds_protocol::token::NbcRow
@@ -5144,6 +5147,7 @@ pub struct tds_protocol::RawRow
 pub tds_protocol::RawRow::data: bytes::bytes::Bytes
 impl tds_protocol::token::RawRow
 pub fn tds_protocol::token::RawRow::decode(&mut impl bytes::buf::buf_impl::Buf, &tds_protocol::token::ColMetaData) -> core::result::Result<Self, tds_protocol::error::ProtocolError>
+pub fn tds_protocol::token::RawRow::decode_prefix(&mut impl bytes::buf::buf_impl::Buf, &tds_protocol::token::ColMetaData, usize) -> core::result::Result<Self, tds_protocol::error::ProtocolError>
 impl core::clone::Clone for tds_protocol::token::RawRow
 pub fn tds_protocol::token::RawRow::clone(&self) -> tds_protocol::token::RawRow
 impl core::fmt::Debug for tds_protocol::token::RawRow


### PR DESCRIPTION
## Summary

Completes Stage 4 (follows #254 / the PLP decoder). Adds **`Client::query_stream_blob`**, which streams a row's trailing MAX column directly from the socket instead of materializing the cell — closing the last OOM case Stages 1–3 don't cover (row streaming bounds peak to ~one row, but a row holding a 4 GB BLOB is still ~4 GB once decoded).

```rust
let mut stream = client.query_stream_blob("SELECT id, document FROM files", &[]).await?;
while let Some(row) = stream.next().await? {
    let id: i32 = row.get_by_name("id")?;
    stream.copy_blob_to(&mut file).await?; // streamed, never fully buffered
}
```

## The memory win

A single 30 MB `VARBINARY(MAX)` cell streamed to a sink, under the counting allocator:

| Path | Peak heap delta |
|------|-----------------|
| buffered (whole cell in the row) | ~30 MB |
| `query_stream_blob` | **~9 KB** |

## How it works

- `BlobStream` decodes each row's **leading scalar columns** into a `Row` (small), then exposes the **trailing MAX column** as a chunk stream driven by the Stage 4 `PlpDecoder`, pulling PLP chunks from the connection on demand. Peak = one packet + one chunk.
- New `RawRow::decode_prefix` / `NbcRow::decode_prefix` decode the leading columns of a (possibly null-bitmap-compressed) row and stop at the MAX column.
- `read_chunk()` / `copy_blob_to(writer)` consume the blob; `next()` auto-drains an unconsumed blob so the wire stays aligned (consume-in-order contract).

## Constraints (by design, documented + validated)

- The MAX column must be the **last** column (TDS sends columns inline; nothing can follow a streamed blob). `query_stream_blob` errors clearly otherwise.
- Exactly one MAX column.
- Always Encrypted result sets are rejected on this path for now.

These mirror the two design subtleties surfaced on #254 (trailing-column constraint; async `read_chunk` rather than `AsyncRead`, since fetching a chunk needs an async socket read).

## Testing

Live-verified vs SQL Server 2022 (`tests/blob_stream.rs`): 100 KB and multi-row `VARBINARY(MAX)`, `NVARCHAR(MAX)` text (UTF-16LE bytes), **NULL blob (NBCROW path)**, auto-drain-on-advance with clean connection reuse, and the validation errors. Memory proof added to `tests/streaming_memory.rs`. Full local gauntlet + 20 live tests green. Public API additive.

## Scope / follow-ups (v0.18.0 milestone)

- Stage 5: multi-result-set boundary introspection in the streaming path.
- Stage 6: cleanup / benchmarks / docs (ADR-007 → "streamed").
- Later (if demand): general multi-BLOB streaming-row cursor; AE on the blob path.