### PR TITLE
docs(changelog): correct the v0.9.0 "yanked" claim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -208,7 +208,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.10.0] - 2026-04-17
 
-> **v0.9.0 was yanked from crates.io.** v0.9.0 contained two critical bugs
+> **Do not use v0.9.0.** It remains published on crates.io (it was not yanked) but contained two critical bugs
 > (LOGIN7 feature extension pointer indirection and `EncryptionContext`
 > provider loss under `Config` clone) that prevented Always Encrypted from
 > functioning at all. Both are fixed in this release. If you are evaluating


### PR DESCRIPTION
## Summary

The v0.10.0 CHANGELOG advisory banner stated "v0.9.0 was yanked from crates.io." That is inaccurate — crates.io reports `mssql-client 0.9.0 yanked: false`; v0.9.0 is still published and installable. This corrects the banner to warn users off v0.9.0 (its Always Encrypted bugs are real and were fixed in v0.10.0) without claiming a yank that never happened.

Surfaced while triaging issue #90 (the same false claim was in that issue, corrected separately). We decided **not** to yank v0.9.0 — it is six minors back and EOL per SECURITY.md — so the honest fix is to correct the record.

## Type of change

- [x] Documentation only

Refs #90.