### PR TITLE
feat(client)!: stream within transactions; address streaming review

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -547,8 +547,11 @@ if results.next_result().await? {
 > (peak ≈ one chunk). The buffered `query` remains for the common small-result
 > case — it reassembles the full payload then decodes rows lazily (peak ≈ raw
 > payload size). Validated by the counting-allocator tests in
-> `tests/streaming_memory.rs` (≈10 MB result set → ~20 KB peak; 30 MB BLOB →
-> ~9 KB peak).
+> `tests/streaming_memory.rs`: a ≈10 MB result set and a 30 MB BLOB each keep
+> peak heap delta under the test's conservative 2 MB assertion (observed peaks
+> are far lower — roughly ~20 KB and ~9 KB respectively — but the asserted
+> bound is loose to stay robust against allocator noise). The buffered path
+> would peak near the full payload (~40 MB for the same result set).
 
 **Buffered (default, convenient — `QueryStream`):**
 ```rust

--- a/LIMITATIONS.md
+++ b/LIMITATIONS.md
@@ -77,6 +77,12 @@ demand and bounds peak memory to roughly one row regardless of result-set
 size (`while let Some(row) = stream.try_next().await? { … }`). `OFFSET`/`FETCH`
 paging remains an alternative when you want server-side bounding.
 
+`query_stream()` (and `query_stream_blob()`) are available on both
+`Client<Ready>` and `Client<InTransaction>`, so a large result set can be
+streamed inside an open transaction. The stream borrows the client mutably for
+its lifetime, so it must be consumed or dropped before the transaction can be
+committed or rolled back.
+
 ---
 
 ### Large Object (LOB) Streaming — `query_stream_blob()`

--- a/crates/mssql-client/src/blob_stream.rs
+++ b/crates/mssql-client/src/blob_stream.rs
@@ -42,7 +42,7 @@ use crate::client::response::server_token_to_error;
 use crate::error::{Error, Result};
 use crate::plp::{PlpDecoder, PlpEvent};
 use crate::row::{Column, Row};
-use crate::state::Ready;
+use crate::state::{ConnectionState, Ready};
 
 /// Whether a column is a PLP-encoded MAX type that this path can sub-stream.
 pub(crate) fn is_plp_max(col: &ColumnData) -> bool {
@@ -59,8 +59,8 @@ pub(crate) fn is_plp_max(col: &ColumnData) -> bool {
 /// socket. See the [module docs](self). Obtain one from
 /// [`Client::query_stream_blob`](crate::Client::query_stream_blob).
 #[must_use = "streams must be consumed; dropping a stream discards remaining rows"]
-pub struct BlobStream<'a> {
-    client: &'a mut Client<Ready>,
+pub struct BlobStream<'a, S: ConnectionState = Ready> {
+    client: &'a mut Client<S>,
     /// Unconsumed wire bytes (post-metadata), shared by the column decode and
     /// the PLP chunk streaming.
     buf: Bytes,
@@ -82,9 +82,9 @@ pub struct BlobStream<'a> {
     finished: bool,
 }
 
-impl<'a> BlobStream<'a> {
+impl<'a, S: ConnectionState> BlobStream<'a, S> {
     pub(crate) fn new(
-        client: &'a mut Client<Ready>,
+        client: &'a mut Client<S>,
         buf: Bytes,
         eom: bool,
         encryption_enabled: bool,
@@ -95,7 +95,7 @@ impl<'a> BlobStream<'a> {
             columns: meta.columns.iter().take(blob_index).cloned().collect(),
             cek_table: meta.cek_table.clone(),
         };
-        let scalar_columns = Client::<Ready>::build_columns(&prefix_meta);
+        let scalar_columns = Client::<S>::build_columns(&prefix_meta);
         Self {
             client,
             buf,
@@ -158,6 +158,12 @@ impl<'a> BlobStream<'a> {
 
     /// Read the next chunk of the current row's blob, or `None` when it is fully
     /// read (or NULL). Reads more packets from the socket as needed.
+    ///
+    /// Chunks are **raw bytes**, not decoded text. For an `NVARCHAR(MAX)` /
+    /// `XML` column the bytes are little-endian UCS-2, and a chunk boundary can
+    /// fall in the middle of a two-byte code unit (or a surrogate pair) — so do
+    /// not decode each chunk to `str` independently. Concatenate the chunks
+    /// first (or stream to a byte sink), then decode the whole value.
     pub async fn read_chunk(&mut self) -> Result<Option<Bytes>> {
         loop {
             let event = match self.plp.as_mut() {
@@ -315,7 +321,14 @@ impl<'a> BlobStream<'a> {
             Token::ColMetaData(_) => Err(Error::Protocol(
                 "query_stream_blob does not support multiple result sets".to_string(),
             )),
-            // DoneProc / DoneInProc / Info / Order / EnvChange / etc.
+            Token::EnvChange(ref e) => {
+                // Keep the transaction descriptor in sync with raw
+                // BEGIN/COMMIT/ROLLBACK seen mid-stream, as the buffered
+                // readers do.
+                self.client.apply_transaction_env_change(e);
+                Ok(Control::Continue)
+            }
+            // DoneProc / DoneInProc / Info / Order / etc.
             _ => Ok(Control::Continue),
         }
     }

--- a/crates/mssql-client/src/client.rs
+++ b/crates/mssql-client/src/client.rs
@@ -312,6 +312,15 @@ impl<S: ConnectionState> Client<S> {
         }
     }
 
+    /// Apply a transaction-related `ENVCHANGE` to this client's descriptor.
+    ///
+    /// Lets the streaming readers (which live in sibling modules) keep the
+    /// transaction descriptor in sync with raw `BEGIN`/`COMMIT`/`ROLLBACK`
+    /// batches seen mid-stream, exactly as the buffered readers do.
+    pub(crate) fn apply_transaction_env_change(&mut self, env: &EnvChange) {
+        Self::process_transaction_env_change(env, &mut self.transaction_descriptor);
+    }
+
     /// Send a SQL batch to the server.
     ///
     /// Uses the client's current transaction descriptor in ALL_HEADERS.
@@ -1016,6 +1025,194 @@ impl<S: ConnectionState> Client<S> {
     pub(crate) fn server_collation(&self) -> Option<&tds_protocol::token::Collation> {
         self.server_collation.as_ref()
     }
+
+    /// Shared implementation behind `query_stream` for both `Ready` and
+    /// `InTransaction`. Sends the request, then pulls packets until the first
+    /// result set's `ColMetaData` (resolving columns and any Always Encrypted
+    /// decryptor up front) before handing back a [`RowStream`].
+    pub(crate) async fn query_stream_inner<'a>(
+        &'a mut self,
+        sql: &str,
+        params: &[&(dyn crate::ToSql + Sync)],
+    ) -> Result<crate::row_stream::RowStream<'a, S>> {
+        use crate::client::response::server_token_to_error;
+        use crate::row_source::{Pull, RowSource};
+        use tds_protocol::token::Token;
+
+        tracing::debug!(sql = sql, params_count = params.len(), "streaming query");
+
+        // Send the request (same wire format as the buffered path).
+        if params.is_empty() {
+            self.send_sql_batch(sql).await?;
+        } else {
+            let rpc = self.build_parameterized_rpc(sql, params).await?;
+            self.send_rpc(&rpc).await?;
+        }
+        self.in_flight = true;
+
+        #[cfg(feature = "always-encrypted")]
+        let encryption_enabled = self.encryption_context.is_some();
+        #[cfg(not(feature = "always-encrypted"))]
+        let encryption_enabled = false;
+
+        let mut source = RowSource::new(encryption_enabled);
+
+        // Prelude: pull packets until the first result set's ColMetaData (so the
+        // columns and any Always Encrypted decryptor are resolved up front), or
+        // until a terminal Done/Error if there is no result set.
+        loop {
+            match source.pull()? {
+                Pull::Token(Token::ColMetaData(meta)) => {
+                    let columns = Self::build_columns(&meta);
+                    #[cfg(feature = "always-encrypted")]
+                    let decryptor = self
+                        .resolve_decryptor(&meta)
+                        .await?
+                        .map(std::sync::Arc::new);
+                    return Ok(crate::row_stream::RowStream::new(
+                        self,
+                        source,
+                        columns,
+                        meta,
+                        #[cfg(feature = "always-encrypted")]
+                        decryptor,
+                    ));
+                }
+                Pull::Token(Token::Error(err)) => {
+                    self.in_flight = false;
+                    return Err(server_token_to_error(&err));
+                }
+                Pull::Token(Token::Done(done)) => {
+                    if done.status.error {
+                        self.in_flight = false;
+                        return Err(Error::Query(
+                            "query failed (server set error flag in DONE token)".to_string(),
+                        ));
+                    }
+                    if !done.status.more {
+                        // No result set (e.g. an INSERT) — an empty stream.
+                        self.in_flight = false;
+                        return Ok(crate::row_stream::RowStream::empty(self));
+                    }
+                    // More results may follow; keep looking for ColMetaData.
+                }
+                Pull::Token(Token::EnvChange(env)) => {
+                    Self::process_transaction_env_change(&env, &mut self.transaction_descriptor);
+                }
+                Pull::Token(_) => {
+                    // Info / Order / DoneProc / DoneInProc, etc. — keep pulling.
+                }
+                Pull::NeedMore => match self.read_response_packet().await? {
+                    Some((payload, is_eom)) => source.push_packet(payload, is_eom),
+                    None => {
+                        self.in_flight = false;
+                        return Err(Error::ConnectionClosed);
+                    }
+                },
+                Pull::End => {
+                    self.in_flight = false;
+                    return Ok(crate::row_stream::RowStream::empty(self));
+                }
+            }
+        }
+    }
+
+    /// Shared implementation behind `query_stream_blob` for both `Ready` and
+    /// `InTransaction`.
+    pub(crate) async fn query_stream_blob_inner<'a>(
+        &'a mut self,
+        sql: &str,
+        params: &[&(dyn crate::ToSql + Sync)],
+    ) -> Result<crate::blob_stream::BlobStream<'a, S>> {
+        use crate::client::response::server_token_to_error;
+        use crate::row_source::{Pull, RowSource};
+        use tds_protocol::token::Token;
+
+        if params.is_empty() {
+            self.send_sql_batch(sql).await?;
+        } else {
+            let rpc = self.build_parameterized_rpc(sql, params).await?;
+            self.send_rpc(&rpc).await?;
+        }
+        self.in_flight = true;
+
+        #[cfg(feature = "always-encrypted")]
+        let encryption_enabled = self.encryption_context.is_some();
+        #[cfg(not(feature = "always-encrypted"))]
+        let encryption_enabled = false;
+
+        let mut source = RowSource::new(encryption_enabled);
+
+        loop {
+            match source.pull()? {
+                Pull::Token(Token::ColMetaData(meta)) => {
+                    let blob_index = Self::validate_blob_result_set(&meta)?;
+                    let (buf, eom) = source.into_parts();
+                    return Ok(crate::blob_stream::BlobStream::new(
+                        self,
+                        buf,
+                        eom,
+                        encryption_enabled,
+                        meta,
+                        blob_index,
+                    ));
+                }
+                Pull::Token(Token::Error(err)) => {
+                    self.in_flight = false;
+                    return Err(server_token_to_error(&err));
+                }
+                Pull::Token(Token::Done(_)) => {
+                    self.in_flight = false;
+                    return Err(Error::Protocol(
+                        "query_stream_blob: query produced no result set".to_string(),
+                    ));
+                }
+                Pull::Token(_) => {}
+                Pull::NeedMore => match self.read_response_packet().await? {
+                    Some((payload, is_eom)) => source.push_packet(payload, is_eom),
+                    None => {
+                        self.in_flight = false;
+                        return Err(Error::ConnectionClosed);
+                    }
+                },
+                Pull::End => {
+                    self.in_flight = false;
+                    return Err(Error::Protocol(
+                        "query_stream_blob: query produced no result set".to_string(),
+                    ));
+                }
+            }
+        }
+    }
+
+    /// Validate that a result set is shaped for [`query_stream_blob`] and return
+    /// the index of its single trailing MAX column.
+    fn validate_blob_result_set(meta: &tds_protocol::token::ColMetaData) -> Result<usize> {
+        if meta.cek_table.is_some() {
+            return Err(Error::Protocol(
+                "query_stream_blob does not support Always Encrypted result sets".to_string(),
+            ));
+        }
+        let max_cols: Vec<usize> = meta
+            .columns
+            .iter()
+            .enumerate()
+            .filter(|(_, c)| crate::blob_stream::is_plp_max(c))
+            .map(|(i, _)| i)
+            .collect();
+        match max_cols.as_slice() {
+            [] => Err(Error::Protocol(
+                "query_stream_blob: result set has no MAX column — use query_stream".to_string(),
+            )),
+            [idx] if *idx == meta.columns.len() - 1 => Ok(*idx),
+            [_] => Err(Error::Protocol(
+                "query_stream_blob: the MAX column must be the last column".to_string(),
+            )),
+            _ => Err(Error::Protocol(
+                "query_stream_blob: result set has more than one MAX column".to_string(),
+            )),
+        }
+    }
 }
 
 impl Client<Ready> {
@@ -1163,7 +1360,8 @@ impl Client<Ready> {
     ///
     /// The returned [`RowStream`](crate::RowStream) borrows the client for its
     /// lifetime, so no other request can run on this connection until the stream
-    /// is consumed or dropped.
+    /// is consumed or dropped. Also available on `Client<InTransaction>` to
+    /// stream within a transaction.
     ///
     /// # Example
     ///
@@ -1181,87 +1379,8 @@ impl Client<Ready> {
         &'a mut self,
         sql: &str,
         params: &[&(dyn crate::ToSql + Sync)],
-    ) -> Result<crate::row_stream::RowStream<'a>> {
-        use crate::client::response::server_token_to_error;
-        use crate::row_source::{Pull, RowSource};
-        use tds_protocol::token::Token;
-
-        tracing::debug!(sql = sql, params_count = params.len(), "streaming query");
-
-        // Send the request (same wire format as the buffered path).
-        if params.is_empty() {
-            self.send_sql_batch(sql).await?;
-        } else {
-            let rpc = self.build_parameterized_rpc(sql, params).await?;
-            self.send_rpc(&rpc).await?;
-        }
-        self.in_flight = true;
-
-        #[cfg(feature = "always-encrypted")]
-        let encryption_enabled = self.encryption_context.is_some();
-        #[cfg(not(feature = "always-encrypted"))]
-        let encryption_enabled = false;
-
-        let mut source = RowSource::new(encryption_enabled);
-
-        // Prelude: pull packets until the first result set's ColMetaData (so the
-        // columns and any Always Encrypted decryptor are resolved up front), or
-        // until a terminal Done/Error if there is no result set.
-        loop {
-            match source.pull()? {
-                Pull::Token(Token::ColMetaData(meta)) => {
-                    let columns = Self::build_columns(&meta);
-                    #[cfg(feature = "always-encrypted")]
-                    let decryptor = self
-                        .resolve_decryptor(&meta)
-                        .await?
-                        .map(std::sync::Arc::new);
-                    return Ok(crate::row_stream::RowStream::new(
-                        self,
-                        source,
-                        columns,
-                        meta,
-                        #[cfg(feature = "always-encrypted")]
-                        decryptor,
-                    ));
-                }
-                Pull::Token(Token::Error(err)) => {
-                    self.in_flight = false;
-                    return Err(server_token_to_error(&err));
-                }
-                Pull::Token(Token::Done(done)) => {
-                    if done.status.error {
-                        self.in_flight = false;
-                        return Err(Error::Query(
-                            "query failed (server set error flag in DONE token)".to_string(),
-                        ));
-                    }
-                    if !done.status.more {
-                        // No result set (e.g. an INSERT) — an empty stream.
-                        self.in_flight = false;
-                        return Ok(crate::row_stream::RowStream::empty(self));
-                    }
-                    // More results may follow; keep looking for ColMetaData.
-                }
-                Pull::Token(Token::EnvChange(env)) => {
-                    Self::process_transaction_env_change(&env, &mut self.transaction_descriptor);
-                }
-                Pull::Token(_) => {
-                    // Info / Order / DoneProc / DoneInProc, etc. — keep pulling.
-                }
-                Pull::NeedMore => match self.read_response_packet().await? {
-                    Some((payload, is_eom)) => source.push_packet(payload, is_eom),
-                    None => {
-                        self.in_flight = false;
-                        return Err(Error::ConnectionClosed);
-                    }
-                },
-                Pull::End => {
-                    self.in_flight = false;
-                    return Ok(crate::row_stream::RowStream::empty(self));
-                }
-            }
-        }
+    ) -> Result<crate::row_stream::RowStream<'a, Ready>> {
+        self.query_stream_inner(sql, params).await
     }
 
     /// Execute a query and stream a row's trailing MAX column from the network.
@@ -1277,7 +1396,8 @@ impl Client<Ready> {
     /// [`BlobStream`](crate::BlobStream) yields scalar [`Row`](crate::Row)s via
     /// [`next`](crate::BlobStream::next); read each row's blob with
     /// [`read_chunk`](crate::BlobStream::read_chunk) /
-    /// [`copy_blob_to`](crate::BlobStream::copy_blob_to) before advancing.
+    /// [`copy_blob_to`](crate::BlobStream::copy_blob_to) before advancing. Also
+    /// available on `Client<InTransaction>`.
     ///
     /// # Errors
     ///
@@ -1288,95 +1408,8 @@ impl Client<Ready> {
         &'a mut self,
         sql: &str,
         params: &[&(dyn crate::ToSql + Sync)],
-    ) -> Result<crate::blob_stream::BlobStream<'a>> {
-        use crate::client::response::server_token_to_error;
-        use crate::row_source::{Pull, RowSource};
-        use tds_protocol::token::Token;
-
-        if params.is_empty() {
-            self.send_sql_batch(sql).await?;
-        } else {
-            let rpc = self.build_parameterized_rpc(sql, params).await?;
-            self.send_rpc(&rpc).await?;
-        }
-        self.in_flight = true;
-
-        #[cfg(feature = "always-encrypted")]
-        let encryption_enabled = self.encryption_context.is_some();
-        #[cfg(not(feature = "always-encrypted"))]
-        let encryption_enabled = false;
-
-        let mut source = RowSource::new(encryption_enabled);
-
-        loop {
-            match source.pull()? {
-                Pull::Token(Token::ColMetaData(meta)) => {
-                    let blob_index = Self::validate_blob_result_set(&meta)?;
-                    let (buf, eom) = source.into_parts();
-                    return Ok(crate::blob_stream::BlobStream::new(
-                        self,
-                        buf,
-                        eom,
-                        encryption_enabled,
-                        meta,
-                        blob_index,
-                    ));
-                }
-                Pull::Token(Token::Error(err)) => {
-                    self.in_flight = false;
-                    return Err(server_token_to_error(&err));
-                }
-                Pull::Token(Token::Done(_)) => {
-                    self.in_flight = false;
-                    return Err(Error::Protocol(
-                        "query_stream_blob: query produced no result set".to_string(),
-                    ));
-                }
-                Pull::Token(_) => {}
-                Pull::NeedMore => match self.read_response_packet().await? {
-                    Some((payload, is_eom)) => source.push_packet(payload, is_eom),
-                    None => {
-                        self.in_flight = false;
-                        return Err(Error::ConnectionClosed);
-                    }
-                },
-                Pull::End => {
-                    self.in_flight = false;
-                    return Err(Error::Protocol(
-                        "query_stream_blob: query produced no result set".to_string(),
-                    ));
-                }
-            }
-        }
-    }
-
-    /// Validate that a result set is shaped for [`query_stream_blob`] and return
-    /// the index of its single trailing MAX column.
-    fn validate_blob_result_set(meta: &tds_protocol::token::ColMetaData) -> Result<usize> {
-        if meta.cek_table.is_some() {
-            return Err(Error::Protocol(
-                "query_stream_blob does not support Always Encrypted result sets".to_string(),
-            ));
-        }
-        let max_cols: Vec<usize> = meta
-            .columns
-            .iter()
-            .enumerate()
-            .filter(|(_, c)| crate::blob_stream::is_plp_max(c))
-            .map(|(i, _)| i)
-            .collect();
-        match max_cols.as_slice() {
-            [] => Err(Error::Protocol(
-                "query_stream_blob: result set has no MAX column — use query_stream".to_string(),
-            )),
-            [idx] if *idx == meta.columns.len() - 1 => Ok(*idx),
-            [_] => Err(Error::Protocol(
-                "query_stream_blob: the MAX column must be the last column".to_string(),
-            )),
-            _ => Err(Error::Protocol(
-                "query_stream_blob: result set has more than one MAX column".to_string(),
-            )),
-        }
+    ) -> Result<crate::blob_stream::BlobStream<'a, Ready>> {
+        self.query_stream_blob_inner(sql, params).await
     }
 
     /// Execute a query with a specific timeout.
@@ -1957,6 +1990,34 @@ impl Client<InTransaction> {
                 resp.meta,
             ))
         }
+    }
+
+    /// Stream rows incrementally from the network within the transaction.
+    ///
+    /// Identical to [`Client<Ready>::query_stream`] except the query runs inside
+    /// the open transaction. The returned [`RowStream`](crate::RowStream)
+    /// borrows the transaction client for its lifetime, so the stream must be
+    /// consumed or dropped before the transaction can be committed or rolled
+    /// back.
+    pub async fn query_stream<'a>(
+        &'a mut self,
+        sql: &str,
+        params: &[&(dyn crate::ToSql + Sync)],
+    ) -> Result<crate::row_stream::RowStream<'a, InTransaction>> {
+        self.query_stream_inner(sql, params).await
+    }
+
+    /// Stream a row's trailing MAX column from the network within the
+    /// transaction.
+    ///
+    /// See [`Client<Ready>::query_stream_blob`] for semantics and constraints;
+    /// the only difference is that the query runs inside the open transaction.
+    pub async fn query_stream_blob<'a>(
+        &'a mut self,
+        sql: &str,
+        params: &[&(dyn crate::ToSql + Sync)],
+    ) -> Result<crate::blob_stream::BlobStream<'a, InTransaction>> {
+        self.query_stream_blob_inner(sql, params).await
     }
 
     /// Execute a statement within the transaction.

--- a/crates/mssql-client/src/row_stream.rs
+++ b/crates/mssql-client/src/row_stream.rs
@@ -29,7 +29,7 @@ use crate::Client;
 use crate::error::{Error, Result};
 use crate::row::{Column, Row};
 use crate::row_source::{Pull, RowSource};
-use crate::state::Ready;
+use crate::state::{ConnectionState, Ready};
 
 /// An incrementally streamed result set: rows are read from the network as they
 /// are pulled, not buffered up front.
@@ -42,10 +42,12 @@ use crate::state::Ready;
 /// is consumed via [`try_next`](Self::try_next) / [`collect_all`](Self::collect_all)
 /// rather than the synchronous [`Iterator`] that `QueryStream` offers.
 #[must_use = "streams must be consumed; dropping a stream discards remaining rows"]
-pub struct RowStream<'a> {
+pub struct RowStream<'a, S: ConnectionState = Ready> {
     /// The client whose connection supplies packets. Borrowed for the stream's
-    /// lifetime so no other request can run concurrently.
-    client: &'a mut Client<Ready>,
+    /// lifetime so no other request can run concurrently. Generic over the
+    /// connection state so the same stream serves both `Ready` and
+    /// `InTransaction` clients.
+    client: &'a mut Client<S>,
     /// The incremental token decoder over the rolling packet buffer.
     source: RowSource,
     /// Columns for the current result set (rebuilt on each ColMetaData).
@@ -59,11 +61,11 @@ pub struct RowStream<'a> {
     finished: bool,
 }
 
-impl<'a> RowStream<'a> {
+impl<'a, S: ConnectionState> RowStream<'a, S> {
     /// Construct a stream positioned just after the first ColMetaData, ready to
     /// yield the result set's rows. Called by `Client::query_stream`.
     pub(crate) fn new(
-        client: &'a mut Client<Ready>,
+        client: &'a mut Client<S>,
         source: RowSource,
         columns: Vec<Column>,
         meta: ColMetaData,
@@ -84,7 +86,7 @@ impl<'a> RowStream<'a> {
 
     /// Construct an already-finished stream (the query produced no result set,
     /// e.g. an `INSERT`). The caller has already cleared the in-flight flag.
-    pub(crate) fn empty(client: &'a mut Client<Ready>) -> Self {
+    pub(crate) fn empty(client: &'a mut Client<S>) -> Self {
         Self {
             client,
             source: RowSource::new(false),
@@ -141,8 +143,14 @@ impl<'a> RowStream<'a> {
                     // Otherwise keep going: rows of another result set, or the
                     // final DONE followed by Pull::End, may still come.
                 }
+                Pull::Token(Token::EnvChange(env)) => {
+                    // Keep the transaction descriptor in sync with raw
+                    // BEGIN/COMMIT/ROLLBACK seen mid-stream, as the buffered
+                    // readers do.
+                    self.client.apply_transaction_env_change(&env);
+                }
                 Pull::Token(_) => {
-                    // Info / EnvChange / Order / DoneProc / DoneInProc, etc.
+                    // Info / Order / DoneProc / DoneInProc, etc.
                     // Not row data; keep pulling.
                 }
                 Pull::NeedMore => match self.client.read_response_packet().await? {
@@ -199,7 +207,7 @@ impl<'a> RowStream<'a> {
 
     /// Adopt a new result set's metadata mid-stream (multi-statement batch).
     async fn switch_result_set(&mut self, meta: ColMetaData) -> Result<()> {
-        self.columns = Client::<Ready>::build_columns(&meta);
+        self.columns = Client::<S>::build_columns(&meta);
         #[cfg(feature = "always-encrypted")]
         {
             self.decryptor = self

--- a/crates/mssql-client/src/state.rs
+++ b/crates/mssql-client/src/state.rs
@@ -13,9 +13,16 @@
 //! ```
 //!
 //! Queries do not change the connection state: `query()` borrows the client
-//! mutably and returns an iterable result. The [`Streaming`] state type is
-//! declared for the planned socket-streaming work but no API currently
-//! transitions into it.
+//! mutably and returns an iterable result.
+//!
+//! Incremental streaming (`query_stream` / `query_stream_blob`) likewise does
+//! **not** transition into a dedicated state. Rather than the [`Streaming`]
+//! type-state originally sketched, the streams borrow the client mutably
+//! (`&mut Client<S>`) for their lifetime: the borrow checker already enforces
+//! that no other request can run on the connection until the stream is dropped,
+//! and a `&mut` borrow — unlike a consuming state transition — works uniformly
+//! for both [`Ready`] and [`InTransaction`] clients and returns the borrow
+//! automatically. The [`Streaming`] marker is therefore retained but unused.
 
 use std::marker::PhantomData;
 

--- a/crates/mssql-client/tests/blob_stream.rs
+++ b/crates/mssql-client/tests/blob_stream.rs
@@ -152,6 +152,75 @@ async fn blob_stream_nvarchar_max() {
     assert!(buf.chunks(2).all(|c| c == [0x41, 0x00]));
 }
 
+/// Dropping the stream after reading only part of a large blob leaves the
+/// connection in-flight; a directly reused client recovers it on the next
+/// request rather than reading the abandoned blob's bytes.
+#[tokio::test]
+#[ignore = "Requires SQL Server"]
+async fn blob_stream_drop_mid_blob_then_reuse() {
+    let Some(cfg) = get_test_config() else {
+        return;
+    };
+    let mut client = Client::connect(cfg).await.expect("connect");
+
+    // A 2 MB blob — large enough that a few chunks leaves most of it on the wire.
+    const SQL: &str = "SELECT 1 AS id, \
+        CAST(REPLICATE(CAST('A' AS VARCHAR(MAX)), 2000000) AS VARBINARY(MAX)) AS doc";
+
+    {
+        let mut stream = client.query_stream_blob(SQL, &[]).await.expect("stream");
+        let _ = stream.next().await.expect("next").expect("one row");
+        // Read just one chunk, then drop the stream with the blob half-read.
+        let chunk = stream.read_chunk().await.expect("chunk");
+        assert!(chunk.is_some(), "expected at least one blob chunk");
+    }
+
+    // The next request must recover the abandoned response, not its bytes.
+    let rows = client
+        .query("SELECT 23 AS v", &[])
+        .await
+        .expect("reuse after mid-blob drop")
+        .collect_all()
+        .await
+        .expect("collect");
+    assert_eq!(rows[0].get_by_name::<i32>("v").unwrap(), 23);
+}
+
+/// `query_stream_blob` works on a `Client<InTransaction>`.
+#[tokio::test]
+#[ignore = "Requires SQL Server"]
+async fn blob_stream_within_transaction() {
+    let Some(cfg) = get_test_config() else {
+        return;
+    };
+    let client = Client::connect(cfg).await.expect("connect");
+    let mut tx = client.begin_transaction().await.expect("begin");
+
+    const SQL: &str = "SELECT 1 AS id, \
+        CAST(REPLICATE(CAST('B' AS VARCHAR(MAX)), 80000) AS VARBINARY(MAX)) AS doc";
+
+    {
+        let mut stream = tx.query_stream_blob(SQL, &[]).await.expect("stream in tx");
+        let row = stream.next().await.expect("next").expect("one row");
+        assert_eq!(row.get_by_name::<i32>("id").unwrap(), 1);
+        let mut sink: Vec<u8> = Vec::new();
+        let n = stream.copy_blob_to(&mut sink).await.expect("copy blob");
+        assert_eq!(n, 80_000);
+        assert!(sink.iter().all(|&b| b == 0x42), "all bytes must be 'B'");
+        assert!(stream.next().await.expect("next").is_none());
+    }
+
+    let mut client = tx.commit().await.expect("commit");
+    let rows = client
+        .query("SELECT 29 AS v", &[])
+        .await
+        .expect("reuse after commit")
+        .collect_all()
+        .await
+        .expect("collect");
+    assert_eq!(rows[0].get_by_name::<i32>("v").unwrap(), 29);
+}
+
 /// Validation: a result set with no MAX column is rejected.
 #[tokio::test]
 #[ignore = "Requires SQL Server"]

--- a/crates/mssql-client/tests/query_stream.rs
+++ b/crates/mssql-client/tests/query_stream.rs
@@ -242,6 +242,98 @@ async fn cancel_after_full_drain_is_noop() {
     assert_eq!(rows[0].get_by_name::<i32>("v").unwrap(), 1);
 }
 
+/// A server error raised *after* rows have already been yielded surfaces on
+/// `try_next`, and the connection is left clean for the next request.
+#[tokio::test]
+#[ignore = "Requires SQL Server"]
+async fn error_mid_stream_then_reuse() {
+    let Some(cfg) = get_test_config() else {
+        return;
+    };
+    let mut client = Client::connect(cfg).await.expect("connect");
+
+    // First statement yields a row; the second raises a mid-stream error.
+    const SQL: &str = "SELECT 1 AS n; RAISERROR('boom', 16, 1);";
+
+    {
+        let mut stream = client.query_stream(SQL, &[]).await.expect("stream");
+        // The first row comes through fine.
+        let row = stream.try_next().await.expect("first row").expect("a row");
+        assert_eq!(row.get_by_name::<i32>("n").unwrap(), 1);
+        // A later pull hits the server error.
+        let mut found: Option<Error> = None;
+        loop {
+            match stream.try_next().await {
+                Ok(Some(_)) => continue,
+                Ok(None) => break,
+                Err(e) => {
+                    found = Some(e);
+                    break;
+                }
+            }
+        }
+        let err = found.expect("expected a server error, got end of stream");
+        assert!(
+            matches!(err, Error::Server { .. }),
+            "expected Error::Server, got {err:?}"
+        );
+    }
+
+    // The connection must be reusable after surfacing the mid-stream error.
+    let rows = client
+        .query("SELECT 13 AS v", &[])
+        .await
+        .expect("reuse after mid-stream error")
+        .collect_all()
+        .await
+        .expect("collect");
+    assert_eq!(rows[0].get_by_name::<i32>("v").unwrap(), 13);
+}
+
+/// `query_stream` works on a `Client<InTransaction>`: it reads uncommitted rows
+/// written earlier in the same transaction, and the transaction can be
+/// committed/rolled back once the stream is dropped.
+#[tokio::test]
+#[ignore = "Requires SQL Server"]
+async fn query_stream_within_transaction() {
+    let Some(cfg) = get_test_config() else {
+        return;
+    };
+    let client = Client::connect(cfg).await.expect("connect");
+
+    let mut tx = client.begin_transaction().await.expect("begin");
+    tx.execute("CREATE TABLE #stream_tx (n INT)", &[])
+        .await
+        .expect("create temp table");
+    tx.execute("INSERT INTO #stream_tx VALUES (1), (2), (3)", &[])
+        .await
+        .expect("insert");
+
+    let mut got: Vec<i32> = Vec::new();
+    {
+        // Stream the uncommitted rows from within the transaction.
+        let mut stream = tx
+            .query_stream("SELECT n FROM #stream_tx ORDER BY n", &[])
+            .await
+            .expect("stream in transaction");
+        while let Some(row) = stream.try_next().await.expect("row") {
+            got.push(row.get_by_name::<i32>("n").unwrap());
+        }
+    }
+    assert_eq!(got, vec![1, 2, 3], "streamed the in-transaction rows");
+
+    // The borrow has ended, so the transaction can now be rolled back.
+    let mut client = tx.rollback().await.expect("rollback");
+    let rows = client
+        .query("SELECT 17 AS v", &[])
+        .await
+        .expect("reuse after rollback")
+        .collect_all()
+        .await
+        .expect("collect");
+    assert_eq!(rows[0].get_by_name::<i32>("v").unwrap(), 17);
+}
+
 /// Parameterized streaming works (sp_executesql path).
 #[tokio::test]
 #[ignore = "Requires SQL Server"]

--- a/public-api/mssql-client.txt
+++ b/public-api/mssql-client.txt
@@ -127,46 +127,46 @@ pub type mssql_client::blob::BlobReader::Output = T
 impl<V, T> ppv_lite86::types::VZip<V> for mssql_client::blob::BlobReader where V: ppv_lite86::types::MultiLane<T>
 pub fn mssql_client::blob::BlobReader::vzip(self) -> V
 pub mod mssql_client::blob_stream
-pub struct mssql_client::blob_stream::BlobStream<'a>
-impl<'a> mssql_client::blob_stream::BlobStream<'a>
-pub fn mssql_client::blob_stream::BlobStream<'a>::blob_is_null(&self) -> bool
-pub fn mssql_client::blob_stream::BlobStream<'a>::blob_len(&self) -> core::option::Option<u64>
-pub fn mssql_client::blob_stream::BlobStream<'a>::columns(&self) -> &[mssql_client::row::Column]
-pub async fn mssql_client::blob_stream::BlobStream<'a>::copy_blob_to<W>(&mut self, &mut W) -> mssql_client::error::Result<u64> where W: tokio::io::async_write::AsyncWrite + core::marker::Unpin
-pub async fn mssql_client::blob_stream::BlobStream<'a>::next(&mut self) -> mssql_client::error::Result<core::option::Option<mssql_client::row::Row>>
-pub async fn mssql_client::blob_stream::BlobStream<'a>::read_chunk(&mut self) -> mssql_client::error::Result<core::option::Option<bytes::bytes::Bytes>>
-impl<'a> !core::marker::Freeze for mssql_client::blob_stream::BlobStream<'a>
-impl<'a> core::marker::Send for mssql_client::blob_stream::BlobStream<'a>
-impl<'a> core::marker::Sync for mssql_client::blob_stream::BlobStream<'a>
-impl<'a> core::marker::Unpin for mssql_client::blob_stream::BlobStream<'a>
-impl<'a> !core::panic::unwind_safe::RefUnwindSafe for mssql_client::blob_stream::BlobStream<'a>
-impl<'a> !core::panic::unwind_safe::UnwindSafe for mssql_client::blob_stream::BlobStream<'a>
-impl<T, U> core::convert::Into<U> for mssql_client::blob_stream::BlobStream<'a> where U: core::convert::From<T>
-pub fn mssql_client::blob_stream::BlobStream<'a>::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for mssql_client::blob_stream::BlobStream<'a> where U: core::convert::Into<T>
-pub type mssql_client::blob_stream::BlobStream<'a>::Error = core::convert::Infallible
-pub fn mssql_client::blob_stream::BlobStream<'a>::try_from(U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for mssql_client::blob_stream::BlobStream<'a> where U: core::convert::TryFrom<T>
-pub type mssql_client::blob_stream::BlobStream<'a>::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn mssql_client::blob_stream::BlobStream<'a>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for mssql_client::blob_stream::BlobStream<'a> where T: 'static + ?core::marker::Sized
-pub fn mssql_client::blob_stream::BlobStream<'a>::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for mssql_client::blob_stream::BlobStream<'a> where T: ?core::marker::Sized
-pub fn mssql_client::blob_stream::BlobStream<'a>::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for mssql_client::blob_stream::BlobStream<'a> where T: ?core::marker::Sized
-pub fn mssql_client::blob_stream::BlobStream<'a>::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for mssql_client::blob_stream::BlobStream<'a>
-pub fn mssql_client::blob_stream::BlobStream<'a>::from(T) -> T
-impl<T> opentelemetry::context::future_ext::FutureExt for mssql_client::blob_stream::BlobStream<'a>
-impl<T> tower_http::follow_redirect::policy::PolicyExt for mssql_client::blob_stream::BlobStream<'a> where T: ?core::marker::Sized
-pub fn mssql_client::blob_stream::BlobStream<'a>::and<P, B, E>(self, P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
-pub fn mssql_client::blob_stream::BlobStream<'a>::or<P, B, E>(self, P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
-impl<T> tracing::instrument::Instrument for mssql_client::blob_stream::BlobStream<'a>
-impl<T> tracing::instrument::WithSubscriber for mssql_client::blob_stream::BlobStream<'a>
-impl<T> typenum::type_operators::Same for mssql_client::blob_stream::BlobStream<'a>
-pub type mssql_client::blob_stream::BlobStream<'a>::Output = T
-impl<V, T> ppv_lite86::types::VZip<V> for mssql_client::blob_stream::BlobStream<'a> where V: ppv_lite86::types::MultiLane<T>
-pub fn mssql_client::blob_stream::BlobStream<'a>::vzip(self) -> V
+pub struct mssql_client::blob_stream::BlobStream<'a, S: mssql_client::state::ConnectionState>
+impl<'a, S: mssql_client::state::ConnectionState> mssql_client::blob_stream::BlobStream<'a, S>
+pub fn mssql_client::blob_stream::BlobStream<'a, S>::blob_is_null(&self) -> bool
+pub fn mssql_client::blob_stream::BlobStream<'a, S>::blob_len(&self) -> core::option::Option<u64>
+pub fn mssql_client::blob_stream::BlobStream<'a, S>::columns(&self) -> &[mssql_client::row::Column]
+pub async fn mssql_client::blob_stream::BlobStream<'a, S>::copy_blob_to<W>(&mut self, &mut W) -> mssql_client::error::Result<u64> where W: tokio::io::async_write::AsyncWrite + core::marker::Unpin
+pub async fn mssql_client::blob_stream::BlobStream<'a, S>::next(&mut self) -> mssql_client::error::Result<core::option::Option<mssql_client::row::Row>>
+pub async fn mssql_client::blob_stream::BlobStream<'a, S>::read_chunk(&mut self) -> mssql_client::error::Result<core::option::Option<bytes::bytes::Bytes>>
+impl<'a, S> !core::marker::Freeze for mssql_client::blob_stream::BlobStream<'a, S>
+impl<'a, S> core::marker::Send for mssql_client::blob_stream::BlobStream<'a, S> where S: core::marker::Send
+impl<'a, S> core::marker::Sync for mssql_client::blob_stream::BlobStream<'a, S> where S: core::marker::Sync
+impl<'a, S> core::marker::Unpin for mssql_client::blob_stream::BlobStream<'a, S>
+impl<'a, S> !core::panic::unwind_safe::RefUnwindSafe for mssql_client::blob_stream::BlobStream<'a, S>
+impl<'a, S> !core::panic::unwind_safe::UnwindSafe for mssql_client::blob_stream::BlobStream<'a, S>
+impl<T, U> core::convert::Into<U> for mssql_client::blob_stream::BlobStream<'a, S> where U: core::convert::From<T>
+pub fn mssql_client::blob_stream::BlobStream<'a, S>::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for mssql_client::blob_stream::BlobStream<'a, S> where U: core::convert::Into<T>
+pub type mssql_client::blob_stream::BlobStream<'a, S>::Error = core::convert::Infallible
+pub fn mssql_client::blob_stream::BlobStream<'a, S>::try_from(U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for mssql_client::blob_stream::BlobStream<'a, S> where U: core::convert::TryFrom<T>
+pub type mssql_client::blob_stream::BlobStream<'a, S>::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn mssql_client::blob_stream::BlobStream<'a, S>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> core::any::Any for mssql_client::blob_stream::BlobStream<'a, S> where T: 'static + ?core::marker::Sized
+pub fn mssql_client::blob_stream::BlobStream<'a, S>::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for mssql_client::blob_stream::BlobStream<'a, S> where T: ?core::marker::Sized
+pub fn mssql_client::blob_stream::BlobStream<'a, S>::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for mssql_client::blob_stream::BlobStream<'a, S> where T: ?core::marker::Sized
+pub fn mssql_client::blob_stream::BlobStream<'a, S>::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for mssql_client::blob_stream::BlobStream<'a, S>
+pub fn mssql_client::blob_stream::BlobStream<'a, S>::from(T) -> T
+impl<T> opentelemetry::context::future_ext::FutureExt for mssql_client::blob_stream::BlobStream<'a, S>
+impl<T> tower_http::follow_redirect::policy::PolicyExt for mssql_client::blob_stream::BlobStream<'a, S> where T: ?core::marker::Sized
+pub fn mssql_client::blob_stream::BlobStream<'a, S>::and<P, B, E>(self, P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn mssql_client::blob_stream::BlobStream<'a, S>::or<P, B, E>(self, P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+impl<T> tracing::instrument::Instrument for mssql_client::blob_stream::BlobStream<'a, S>
+impl<T> tracing::instrument::WithSubscriber for mssql_client::blob_stream::BlobStream<'a, S>
+impl<T> typenum::type_operators::Same for mssql_client::blob_stream::BlobStream<'a, S>
+pub type mssql_client::blob_stream::BlobStream<'a, S>::Output = T
+impl<V, T> ppv_lite86::types::VZip<V> for mssql_client::blob_stream::BlobStream<'a, S> where V: ppv_lite86::types::MultiLane<T>
+pub fn mssql_client::blob_stream::BlobStream<'a, S>::vzip(self) -> V
 pub mod mssql_client::bulk
 pub struct mssql_client::bulk::BulkColumn
 pub mssql_client::bulk::BulkColumn::name: alloc::string::String
@@ -790,6 +790,8 @@ pub async fn mssql_client::client::Client<mssql_client::state::InTransaction>::c
 pub async fn mssql_client::client::Client<mssql_client::state::InTransaction>::execute(&mut self, &str, &[&(dyn mssql_types::to_sql::ToSql + core::marker::Sync)]) -> mssql_client::error::Result<u64>
 pub async fn mssql_client::client::Client<mssql_client::state::InTransaction>::execute_with_timeout(&mut self, &str, &[&(dyn mssql_types::to_sql::ToSql + core::marker::Sync)], core::time::Duration) -> mssql_client::error::Result<u64>
 pub async fn mssql_client::client::Client<mssql_client::state::InTransaction>::query<'a>(&'a mut self, &str, &[&(dyn mssql_types::to_sql::ToSql + core::marker::Sync)]) -> mssql_client::error::Result<mssql_client::stream::QueryStream<'a>>
+pub async fn mssql_client::client::Client<mssql_client::state::InTransaction>::query_stream<'a>(&'a mut self, &str, &[&(dyn mssql_types::to_sql::ToSql + core::marker::Sync)]) -> mssql_client::error::Result<mssql_client::row_stream::RowStream<'a, mssql_client::state::InTransaction>>
+pub async fn mssql_client::client::Client<mssql_client::state::InTransaction>::query_stream_blob<'a>(&'a mut self, &str, &[&(dyn mssql_types::to_sql::ToSql + core::marker::Sync)]) -> mssql_client::error::Result<mssql_client::blob_stream::BlobStream<'a, mssql_client::state::InTransaction>>
 pub async fn mssql_client::client::Client<mssql_client::state::InTransaction>::query_with_timeout<'a>(&'a mut self, &str, &[&(dyn mssql_types::to_sql::ToSql + core::marker::Sync)], core::time::Duration) -> mssql_client::error::Result<mssql_client::stream::QueryStream<'a>>
 pub async fn mssql_client::client::Client<mssql_client::state::InTransaction>::release_savepoint(&mut self, mssql_client::transaction::SavePoint) -> mssql_client::error::Result<()>
 pub async fn mssql_client::client::Client<mssql_client::state::InTransaction>::rollback(self) -> mssql_client::error::Result<mssql_client::client::Client<mssql_client::state::Ready>>
@@ -812,8 +814,8 @@ pub fn mssql_client::client::Client<mssql_client::state::Ready>::needs_reset(&se
 pub fn mssql_client::client::Client<mssql_client::state::Ready>::port(&self) -> u16
 pub async fn mssql_client::client::Client<mssql_client::state::Ready>::query<'a>(&'a mut self, &str, &[&(dyn mssql_types::to_sql::ToSql + core::marker::Sync)]) -> mssql_client::error::Result<mssql_client::stream::QueryStream<'a>>
 pub async fn mssql_client::client::Client<mssql_client::state::Ready>::query_multiple<'a>(&'a mut self, &str, &[&(dyn mssql_types::to_sql::ToSql + core::marker::Sync)]) -> mssql_client::error::Result<mssql_client::stream::MultiResultStream<'a>>
-pub async fn mssql_client::client::Client<mssql_client::state::Ready>::query_stream<'a>(&'a mut self, &str, &[&(dyn mssql_types::to_sql::ToSql + core::marker::Sync)]) -> mssql_client::error::Result<mssql_client::row_stream::RowStream<'a>>
-pub async fn mssql_client::client::Client<mssql_client::state::Ready>::query_stream_blob<'a>(&'a mut self, &str, &[&(dyn mssql_types::to_sql::ToSql + core::marker::Sync)]) -> mssql_client::error::Result<mssql_client::blob_stream::BlobStream<'a>>
+pub async fn mssql_client::client::Client<mssql_client::state::Ready>::query_stream<'a>(&'a mut self, &str, &[&(dyn mssql_types::to_sql::ToSql + core::marker::Sync)]) -> mssql_client::error::Result<mssql_client::row_stream::RowStream<'a, mssql_client::state::Ready>>
+pub async fn mssql_client::client::Client<mssql_client::state::Ready>::query_stream_blob<'a>(&'a mut self, &str, &[&(dyn mssql_types::to_sql::ToSql + core::marker::Sync)]) -> mssql_client::error::Result<mssql_client::blob_stream::BlobStream<'a, mssql_client::state::Ready>>
 pub async fn mssql_client::client::Client<mssql_client::state::Ready>::query_with_timeout<'a>(&'a mut self, &str, &[&(dyn mssql_types::to_sql::ToSql + core::marker::Sync)], core::time::Duration) -> mssql_client::error::Result<mssql_client::stream::QueryStream<'a>>
 pub async fn mssql_client::client::Client<mssql_client::state::Ready>::simple_query(&mut self, &str) -> mssql_client::error::Result<()>
 impl<S: mssql_client::state::ConnectionState> mssql_client::client::Client<S>
@@ -2235,45 +2237,45 @@ pub type mssql_client::row::RowIter<'a>::Output = T
 impl<V, T> ppv_lite86::types::VZip<V> for mssql_client::row::RowIter<'a> where V: ppv_lite86::types::MultiLane<T>
 pub fn mssql_client::row::RowIter<'a>::vzip(self) -> V
 pub mod mssql_client::row_stream
-pub struct mssql_client::row_stream::RowStream<'a>
-impl<'a> mssql_client::row_stream::RowStream<'a>
-pub async fn mssql_client::row_stream::RowStream<'a>::cancel(self) -> mssql_client::error::Result<()>
-pub async fn mssql_client::row_stream::RowStream<'a>::collect_all(self) -> mssql_client::error::Result<alloc::vec::Vec<mssql_client::row::Row>>
-pub fn mssql_client::row_stream::RowStream<'a>::columns(&self) -> &[mssql_client::row::Column]
-pub fn mssql_client::row_stream::RowStream<'a>::is_finished(&self) -> bool
-pub async fn mssql_client::row_stream::RowStream<'a>::try_next(&mut self) -> mssql_client::error::Result<core::option::Option<mssql_client::row::Row>>
-impl<'a> !core::marker::Freeze for mssql_client::row_stream::RowStream<'a>
-impl<'a> core::marker::Send for mssql_client::row_stream::RowStream<'a>
-impl<'a> core::marker::Sync for mssql_client::row_stream::RowStream<'a>
-impl<'a> core::marker::Unpin for mssql_client::row_stream::RowStream<'a>
-impl<'a> !core::panic::unwind_safe::RefUnwindSafe for mssql_client::row_stream::RowStream<'a>
-impl<'a> !core::panic::unwind_safe::UnwindSafe for mssql_client::row_stream::RowStream<'a>
-impl<T, U> core::convert::Into<U> for mssql_client::row_stream::RowStream<'a> where U: core::convert::From<T>
-pub fn mssql_client::row_stream::RowStream<'a>::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for mssql_client::row_stream::RowStream<'a> where U: core::convert::Into<T>
-pub type mssql_client::row_stream::RowStream<'a>::Error = core::convert::Infallible
-pub fn mssql_client::row_stream::RowStream<'a>::try_from(U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for mssql_client::row_stream::RowStream<'a> where U: core::convert::TryFrom<T>
-pub type mssql_client::row_stream::RowStream<'a>::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn mssql_client::row_stream::RowStream<'a>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for mssql_client::row_stream::RowStream<'a> where T: 'static + ?core::marker::Sized
-pub fn mssql_client::row_stream::RowStream<'a>::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for mssql_client::row_stream::RowStream<'a> where T: ?core::marker::Sized
-pub fn mssql_client::row_stream::RowStream<'a>::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for mssql_client::row_stream::RowStream<'a> where T: ?core::marker::Sized
-pub fn mssql_client::row_stream::RowStream<'a>::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for mssql_client::row_stream::RowStream<'a>
-pub fn mssql_client::row_stream::RowStream<'a>::from(T) -> T
-impl<T> opentelemetry::context::future_ext::FutureExt for mssql_client::row_stream::RowStream<'a>
-impl<T> tower_http::follow_redirect::policy::PolicyExt for mssql_client::row_stream::RowStream<'a> where T: ?core::marker::Sized
-pub fn mssql_client::row_stream::RowStream<'a>::and<P, B, E>(self, P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
-pub fn mssql_client::row_stream::RowStream<'a>::or<P, B, E>(self, P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
-impl<T> tracing::instrument::Instrument for mssql_client::row_stream::RowStream<'a>
-impl<T> tracing::instrument::WithSubscriber for mssql_client::row_stream::RowStream<'a>
-impl<T> typenum::type_operators::Same for mssql_client::row_stream::RowStream<'a>
-pub type mssql_client::row_stream::RowStream<'a>::Output = T
-impl<V, T> ppv_lite86::types::VZip<V> for mssql_client::row_stream::RowStream<'a> where V: ppv_lite86::types::MultiLane<T>
-pub fn mssql_client::row_stream::RowStream<'a>::vzip(self) -> V
+pub struct mssql_client::row_stream::RowStream<'a, S: mssql_client::state::ConnectionState>
+impl<'a, S: mssql_client::state::ConnectionState> mssql_client::row_stream::RowStream<'a, S>
+pub async fn mssql_client::row_stream::RowStream<'a, S>::cancel(self) -> mssql_client::error::Result<()>
+pub async fn mssql_client::row_stream::RowStream<'a, S>::collect_all(self) -> mssql_client::error::Result<alloc::vec::Vec<mssql_client::row::Row>>
+pub fn mssql_client::row_stream::RowStream<'a, S>::columns(&self) -> &[mssql_client::row::Column]
+pub fn mssql_client::row_stream::RowStream<'a, S>::is_finished(&self) -> bool
+pub async fn mssql_client::row_stream::RowStream<'a, S>::try_next(&mut self) -> mssql_client::error::Result<core::option::Option<mssql_client::row::Row>>
+impl<'a, S> !core::marker::Freeze for mssql_client::row_stream::RowStream<'a, S>
+impl<'a, S> core::marker::Send for mssql_client::row_stream::RowStream<'a, S> where S: core::marker::Send
+impl<'a, S> core::marker::Sync for mssql_client::row_stream::RowStream<'a, S> where S: core::marker::Sync
+impl<'a, S> core::marker::Unpin for mssql_client::row_stream::RowStream<'a, S>
+impl<'a, S> !core::panic::unwind_safe::RefUnwindSafe for mssql_client::row_stream::RowStream<'a, S>
+impl<'a, S> !core::panic::unwind_safe::UnwindSafe for mssql_client::row_stream::RowStream<'a, S>
+impl<T, U> core::convert::Into<U> for mssql_client::row_stream::RowStream<'a, S> where U: core::convert::From<T>
+pub fn mssql_client::row_stream::RowStream<'a, S>::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for mssql_client::row_stream::RowStream<'a, S> where U: core::convert::Into<T>
+pub type mssql_client::row_stream::RowStream<'a, S>::Error = core::convert::Infallible
+pub fn mssql_client::row_stream::RowStream<'a, S>::try_from(U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for mssql_client::row_stream::RowStream<'a, S> where U: core::convert::TryFrom<T>
+pub type mssql_client::row_stream::RowStream<'a, S>::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn mssql_client::row_stream::RowStream<'a, S>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> core::any::Any for mssql_client::row_stream::RowStream<'a, S> where T: 'static + ?core::marker::Sized
+pub fn mssql_client::row_stream::RowStream<'a, S>::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for mssql_client::row_stream::RowStream<'a, S> where T: ?core::marker::Sized
+pub fn mssql_client::row_stream::RowStream<'a, S>::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for mssql_client::row_stream::RowStream<'a, S> where T: ?core::marker::Sized
+pub fn mssql_client::row_stream::RowStream<'a, S>::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for mssql_client::row_stream::RowStream<'a, S>
+pub fn mssql_client::row_stream::RowStream<'a, S>::from(T) -> T
+impl<T> opentelemetry::context::future_ext::FutureExt for mssql_client::row_stream::RowStream<'a, S>
+impl<T> tower_http::follow_redirect::policy::PolicyExt for mssql_client::row_stream::RowStream<'a, S> where T: ?core::marker::Sized
+pub fn mssql_client::row_stream::RowStream<'a, S>::and<P, B, E>(self, P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn mssql_client::row_stream::RowStream<'a, S>::or<P, B, E>(self, P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+impl<T> tracing::instrument::Instrument for mssql_client::row_stream::RowStream<'a, S>
+impl<T> tracing::instrument::WithSubscriber for mssql_client::row_stream::RowStream<'a, S>
+impl<T> typenum::type_operators::Same for mssql_client::row_stream::RowStream<'a, S>
+pub type mssql_client::row_stream::RowStream<'a, S>::Output = T
+impl<V, T> ppv_lite86::types::VZip<V> for mssql_client::row_stream::RowStream<'a, S> where V: ppv_lite86::types::MultiLane<T>
+pub fn mssql_client::row_stream::RowStream<'a, S>::vzip(self) -> V
 pub mod mssql_client::span_names
 pub const mssql_client::span_names::BEGIN_TRANSACTION: &str
 pub const mssql_client::span_names::BULK_INSERT: &str
@@ -3730,46 +3732,46 @@ impl<T> typenum::type_operators::Same for mssql_client::change_tracking::SyncVer
 pub type mssql_client::change_tracking::SyncVersionStatus::Output = T
 impl<V, T> ppv_lite86::types::VZip<V> for mssql_client::change_tracking::SyncVersionStatus where V: ppv_lite86::types::MultiLane<T>
 pub fn mssql_client::change_tracking::SyncVersionStatus::vzip(self) -> V
-pub struct mssql_client::BlobStream<'a>
-impl<'a> mssql_client::blob_stream::BlobStream<'a>
-pub fn mssql_client::blob_stream::BlobStream<'a>::blob_is_null(&self) -> bool
-pub fn mssql_client::blob_stream::BlobStream<'a>::blob_len(&self) -> core::option::Option<u64>
-pub fn mssql_client::blob_stream::BlobStream<'a>::columns(&self) -> &[mssql_client::row::Column]
-pub async fn mssql_client::blob_stream::BlobStream<'a>::copy_blob_to<W>(&mut self, &mut W) -> mssql_client::error::Result<u64> where W: tokio::io::async_write::AsyncWrite + core::marker::Unpin
-pub async fn mssql_client::blob_stream::BlobStream<'a>::next(&mut self) -> mssql_client::error::Result<core::option::Option<mssql_client::row::Row>>
-pub async fn mssql_client::blob_stream::BlobStream<'a>::read_chunk(&mut self) -> mssql_client::error::Result<core::option::Option<bytes::bytes::Bytes>>
-impl<'a> !core::marker::Freeze for mssql_client::blob_stream::BlobStream<'a>
-impl<'a> core::marker::Send for mssql_client::blob_stream::BlobStream<'a>
-impl<'a> core::marker::Sync for mssql_client::blob_stream::BlobStream<'a>
-impl<'a> core::marker::Unpin for mssql_client::blob_stream::BlobStream<'a>
-impl<'a> !core::panic::unwind_safe::RefUnwindSafe for mssql_client::blob_stream::BlobStream<'a>
-impl<'a> !core::panic::unwind_safe::UnwindSafe for mssql_client::blob_stream::BlobStream<'a>
-impl<T, U> core::convert::Into<U> for mssql_client::blob_stream::BlobStream<'a> where U: core::convert::From<T>
-pub fn mssql_client::blob_stream::BlobStream<'a>::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for mssql_client::blob_stream::BlobStream<'a> where U: core::convert::Into<T>
-pub type mssql_client::blob_stream::BlobStream<'a>::Error = core::convert::Infallible
-pub fn mssql_client::blob_stream::BlobStream<'a>::try_from(U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for mssql_client::blob_stream::BlobStream<'a> where U: core::convert::TryFrom<T>
-pub type mssql_client::blob_stream::BlobStream<'a>::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn mssql_client::blob_stream::BlobStream<'a>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for mssql_client::blob_stream::BlobStream<'a> where T: 'static + ?core::marker::Sized
-pub fn mssql_client::blob_stream::BlobStream<'a>::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for mssql_client::blob_stream::BlobStream<'a> where T: ?core::marker::Sized
-pub fn mssql_client::blob_stream::BlobStream<'a>::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for mssql_client::blob_stream::BlobStream<'a> where T: ?core::marker::Sized
-pub fn mssql_client::blob_stream::BlobStream<'a>::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for mssql_client::blob_stream::BlobStream<'a>
-pub fn mssql_client::blob_stream::BlobStream<'a>::from(T) -> T
-impl<T> opentelemetry::context::future_ext::FutureExt for mssql_client::blob_stream::BlobStream<'a>
-impl<T> tower_http::follow_redirect::policy::PolicyExt for mssql_client::blob_stream::BlobStream<'a> where T: ?core::marker::Sized
-pub fn mssql_client::blob_stream::BlobStream<'a>::and<P, B, E>(self, P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
-pub fn mssql_client::blob_stream::BlobStream<'a>::or<P, B, E>(self, P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
-impl<T> tracing::instrument::Instrument for mssql_client::blob_stream::BlobStream<'a>
-impl<T> tracing::instrument::WithSubscriber for mssql_client::blob_stream::BlobStream<'a>
-impl<T> typenum::type_operators::Same for mssql_client::blob_stream::BlobStream<'a>
-pub type mssql_client::blob_stream::BlobStream<'a>::Output = T
-impl<V, T> ppv_lite86::types::VZip<V> for mssql_client::blob_stream::BlobStream<'a> where V: ppv_lite86::types::MultiLane<T>
-pub fn mssql_client::blob_stream::BlobStream<'a>::vzip(self) -> V
+pub struct mssql_client::BlobStream<'a, S: mssql_client::state::ConnectionState>
+impl<'a, S: mssql_client::state::ConnectionState> mssql_client::blob_stream::BlobStream<'a, S>
+pub fn mssql_client::blob_stream::BlobStream<'a, S>::blob_is_null(&self) -> bool
+pub fn mssql_client::blob_stream::BlobStream<'a, S>::blob_len(&self) -> core::option::Option<u64>
+pub fn mssql_client::blob_stream::BlobStream<'a, S>::columns(&self) -> &[mssql_client::row::Column]
+pub async fn mssql_client::blob_stream::BlobStream<'a, S>::copy_blob_to<W>(&mut self, &mut W) -> mssql_client::error::Result<u64> where W: tokio::io::async_write::AsyncWrite + core::marker::Unpin
+pub async fn mssql_client::blob_stream::BlobStream<'a, S>::next(&mut self) -> mssql_client::error::Result<core::option::Option<mssql_client::row::Row>>
+pub async fn mssql_client::blob_stream::BlobStream<'a, S>::read_chunk(&mut self) -> mssql_client::error::Result<core::option::Option<bytes::bytes::Bytes>>
+impl<'a, S> !core::marker::Freeze for mssql_client::blob_stream::BlobStream<'a, S>
+impl<'a, S> core::marker::Send for mssql_client::blob_stream::BlobStream<'a, S> where S: core::marker::Send
+impl<'a, S> core::marker::Sync for mssql_client::blob_stream::BlobStream<'a, S> where S: core::marker::Sync
+impl<'a, S> core::marker::Unpin for mssql_client::blob_stream::BlobStream<'a, S>
+impl<'a, S> !core::panic::unwind_safe::RefUnwindSafe for mssql_client::blob_stream::BlobStream<'a, S>
+impl<'a, S> !core::panic::unwind_safe::UnwindSafe for mssql_client::blob_stream::BlobStream<'a, S>
+impl<T, U> core::convert::Into<U> for mssql_client::blob_stream::BlobStream<'a, S> where U: core::convert::From<T>
+pub fn mssql_client::blob_stream::BlobStream<'a, S>::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for mssql_client::blob_stream::BlobStream<'a, S> where U: core::convert::Into<T>
+pub type mssql_client::blob_stream::BlobStream<'a, S>::Error = core::convert::Infallible
+pub fn mssql_client::blob_stream::BlobStream<'a, S>::try_from(U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for mssql_client::blob_stream::BlobStream<'a, S> where U: core::convert::TryFrom<T>
+pub type mssql_client::blob_stream::BlobStream<'a, S>::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn mssql_client::blob_stream::BlobStream<'a, S>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> core::any::Any for mssql_client::blob_stream::BlobStream<'a, S> where T: 'static + ?core::marker::Sized
+pub fn mssql_client::blob_stream::BlobStream<'a, S>::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for mssql_client::blob_stream::BlobStream<'a, S> where T: ?core::marker::Sized
+pub fn mssql_client::blob_stream::BlobStream<'a, S>::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for mssql_client::blob_stream::BlobStream<'a, S> where T: ?core::marker::Sized
+pub fn mssql_client::blob_stream::BlobStream<'a, S>::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for mssql_client::blob_stream::BlobStream<'a, S>
+pub fn mssql_client::blob_stream::BlobStream<'a, S>::from(T) -> T
+impl<T> opentelemetry::context::future_ext::FutureExt for mssql_client::blob_stream::BlobStream<'a, S>
+impl<T> tower_http::follow_redirect::policy::PolicyExt for mssql_client::blob_stream::BlobStream<'a, S> where T: ?core::marker::Sized
+pub fn mssql_client::blob_stream::BlobStream<'a, S>::and<P, B, E>(self, P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn mssql_client::blob_stream::BlobStream<'a, S>::or<P, B, E>(self, P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+impl<T> tracing::instrument::Instrument for mssql_client::blob_stream::BlobStream<'a, S>
+impl<T> tracing::instrument::WithSubscriber for mssql_client::blob_stream::BlobStream<'a, S>
+impl<T> typenum::type_operators::Same for mssql_client::blob_stream::BlobStream<'a, S>
+pub type mssql_client::blob_stream::BlobStream<'a, S>::Output = T
+impl<V, T> ppv_lite86::types::VZip<V> for mssql_client::blob_stream::BlobStream<'a, S> where V: ppv_lite86::types::MultiLane<T>
+pub fn mssql_client::blob_stream::BlobStream<'a, S>::vzip(self) -> V
 pub struct mssql_client::BulkColumn
 pub mssql_client::BulkColumn::name: alloc::string::String
 pub mssql_client::BulkColumn::nullable: bool
@@ -4261,6 +4263,8 @@ pub async fn mssql_client::client::Client<mssql_client::state::InTransaction>::c
 pub async fn mssql_client::client::Client<mssql_client::state::InTransaction>::execute(&mut self, &str, &[&(dyn mssql_types::to_sql::ToSql + core::marker::Sync)]) -> mssql_client::error::Result<u64>
 pub async fn mssql_client::client::Client<mssql_client::state::InTransaction>::execute_with_timeout(&mut self, &str, &[&(dyn mssql_types::to_sql::ToSql + core::marker::Sync)], core::time::Duration) -> mssql_client::error::Result<u64>
 pub async fn mssql_client::client::Client<mssql_client::state::InTransaction>::query<'a>(&'a mut self, &str, &[&(dyn mssql_types::to_sql::ToSql + core::marker::Sync)]) -> mssql_client::error::Result<mssql_client::stream::QueryStream<'a>>
+pub async fn mssql_client::client::Client<mssql_client::state::InTransaction>::query_stream<'a>(&'a mut self, &str, &[&(dyn mssql_types::to_sql::ToSql + core::marker::Sync)]) -> mssql_client::error::Result<mssql_client::row_stream::RowStream<'a, mssql_client::state::InTransaction>>
+pub async fn mssql_client::client::Client<mssql_client::state::InTransaction>::query_stream_blob<'a>(&'a mut self, &str, &[&(dyn mssql_types::to_sql::ToSql + core::marker::Sync)]) -> mssql_client::error::Result<mssql_client::blob_stream::BlobStream<'a, mssql_client::state::InTransaction>>
 pub async fn mssql_client::client::Client<mssql_client::state::InTransaction>::query_with_timeout<'a>(&'a mut self, &str, &[&(dyn mssql_types::to_sql::ToSql + core::marker::Sync)], core::time::Duration) -> mssql_client::error::Result<mssql_client::stream::QueryStream<'a>>
 pub async fn mssql_client::client::Client<mssql_client::state::InTransaction>::release_savepoint(&mut self, mssql_client::transaction::SavePoint) -> mssql_client::error::Result<()>
 pub async fn mssql_client::client::Client<mssql_client::state::InTransaction>::rollback(self) -> mssql_client::error::Result<mssql_client::client::Client<mssql_client::state::Ready>>
@@ -4283,8 +4287,8 @@ pub fn mssql_client::client::Client<mssql_client::state::Ready>::needs_reset(&se
 pub fn mssql_client::client::Client<mssql_client::state::Ready>::port(&self) -> u16
 pub async fn mssql_client::client::Client<mssql_client::state::Ready>::query<'a>(&'a mut self, &str, &[&(dyn mssql_types::to_sql::ToSql + core::marker::Sync)]) -> mssql_client::error::Result<mssql_client::stream::QueryStream<'a>>
 pub async fn mssql_client::client::Client<mssql_client::state::Ready>::query_multiple<'a>(&'a mut self, &str, &[&(dyn mssql_types::to_sql::ToSql + core::marker::Sync)]) -> mssql_client::error::Result<mssql_client::stream::MultiResultStream<'a>>
-pub async fn mssql_client::client::Client<mssql_client::state::Ready>::query_stream<'a>(&'a mut self, &str, &[&(dyn mssql_types::to_sql::ToSql + core::marker::Sync)]) -> mssql_client::error::Result<mssql_client::row_stream::RowStream<'a>>
-pub async fn mssql_client::client::Client<mssql_client::state::Ready>::query_stream_blob<'a>(&'a mut self, &str, &[&(dyn mssql_types::to_sql::ToSql + core::marker::Sync)]) -> mssql_client::error::Result<mssql_client::blob_stream::BlobStream<'a>>
+pub async fn mssql_client::client::Client<mssql_client::state::Ready>::query_stream<'a>(&'a mut self, &str, &[&(dyn mssql_types::to_sql::ToSql + core::marker::Sync)]) -> mssql_client::error::Result<mssql_client::row_stream::RowStream<'a, mssql_client::state::Ready>>
+pub async fn mssql_client::client::Client<mssql_client::state::Ready>::query_stream_blob<'a>(&'a mut self, &str, &[&(dyn mssql_types::to_sql::ToSql + core::marker::Sync)]) -> mssql_client::error::Result<mssql_client::blob_stream::BlobStream<'a, mssql_client::state::Ready>>
 pub async fn mssql_client::client::Client<mssql_client::state::Ready>::query_with_timeout<'a>(&'a mut self, &str, &[&(dyn mssql_types::to_sql::ToSql + core::marker::Sync)], core::time::Duration) -> mssql_client::error::Result<mssql_client::stream::QueryStream<'a>>
 pub async fn mssql_client::client::Client<mssql_client::state::Ready>::simple_query(&mut self, &str) -> mssql_client::error::Result<()>
 impl<S: mssql_client::state::ConnectionState> mssql_client::client::Client<S>
@@ -5664,45 +5668,45 @@ impl<T> typenum::type_operators::Same for mssql_client::row::Row
 pub type mssql_client::row::Row::Output = T
 impl<V, T> ppv_lite86::types::VZip<V> for mssql_client::row::Row where V: ppv_lite86::types::MultiLane<T>
 pub fn mssql_client::row::Row::vzip(self) -> V
-pub struct mssql_client::RowStream<'a>
-impl<'a> mssql_client::row_stream::RowStream<'a>
-pub async fn mssql_client::row_stream::RowStream<'a>::cancel(self) -> mssql_client::error::Result<()>
-pub async fn mssql_client::row_stream::RowStream<'a>::collect_all(self) -> mssql_client::error::Result<alloc::vec::Vec<mssql_client::row::Row>>
-pub fn mssql_client::row_stream::RowStream<'a>::columns(&self) -> &[mssql_client::row::Column]
-pub fn mssql_client::row_stream::RowStream<'a>::is_finished(&self) -> bool
-pub async fn mssql_client::row_stream::RowStream<'a>::try_next(&mut self) -> mssql_client::error::Result<core::option::Option<mssql_client::row::Row>>
-impl<'a> !core::marker::Freeze for mssql_client::row_stream::RowStream<'a>
-impl<'a> core::marker::Send for mssql_client::row_stream::RowStream<'a>
-impl<'a> core::marker::Sync for mssql_client::row_stream::RowStream<'a>
-impl<'a> core::marker::Unpin for mssql_client::row_stream::RowStream<'a>
-impl<'a> !core::panic::unwind_safe::RefUnwindSafe for mssql_client::row_stream::RowStream<'a>
-impl<'a> !core::panic::unwind_safe::UnwindSafe for mssql_client::row_stream::RowStream<'a>
-impl<T, U> core::convert::Into<U> for mssql_client::row_stream::RowStream<'a> where U: core::convert::From<T>
-pub fn mssql_client::row_stream::RowStream<'a>::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for mssql_client::row_stream::RowStream<'a> where U: core::convert::Into<T>
-pub type mssql_client::row_stream::RowStream<'a>::Error = core::convert::Infallible
-pub fn mssql_client::row_stream::RowStream<'a>::try_from(U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for mssql_client::row_stream::RowStream<'a> where U: core::convert::TryFrom<T>
-pub type mssql_client::row_stream::RowStream<'a>::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn mssql_client::row_stream::RowStream<'a>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for mssql_client::row_stream::RowStream<'a> where T: 'static + ?core::marker::Sized
-pub fn mssql_client::row_stream::RowStream<'a>::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for mssql_client::row_stream::RowStream<'a> where T: ?core::marker::Sized
-pub fn mssql_client::row_stream::RowStream<'a>::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for mssql_client::row_stream::RowStream<'a> where T: ?core::marker::Sized
-pub fn mssql_client::row_stream::RowStream<'a>::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for mssql_client::row_stream::RowStream<'a>
-pub fn mssql_client::row_stream::RowStream<'a>::from(T) -> T
-impl<T> opentelemetry::context::future_ext::FutureExt for mssql_client::row_stream::RowStream<'a>
-impl<T> tower_http::follow_redirect::policy::PolicyExt for mssql_client::row_stream::RowStream<'a> where T: ?core::marker::Sized
-pub fn mssql_client::row_stream::RowStream<'a>::and<P, B, E>(self, P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
-pub fn mssql_client::row_stream::RowStream<'a>::or<P, B, E>(self, P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
-impl<T> tracing::instrument::Instrument for mssql_client::row_stream::RowStream<'a>
-impl<T> tracing::instrument::WithSubscriber for mssql_client::row_stream::RowStream<'a>
-impl<T> typenum::type_operators::Same for mssql_client::row_stream::RowStream<'a>
-pub type mssql_client::row_stream::RowStream<'a>::Output = T
-impl<V, T> ppv_lite86::types::VZip<V> for mssql_client::row_stream::RowStream<'a> where V: ppv_lite86::types::MultiLane<T>
-pub fn mssql_client::row_stream::RowStream<'a>::vzip(self) -> V
+pub struct mssql_client::RowStream<'a, S: mssql_client::state::ConnectionState>
+impl<'a, S: mssql_client::state::ConnectionState> mssql_client::row_stream::RowStream<'a, S>
+pub async fn mssql_client::row_stream::RowStream<'a, S>::cancel(self) -> mssql_client::error::Result<()>
+pub async fn mssql_client::row_stream::RowStream<'a, S>::collect_all(self) -> mssql_client::error::Result<alloc::vec::Vec<mssql_client::row::Row>>
+pub fn mssql_client::row_stream::RowStream<'a, S>::columns(&self) -> &[mssql_client::row::Column]
+pub fn mssql_client::row_stream::RowStream<'a, S>::is_finished(&self) -> bool
+pub async fn mssql_client::row_stream::RowStream<'a, S>::try_next(&mut self) -> mssql_client::error::Result<core::option::Option<mssql_client::row::Row>>
+impl<'a, S> !core::marker::Freeze for mssql_client::row_stream::RowStream<'a, S>
+impl<'a, S> core::marker::Send for mssql_client::row_stream::RowStream<'a, S> where S: core::marker::Send
+impl<'a, S> core::marker::Sync for mssql_client::row_stream::RowStream<'a, S> where S: core::marker::Sync
+impl<'a, S> core::marker::Unpin for mssql_client::row_stream::RowStream<'a, S>
+impl<'a, S> !core::panic::unwind_safe::RefUnwindSafe for mssql_client::row_stream::RowStream<'a, S>
+impl<'a, S> !core::panic::unwind_safe::UnwindSafe for mssql_client::row_stream::RowStream<'a, S>
+impl<T, U> core::convert::Into<U> for mssql_client::row_stream::RowStream<'a, S> where U: core::convert::From<T>
+pub fn mssql_client::row_stream::RowStream<'a, S>::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for mssql_client::row_stream::RowStream<'a, S> where U: core::convert::Into<T>
+pub type mssql_client::row_stream::RowStream<'a, S>::Error = core::convert::Infallible
+pub fn mssql_client::row_stream::RowStream<'a, S>::try_from(U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for mssql_client::row_stream::RowStream<'a, S> where U: core::convert::TryFrom<T>
+pub type mssql_client::row_stream::RowStream<'a, S>::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn mssql_client::row_stream::RowStream<'a, S>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> core::any::Any for mssql_client::row_stream::RowStream<'a, S> where T: 'static + ?core::marker::Sized
+pub fn mssql_client::row_stream::RowStream<'a, S>::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for mssql_client::row_stream::RowStream<'a, S> where T: ?core::marker::Sized
+pub fn mssql_client::row_stream::RowStream<'a, S>::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for mssql_client::row_stream::RowStream<'a, S> where T: ?core::marker::Sized
+pub fn mssql_client::row_stream::RowStream<'a, S>::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for mssql_client::row_stream::RowStream<'a, S>
+pub fn mssql_client::row_stream::RowStream<'a, S>::from(T) -> T
+impl<T> opentelemetry::context::future_ext::FutureExt for mssql_client::row_stream::RowStream<'a, S>
+impl<T> tower_http::follow_redirect::policy::PolicyExt for mssql_client::row_stream::RowStream<'a, S> where T: ?core::marker::Sized
+pub fn mssql_client::row_stream::RowStream<'a, S>::and<P, B, E>(self, P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn mssql_client::row_stream::RowStream<'a, S>::or<P, B, E>(self, P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+impl<T> tracing::instrument::Instrument for mssql_client::row_stream::RowStream<'a, S>
+impl<T> tracing::instrument::WithSubscriber for mssql_client::row_stream::RowStream<'a, S>
+impl<T> typenum::type_operators::Same for mssql_client::row_stream::RowStream<'a, S>
+pub type mssql_client::row_stream::RowStream<'a, S>::Output = T
+impl<V, T> ppv_lite86::types::VZip<V> for mssql_client::row_stream::RowStream<'a, S> where V: ppv_lite86::types::MultiLane<T>
+pub fn mssql_client::row_stream::RowStream<'a, S>::vzip(self) -> V
 pub struct mssql_client::SanitizationConfig
 pub mssql_client::SanitizationConfig::enabled: bool
 pub mssql_client::SanitizationConfig::max_length: usize


### PR DESCRIPTION
## Summary

Enables incremental streaming (`query_stream` / `query_stream_blob`) on `Client<InTransaction>`, not just `Client<Ready>`, and addresses the rest of the streaming review findings (mid-stream ENVCHANGE sync, BLOB chunk docs, ADR-007 wording, design-deviation docs).

## Linked issues

Refs #257, #258 (streaming follow-ups). Closes none.

## Type of change

- [x] New feature
- [x] Breaking change (see below)
- [x] Documentation
- [x] Test-only additions

## What changed

- **Streaming in transactions.** `RowStream` / `BlobStream` are now generic over connection state (`RowStream<'a, S = Ready>`, `BlobStream<'a, S = Ready>`). `query_stream` / `query_stream_blob` are exposed on both `Ready` and `InTransaction` via a shared `pub(crate)` inner on `impl<S: ConnectionState>` — no duplicated streaming logic. They remain *off* `Disconnected`/`Connected` (type-state preserved; compile-fail tests still pass). The stream borrows the client for its lifetime, so it must be dropped before `commit`/`rollback`.
- **ENVCHANGE mid-stream.** `RowStream::try_next` and `BlobStream` now process transaction ENVCHANGE tokens, keeping `transaction_descriptor` in sync with raw `BEGIN`/`COMMIT`/`ROLLBACK` like the buffered readers.
- **BLOB chunk docs.** `read_chunk` documents that chunks are raw bytes — an `NVARCHAR(MAX)`/`XML` chunk boundary can split a UCS-2 code unit, so chunks must not be decoded to `str` independently.
- **Design + ADR docs.** `state.rs` documents the `&mut`-borrow choice over the unused `Streaming` type-state. ADR-007 wording reconciled with the test (asserts a conservative <2 MB bound; observed peaks ~20 KB / ~9 KB). `LIMITATIONS.md` notes streaming now works inside transactions.

## Test plan

- [x] `cargo nextest run -p mssql-client --all-features` (448 passed) + doctests (65 passed)
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --all --check`, `cargo doc -D warnings`, `cargo xtask check-features`, `typos`, `scripts/check-public-api.sh` all clean
- [x] Live SQL Server 2022: the streaming suites pass, including 4 new `#[ignore]` tests — `error_mid_stream_then_reuse`, `query_stream_within_transaction`, `blob_stream_drop_mid_blob_then_reuse`, `blob_stream_within_transaction`

No standalone backpressure test was added: backpressure is not separately observable without socket-read instrumentation, and `streaming_memory.rs` already proves it (full drain of a ~10 MB result set with bounded peak heap).

## Breaking changes

### What breaks

`RowStream` and `BlobStream` gain a defaulted connection-state type parameter:
`RowStream<'a>` → `RowStream<'a, S = Ready>` (same for `BlobStream`).

### Migration guide

Source-compatible for the common case — naming the types without the parameter still resolves via the `Ready` default:

\`\`\`rust
// Before and after — both compile unchanged:
let mut stream: RowStream<'_> = client.query_stream(sql, &[]).await?;
\`\`\`

Only code that explicitly spelled the full generic list of these types (rare) needs updating.

### Pre-1.0 policy check

- [x] Allowed under STABILITY.md § Pre-1.0 (minor bumps may contain breaking changes pre-1.0)
- [x] Marked with the `!` + `BREAKING CHANGE:` footer so release-plz bumps minor (not patch); the `### Breaking Changes` CHANGELOG entry is generated by release-plz from the commit
- [x] No MSRV change

## Additional notes

`RowStream`/`BlobStream` were genericized rather than duplicated to avoid ~200 lines of parallel streaming logic; the `&mut Client<S>` borrow already enforces connection exclusivity for both states. Public-API snapshot regenerated (`public-api/mssql-client.txt`).