### PR TITLE
docs(limitations): mark CI-verified vs manually-validated SQL Server versions

### DIFF
--- a/LIMITATIONS.md
+++ b/LIMITATIONS.md
@@ -282,6 +282,12 @@ the full rationale.
 | TDS 7.4 | SQL Server 2012+ (default) | `TdsVersion::V7_4` or `TDSVersion=7.4` |
 | TDS 8.0 | SQL Server 2022+ strict mode | `TdsVersion::V8_0` or `Encrypt=strict` |
 
+**How each version is validated:** SQL Server **2017, 2019, and 2022 are
+CI-verified** — the integration suite runs the full `#[ignore]`d test suite
+against all three on every change. SQL Server **2008–2016** (TDS 7.3A/7.3B) and
+Azure SQL are **validated manually** against real servers, not in CI, so
+regressions on those versions are caught later than on the CI-verified ones.
+
 ### TLS Compatibility
 
 Legacy SQL Server (2016 and earlier) may only support TLS 1.0/1.1. Since rustls requires TLS 1.2+, use `Encrypt=no_tls` for unencrypted connections on trusted networks:


### PR DESCRIPTION
## Summary

The LIMITATIONS.md Supported Versions table listed all TDS/SQL Server versions with no indication of which are continuously **CI-verified** (2017/2019/2022) vs **validated only manually** (2008–2016, Azure SQL) — the distinction README.md and CLAUDE.md already make. This adds it so the table doesn't read as uniform coverage.

This is the last loose end of #237; its other items (date-arithmetic `checked_add_signed` swap, mega-function decomposition) are tracked under #204.

## Type of change
- [x] Documentation only

Closes #237.