### PR TITLE
refactor(client)!: pre-1.0 public-surface cleanup — remove dead Streaming state (#286), pub(crate) the AE crypto surface (#285)

### DIFF
--- a/STABILITY.md
+++ b/STABILITY.md
@@ -92,7 +92,7 @@ The following APIs are considered stable and covered by semver guarantees:
 | `Error` enum variants | Stable |
 | `Client::open_filestream()` | Stable (`filestream` feature, Windows only) |
 | `FileStream` / `FileStreamAccess` | Stable (`filestream` feature, Windows only) |
-| `EncryptionContext` / `EncryptionConfig` | Stable (`always-encrypted` feature) |
+| `EncryptionConfig` | Stable (`always-encrypted` feature) |
 | `KeyStoreProvider` trait | Stable (`always-encrypted` feature) |
 | `ApplicationIntent` enum | Stable |
 | `Config::application_intent()` | Stable |

--- a/crates/mssql-client/src/bulk.rs
+++ b/crates/mssql-client/src/bulk.rs
@@ -569,7 +569,7 @@ impl BulkInsert {
     /// This follows the pattern used by Tiberius: the server's own metadata
     /// from `SELECT TOP 0` is echoed back rather than constructing it from
     /// user-specified types.
-    pub fn new_with_server_metadata(
+    pub(crate) fn new_with_server_metadata(
         mut columns: Vec<BulkColumn>,
         batch_size: usize,
         raw_colmetadata: Option<bytes::Bytes>,

--- a/crates/mssql-client/src/client.rs
+++ b/crates/mssql-client/src/client.rs
@@ -501,7 +501,7 @@ impl<S: ConnectionState> Client<S> {
     /// Issues the `sp_describe_parameter_encryption` system RPC for the
     /// parameterized statement `tsql` with the parameter declaration `params`
     /// (e.g. `"@id int, @name nvarchar(64)"`), and parses the two result sets
-    /// into a [`ParameterEncryptionInfo`](crate::ParameterEncryptionInfo): the
+    /// into a [`ParameterEncryptionInfo`](crate::encryption::ParameterEncryptionInfo): the
     /// CEK table, plus — for each parameter the server reports as encrypted —
     /// which CEK and whether deterministic or randomized. Parameters the server
     /// reports as plaintext are omitted.
@@ -509,11 +509,11 @@ impl<S: ConnectionState> Client<S> {
     /// This is the first step of Always Encrypted parameter encryption; the
     /// connection must have negotiated it (`Column Encryption Setting=Enabled`).
     #[cfg(feature = "always-encrypted")]
-    pub async fn describe_parameter_encryption(
+    pub(crate) async fn describe_parameter_encryption(
         &mut self,
         tsql: &str,
         params: &str,
-    ) -> Result<crate::ParameterEncryptionInfo> {
+    ) -> Result<crate::encryption::ParameterEncryptionInfo> {
         let tsql_arg = tsql.to_string();
         let params_arg = params.to_string();
         let mut result = self
@@ -522,7 +522,9 @@ impl<S: ConnectionState> Client<S> {
                 &[&tsql_arg, &params_arg],
             )
             .await?;
-        crate::ParameterEncryptionInfo::from_describe_result_sets(&mut result.result_sets)
+        crate::encryption::ParameterEncryptionInfo::from_describe_result_sets(
+            &mut result.result_sets,
+        )
     }
 
     /// Build the `sp_executesql` request for a parameterized statement.

--- a/crates/mssql-client/src/encryption.rs
+++ b/crates/mssql-client/src/encryption.rs
@@ -50,7 +50,7 @@
 //! ## How decryption works
 //!
 //! 1. Always Encrypted support is negotiated in LOGIN7 (`FEATURE_EXT`).
-//! 2. `ColMetaData` carries [`CryptoMetadata`] and the [`CekTable`]; column
+//! 2. `ColMetaData` carries [`CryptoMetadata`](tds_protocol::crypto::CryptoMetadata) and the [`CekTable`]; column
 //!    encryption keys are resolved asynchronously up front (calling the key-store
 //!    providers).
 //! 3. Each encrypted cell is decrypted during row parsing via
@@ -99,10 +99,12 @@
 //! - **DBA protection**: Even database administrators cannot read encrypted data
 //! - **Key separation**: CMK stays in secure key store, never transmitted
 
+#[cfg(feature = "always-encrypted")]
 use std::collections::HashMap;
 
 use mssql_auth::KeyStoreProvider;
-use tds_protocol::crypto::{CekTable, CekTableEntry, CryptoMetadata, EncryptionTypeWire};
+#[cfg(feature = "always-encrypted")]
+use tds_protocol::crypto::{CekTable, CekTableEntry, EncryptionTypeWire};
 
 #[cfg(feature = "always-encrypted")]
 use mssql_auth::{AeadEncryptor, CekCache, CekCacheKey, EncryptionError};
@@ -191,7 +193,7 @@ impl std::fmt::Debug for EncryptionConfig {
 /// across connection retries/redirects where the `Config` (and its inner
 /// encryption config Arc) gets cloned multiple times.
 #[cfg(feature = "always-encrypted")]
-pub struct EncryptionContext {
+pub(crate) struct EncryptionContext {
     /// Shared handle on the user-supplied configuration. Providers are looked
     /// up by name through this reference, so an arbitrary number of `Arc`
     /// clones do not lose access to them.
@@ -218,18 +220,13 @@ impl EncryptionContext {
         }
     }
 
-    /// Create a new encryption context from configuration.
-    pub fn new(config: EncryptionConfig) -> Self {
-        Self::from_arc(std::sync::Arc::new(config))
-    }
-
     /// Get or decrypt a CEK for a column.
     ///
     /// This handles the CEK caching and decryption logic:
     /// 1. Check cache for existing encryptor
     /// 2. If not cached, decrypt CEK using the appropriate key store
     /// 3. Create and cache the encryptor
-    pub async fn get_encryptor(
+    pub(crate) async fn get_encryptor(
         &self,
         cek_entry: &CekTableEntry,
     ) -> Result<Arc<AeadEncryptor>, EncryptionError> {
@@ -284,7 +281,7 @@ impl EncryptionContext {
     /// * `plaintext` - The plaintext value to encrypt
     /// * `cek_entry` - The CEK table entry for this column
     /// * `encryption_type` - Deterministic or randomized encryption
-    pub async fn encrypt_value(
+    pub(crate) async fn encrypt_value(
         &self,
         plaintext: &[u8],
         cek_entry: &CekTableEntry,
@@ -305,28 +302,6 @@ impl EncryptionContext {
         encryptor.encrypt(plaintext, enc_type)
     }
 
-    /// Decrypt a value from an encrypted column.
-    ///
-    /// # Arguments
-    ///
-    /// * `ciphertext` - The encrypted value
-    /// * `cek_entry` - The CEK table entry for this column
-    pub async fn decrypt_value(
-        &self,
-        ciphertext: &[u8],
-        cek_entry: &CekTableEntry,
-    ) -> Result<Vec<u8>, EncryptionError> {
-        let encryptor = self.get_encryptor(cek_entry).await?;
-        encryptor.decrypt(ciphertext)
-    }
-
-    /// Clear the CEK cache.
-    ///
-    /// Call this when keys may have been rotated.
-    pub fn clear_cache(&self) {
-        self.cek_cache.clear();
-    }
-
     /// Check if a provider is registered.
     pub fn has_provider(&self, name: &str) -> bool {
         self.config.get_provider(name).is_some()
@@ -344,69 +319,20 @@ impl std::fmt::Debug for EncryptionContext {
     }
 }
 
-/// Column encryption metadata for a result set.
-///
-/// This combines the CEK table with per-column crypto metadata,
-/// providing all information needed to decrypt result columns.
-#[derive(Debug, Clone)]
-pub struct ResultSetEncryptionInfo {
-    /// CEK table for this result set.
-    pub cek_table: CekTable,
-    /// Crypto metadata for each column (index matches column ordinal).
-    pub column_crypto: Vec<Option<CryptoMetadata>>,
-}
-
-impl ResultSetEncryptionInfo {
-    /// Create encryption info for a result set.
-    pub fn new(cek_table: CekTable, column_count: usize) -> Self {
-        Self {
-            cek_table,
-            column_crypto: vec![None; column_count],
-        }
-    }
-
-    /// Set crypto metadata for a column.
-    pub fn set_column_crypto(&mut self, ordinal: usize, metadata: CryptoMetadata) {
-        if ordinal < self.column_crypto.len() {
-            self.column_crypto[ordinal] = Some(metadata);
-        }
-    }
-
-    /// Get the CEK entry for a column.
-    pub fn get_cek_for_column(&self, ordinal: usize) -> Option<&CekTableEntry> {
-        let crypto = self.column_crypto.get(ordinal)?.as_ref()?;
-        self.cek_table.get(crypto.cek_table_ordinal)
-    }
-
-    /// Check if a column is encrypted.
-    pub fn is_column_encrypted(&self, ordinal: usize) -> bool {
-        self.column_crypto
-            .get(ordinal)
-            .map(|c| c.is_some())
-            .unwrap_or(false)
-    }
-
-    /// Get the encryption type for a column.
-    pub fn get_encryption_type(&self, ordinal: usize) -> Option<EncryptionTypeWire> {
-        self.column_crypto
-            .get(ordinal)?
-            .as_ref()
-            .map(|c| c.encryption_type)
-    }
-}
-
 /// Parameter encryption metadata for a query.
 ///
 /// This is returned by `sp_describe_parameter_encryption` and describes
 /// how each parameter should be encrypted.
+#[cfg(feature = "always-encrypted")]
 #[derive(Debug, Clone)]
-pub struct ParameterEncryptionInfo {
+pub(crate) struct ParameterEncryptionInfo {
     /// CEK table for parameters.
     pub cek_table: CekTable,
     /// Mapping from parameter name to crypto metadata.
     pub parameters: HashMap<String, ParameterCryptoInfo>,
 }
 
+#[cfg(feature = "always-encrypted")]
 impl ParameterEncryptionInfo {
     /// Create empty parameter encryption info.
     pub fn new() -> Self {
@@ -416,22 +342,13 @@ impl ParameterEncryptionInfo {
         }
     }
 
-    /// Add encryption info for a parameter.
-    pub fn add_parameter(&mut self, name: String, info: ParameterCryptoInfo) {
-        self.parameters.insert(name, info);
-    }
-
     /// Get encryption info for a parameter.
     pub fn get_parameter(&self, name: &str) -> Option<&ParameterCryptoInfo> {
         self.parameters.get(name)
     }
-
-    /// Check if a parameter needs encryption.
-    pub fn needs_encryption(&self, name: &str) -> bool {
-        self.parameters.contains_key(name)
-    }
 }
 
+#[cfg(feature = "always-encrypted")]
 impl Default for ParameterEncryptionInfo {
     fn default() -> Self {
         Self::new()
@@ -440,8 +357,9 @@ impl Default for ParameterEncryptionInfo {
 
 /// Encryption directive for a single parameter, parsed from result set 2 of
 /// `sp_describe_parameter_encryption`.
+#[cfg(feature = "always-encrypted")]
 #[derive(Debug, Clone)]
-pub struct ParameterCryptoInfo {
+pub(crate) struct ParameterCryptoInfo {
     /// 0-based index into [`ParameterEncryptionInfo::cek_table`].
     ///
     /// The server reports a (often 1-based) key ordinal; the parser translates
@@ -454,23 +372,6 @@ pub struct ParameterCryptoInfo {
     pub algorithm_id: u8,
     /// Normalization rule version applied to the plaintext before encryption.
     pub normalization_rule_version: u8,
-}
-
-impl ParameterCryptoInfo {
-    /// Create new parameter crypto info.
-    pub fn new(
-        cek_ordinal: u16,
-        encryption_type: EncryptionTypeWire,
-        algorithm_id: u8,
-        normalization_rule_version: u8,
-    ) -> Self {
-        Self {
-            cek_ordinal,
-            encryption_type,
-            algorithm_id,
-            normalization_rule_version,
-        }
-    }
 }
 
 /// Parsing of the two result sets returned by `sp_describe_parameter_encryption`.
@@ -676,7 +577,7 @@ fn describe_type_error(col: &str, idx: usize, expected: &str, got: Option<&SqlVa
 
 /// Normalize a parameter value to the plaintext byte form Always Encrypted
 /// encrypts — SQL Server's "normalized" form for the value's type. The result
-/// is the plaintext input to [`EncryptionContext::encrypt_value`].
+/// is the plaintext input to `EncryptionContext::encrypt_value`.
 ///
 /// Normalization is type-specific and is **not** the regular TDS wire encoding:
 /// e.g. INT normalizes to 8 little-endian bytes (not 4), and strings/binaries
@@ -1260,52 +1161,6 @@ mod tests {
         assert!(!config.is_ready()); // No providers
     }
 
-    #[test]
-    fn test_result_set_encryption_info() {
-        let cek_table = CekTable::new();
-        let mut info = ResultSetEncryptionInfo::new(cek_table, 3);
-
-        assert!(!info.is_column_encrypted(0));
-        assert!(!info.is_column_encrypted(1));
-        assert!(!info.is_column_encrypted(2));
-
-        let metadata = CryptoMetadata {
-            cek_table_ordinal: 0,
-            base_user_type: 0,
-            base_col_type: 0x26,
-            base_type_info: tds_protocol::token::TypeInfo::default(),
-            algorithm_id: 2,
-            encryption_type: EncryptionTypeWire::Deterministic,
-            normalization_version: 1,
-        };
-
-        info.set_column_crypto(1, metadata);
-        assert!(!info.is_column_encrypted(0));
-        assert!(info.is_column_encrypted(1));
-        assert!(!info.is_column_encrypted(2));
-
-        assert_eq!(
-            info.get_encryption_type(1),
-            Some(EncryptionTypeWire::Deterministic)
-        );
-    }
-
-    #[test]
-    fn test_parameter_encryption_info() {
-        let mut info = ParameterEncryptionInfo::new();
-
-        assert!(!info.needs_encryption("@p1"));
-
-        let crypto = ParameterCryptoInfo::new(0, EncryptionTypeWire::Randomized, 2, 1);
-        info.add_parameter("@p1".to_string(), crypto);
-
-        assert!(info.needs_encryption("@p1"));
-        assert!(!info.needs_encryption("@p2"));
-
-        let param = info.get_parameter("@p1").unwrap();
-        assert_eq!(param.encryption_type, EncryptionTypeWire::Randomized);
-    }
-
     /// Parse synthetic `sp_describe_parameter_encryption` result sets that mirror
     /// the live wire shape (captured in `.tmp/ae-3a2-describe-schema.md`). The
     /// column *order* is validated separately by the live test; this exercises
@@ -1432,7 +1287,7 @@ mod tests {
             "server ordinal 2 -> positional index 1"
         );
 
-        assert!(!info.needs_encryption("@plain"));
+        assert!(info.get_parameter("@plain").is_none());
         assert_eq!(info.parameters.len(), 2);
     }
 

--- a/crates/mssql-client/src/lib.rs
+++ b/crates/mssql-client/src/lib.rs
@@ -155,11 +155,7 @@ pub use tvp::{Tvp, TvpColumn, TvpRow, TvpValue};
 pub use filestream::{FileStream, FileStreamAccess, open_options as filestream_options};
 
 // Always Encrypted types
-#[cfg(feature = "always-encrypted")]
-pub use encryption::EncryptionContext;
-pub use encryption::{
-    EncryptionConfig, ParameterCryptoInfo, ParameterEncryptionInfo, ResultSetEncryptionInfo,
-};
+pub use encryption::EncryptionConfig;
 
 // OpenTelemetry instrumentation (available whether or not otel feature is enabled)
 pub use instrumentation::{

--- a/crates/mssql-client/src/lib.rs
+++ b/crates/mssql-client/src/lib.rs
@@ -130,9 +130,7 @@ pub use mssql_types::{Money, Numeric, SmallMoney, numeric};
 pub use procedure::ProcedureBuilder;
 pub use query::in_params;
 pub use row::{Column, Row};
-pub use state::{
-    Connected, ConnectionState, Disconnected, InTransaction, ProtocolState, Ready, Streaming,
-};
+pub use state::{Connected, ConnectionState, Disconnected, InTransaction, ProtocolState, Ready};
 
 /// Internal entry points for the fuzzing harness in `fuzz/`.
 ///
@@ -209,12 +207,6 @@ mod auto_trait_tests {
     fn client_connected_is_send_sync() {
         assert_send::<Client<Connected>>();
         assert_sync::<Client<Connected>>();
-    }
-
-    #[test]
-    fn client_streaming_is_send_sync() {
-        assert_send::<Client<Streaming>>();
-        assert_sync::<Client<Streaming>>();
     }
 
     // --- Configuration ---

--- a/crates/mssql-client/src/state.rs
+++ b/crates/mssql-client/src/state.rs
@@ -16,13 +16,13 @@
 //! mutably and returns an iterable result.
 //!
 //! Incremental streaming (`query_stream` / `query_stream_blob`) likewise does
-//! **not** transition into a dedicated state. Rather than the [`Streaming`]
-//! type-state originally sketched, the streams borrow the client mutably
+//! **not** transition into a dedicated state. Rather than a dedicated
+//! streaming type-state, the streams borrow the client mutably
 //! (`&mut Client<S>`) for their lifetime: the borrow checker already enforces
 //! that no other request can run on the connection until the stream is dropped,
 //! and a `&mut` borrow — unlike a consuming state transition — works uniformly
 //! for both [`Ready`] and [`InTransaction`] clients and returns the borrow
-//! automatically. The [`Streaming`] marker is therefore retained but unused.
+//! automatically.
 
 use std::marker::PhantomData;
 
@@ -59,18 +59,10 @@ pub struct Ready;
 /// The transaction must be explicitly committed or rolled back.
 pub struct InTransaction;
 
-/// Connection is actively streaming results.
-///
-/// In this state, the connection is processing a result set.
-/// No other operations can be performed until the stream is
-/// consumed or cancelled.
-pub struct Streaming;
-
 impl ConnectionState for Disconnected {}
 impl ConnectionState for Connected {}
 impl ConnectionState for Ready {}
 impl ConnectionState for InTransaction {}
-impl ConnectionState for Streaming {}
 
 mod private {
     pub trait Sealed {}
@@ -78,7 +70,6 @@ mod private {
     impl Sealed for super::Connected {}
     impl Sealed for super::Ready {}
     impl Sealed for super::InTransaction {}
-    impl Sealed for super::Streaming {}
 }
 
 /// Type-level state transition marker.

--- a/crates/mssql-client/tests/always_encrypted.rs
+++ b/crates/mssql-client/tests/always_encrypted.rs
@@ -131,9 +131,7 @@ fn test_encryption_type_wire_conversion() {
 // Tests for mssql-client encryption types
 // =============================================================================
 
-use mssql_client::{
-    EncryptionConfig, ParameterCryptoInfo, ParameterEncryptionInfo, ResultSetEncryptionInfo,
-};
+use mssql_client::EncryptionConfig;
 
 #[test]
 fn test_encryption_config_builder() {
@@ -142,59 +140,6 @@ fn test_encryption_config_builder() {
     assert!(config.enabled);
     assert!(!config.cache_ceks);
     assert!(!config.is_ready()); // No providers registered
-}
-
-#[test]
-fn test_result_set_encryption_info_column_tracking() {
-    let cek_table = CekTable::new();
-    let mut info = ResultSetEncryptionInfo::new(cek_table, 5);
-
-    // Initially no columns are encrypted
-    for i in 0..5 {
-        assert!(!info.is_column_encrypted(i));
-        assert!(info.get_encryption_type(i).is_none());
-    }
-
-    // Mark column 2 as encrypted
-    let metadata = CryptoMetadata {
-        cek_table_ordinal: 0,
-        base_user_type: 0,
-        base_col_type: 0x26,
-        base_type_info: tds_protocol::token::TypeInfo::default(),
-        algorithm_id: 2,
-        encryption_type: EncryptionTypeWire::Deterministic,
-        normalization_version: 1,
-    };
-    info.set_column_crypto(2, metadata);
-
-    assert!(!info.is_column_encrypted(0));
-    assert!(!info.is_column_encrypted(1));
-    assert!(info.is_column_encrypted(2));
-    assert!(!info.is_column_encrypted(3));
-    assert!(!info.is_column_encrypted(4));
-
-    assert_eq!(
-        info.get_encryption_type(2),
-        Some(EncryptionTypeWire::Deterministic)
-    );
-}
-
-#[test]
-fn test_parameter_encryption_info_tracking() {
-    let mut info = ParameterEncryptionInfo::new();
-
-    assert!(!info.needs_encryption("@SSN"));
-    assert!(!info.needs_encryption("@Name"));
-
-    let ssn_crypto = ParameterCryptoInfo::new(0, EncryptionTypeWire::Deterministic, 2, 1);
-    info.add_parameter("@SSN".to_string(), ssn_crypto);
-
-    assert!(info.needs_encryption("@SSN"));
-    assert!(!info.needs_encryption("@Name"));
-
-    let param = info.get_parameter("@SSN").unwrap();
-    assert_eq!(param.cek_ordinal, 0);
-    assert_eq!(param.encryption_type, EncryptionTypeWire::Deterministic);
 }
 
 // =============================================================================
@@ -693,91 +638,6 @@ mod live_server {
     // -------------------------------------------------------------------------
     // Tests
     // -------------------------------------------------------------------------
-
-    /// Drive `sp_describe_parameter_encryption` against a live AE table and
-    /// assert the parser surfaces the CEK and per-parameter directives the
-    /// server reports. This is step one of parameter (write) encryption: the
-    /// statement targets one deterministic INT column and one randomized
-    /// NVARCHAR column, so the server must classify `@p0` deterministic and
-    /// `@p1` randomized, both bound to the table's single CEK.
-    ///
-    /// Runs in the 2017/2019/2022 CI matrix; the parser reads only the
-    /// version-stable first nine RS1 columns, so it must pass on 2017 (which
-    /// omits the 2019+ enclave columns).
-    #[tokio::test]
-    #[ignore = "Requires SQL Server with Always Encrypted"]
-    async fn test_describe_parameter_encryption_classifies_params() {
-        use tds_protocol::crypto::EncryptionTypeWire;
-
-        let admin_cfg = match admin_config() {
-            Some(c) => c,
-            None => return,
-        };
-        let mut admin = Client::connect(admin_cfg).await.expect("admin connect");
-
-        let (rsa_key, pem) = fresh_rsa_keypair();
-        let cek = fresh_cek();
-
-        let fx = setup(
-            &mut admin,
-            &cek,
-            &rsa_key,
-            "CREATE TABLE [{TABLE}] ( \
-             Id INT NOT NULL PRIMARY KEY, \
-             EncInt INT ENCRYPTED WITH ( \
-             COLUMN_ENCRYPTION_KEY = [{CEK}], \
-             ENCRYPTION_TYPE = DETERMINISTIC, \
-             ALGORITHM = 'AEAD_AES_256_CBC_HMAC_SHA_256' ) NULL, \
-             EncName NVARCHAR(64) COLLATE Latin1_General_BIN2 ENCRYPTED WITH ( \
-             COLUMN_ENCRYPTION_KEY = [{CEK}], \
-             ENCRYPTION_TYPE = RANDOMIZED, \
-             ALGORITHM = 'AEAD_AES_256_CBC_HMAC_SHA_256' ) NULL )",
-        )
-        .await;
-        drop(admin);
-
-        let mut client = Client::connect(encrypted_config(&pem).expect("cfg"))
-            .await
-            .expect("ae connect");
-
-        let tsql = format!(
-            "INSERT INTO [{}] (EncInt, EncName) VALUES (@p0, @p1)",
-            fx.table_name
-        );
-        let described = client
-            .describe_parameter_encryption(&tsql, "@p0 int, @p1 nvarchar(64)")
-            .await;
-
-        // Teardown before asserting so a failure never leaks server objects.
-        let mut admin = Client::connect(admin_config().expect("cfg"))
-            .await
-            .expect("admin reconnect");
-        teardown(&mut admin, &fx).await;
-
-        let info = described.expect("describe_parameter_encryption");
-
-        // Exactly one CEK, surfaced with the provider/path/algorithm we
-        // provisioned and a non-empty wrapped-key envelope.
-        assert_eq!(info.cek_table.len(), 1, "exactly one CEK");
-        let entry = info.cek_table.get(0).expect("cek entry 0");
-        let value = entry.primary_value().expect("cek value");
-        assert_eq!(value.key_store_provider_name, PROVIDER_NAME);
-        assert_eq!(value.cmk_path, KEY_PATH);
-        assert_eq!(value.encryption_algorithm, "RSA_OAEP");
-        assert!(!value.encrypted_value.is_empty(), "wrapped-key envelope");
-
-        // @p0 -> deterministic INT, @p1 -> randomized NVARCHAR, both on CEK 0.
-        let p0 = info.get_parameter("@p0").expect("@p0 directive");
-        assert_eq!(p0.encryption_type, EncryptionTypeWire::Deterministic);
-        assert_eq!(p0.algorithm_id, 2, "AEAD_AES_256_CBC_HMAC_SHA256");
-        assert_eq!(p0.normalization_rule_version, 1);
-        assert_eq!(p0.cek_ordinal, 0, "translated to positional CEK index");
-        assert!(info.cek_table.get(p0.cek_ordinal).is_some());
-
-        let p1 = info.get_parameter("@p1").expect("@p1 directive");
-        assert_eq!(p1.encryption_type, EncryptionTypeWire::Randomized);
-        assert_eq!(p1.cek_ordinal, 0);
-    }
 
     /// Full Always Encrypted write→read round-trip: the driver encrypts
     /// deterministic INT, NVARCHAR, and VARBINARY parameters plus a randomized

--- a/public-api/mssql-client.txt
+++ b/public-api/mssql-client.txt
@@ -231,7 +231,6 @@ pub fn mssql_client::bulk::BulkInsert::take_packets(&mut self) -> alloc::vec::Ve
 pub fn mssql_client::bulk::BulkInsert::total_rows(&self) -> u64
 impl mssql_client::bulk::BulkInsert
 pub fn mssql_client::bulk::BulkInsert::new(alloc::vec::Vec<mssql_client::bulk::BulkColumn>, usize) -> Self
-pub fn mssql_client::bulk::BulkInsert::new_with_server_metadata(alloc::vec::Vec<mssql_client::bulk::BulkColumn>, usize, core::option::Option<bytes::bytes::Bytes>, core::option::Option<&[tds_protocol::token::ColumnData]>) -> Self
 pub fn mssql_client::bulk::BulkInsert::send_row<T: mssql_types::to_sql::ToSql>(&mut self, &[T]) -> core::result::Result<(), mssql_client::error::Error>
 pub fn mssql_client::bulk::BulkInsert::send_row_values(&mut self, &[mssql_types::value::SqlValue]) -> core::result::Result<(), mssql_client::error::Error>
 impl core::marker::Freeze for mssql_client::bulk::BulkInsert
@@ -822,7 +821,6 @@ impl<S: mssql_client::state::ConnectionState> mssql_client::client::Client<S>
 pub async fn mssql_client::client::Client<S>::bulk_insert(&mut self, &mssql_client::bulk::BulkInsertBuilder) -> mssql_client::error::Result<mssql_client::bulk::BulkWriter<'_, S>>
 pub async fn mssql_client::client::Client<S>::bulk_insert_without_schema_discovery(&mut self, &mssql_client::bulk::BulkInsertBuilder) -> mssql_client::error::Result<mssql_client::bulk::BulkWriter<'_, S>>
 pub async fn mssql_client::client::Client<S>::call_procedure(&mut self, &str, &[&(dyn mssql_types::to_sql::ToSql + core::marker::Sync)]) -> mssql_client::error::Result<mssql_client::stream::ProcedureResult>
-pub async fn mssql_client::client::Client<S>::describe_parameter_encryption(&mut self, &str, &str) -> mssql_client::error::Result<mssql_client::encryption::ParameterEncryptionInfo>
 pub async fn mssql_client::client::Client<S>::execute_named(&mut self, &str, &[mssql_client::to_params::NamedParam]) -> mssql_client::error::Result<u64>
 pub fn mssql_client::client::Client<S>::procedure(&mut self, &str) -> mssql_client::error::Result<mssql_client::procedure::ProcedureBuilder<'_, S>>
 pub async fn mssql_client::client::Client<S>::query_named<'a>(&'a mut self, &str, &[mssql_client::to_params::NamedParam]) -> mssql_client::error::Result<mssql_client::stream::QueryStream<'a>>
@@ -1243,207 +1241,6 @@ impl<T> typenum::type_operators::Same for mssql_client::encryption::EncryptionCo
 pub type mssql_client::encryption::EncryptionConfig::Output = T
 impl<V, T> ppv_lite86::types::VZip<V> for mssql_client::encryption::EncryptionConfig where V: ppv_lite86::types::MultiLane<T>
 pub fn mssql_client::encryption::EncryptionConfig::vzip(self) -> V
-pub struct mssql_client::encryption::EncryptionContext
-impl mssql_client::encryption::EncryptionContext
-pub fn mssql_client::encryption::EncryptionContext::clear_cache(&self)
-pub async fn mssql_client::encryption::EncryptionContext::decrypt_value(&self, &[u8], &tds_protocol::crypto::CekTableEntry) -> core::result::Result<alloc::vec::Vec<u8>, mssql_auth::encryption::EncryptionError>
-pub async fn mssql_client::encryption::EncryptionContext::encrypt_value(&self, &[u8], &tds_protocol::crypto::CekTableEntry, tds_protocol::crypto::EncryptionTypeWire) -> core::result::Result<alloc::vec::Vec<u8>, mssql_auth::encryption::EncryptionError>
-pub fn mssql_client::encryption::EncryptionContext::from_arc(alloc::sync::Arc<mssql_client::encryption::EncryptionConfig>) -> Self
-pub async fn mssql_client::encryption::EncryptionContext::get_encryptor(&self, &tds_protocol::crypto::CekTableEntry) -> core::result::Result<alloc::sync::Arc<mssql_auth::aead::AeadEncryptor>, mssql_auth::encryption::EncryptionError>
-pub fn mssql_client::encryption::EncryptionContext::has_provider(&self, &str) -> bool
-pub fn mssql_client::encryption::EncryptionContext::new(mssql_client::encryption::EncryptionConfig) -> Self
-impl core::fmt::Debug for mssql_client::encryption::EncryptionContext
-pub fn mssql_client::encryption::EncryptionContext::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl !core::marker::Freeze for mssql_client::encryption::EncryptionContext
-impl core::marker::Send for mssql_client::encryption::EncryptionContext
-impl core::marker::Sync for mssql_client::encryption::EncryptionContext
-impl core::marker::Unpin for mssql_client::encryption::EncryptionContext
-impl !core::panic::unwind_safe::RefUnwindSafe for mssql_client::encryption::EncryptionContext
-impl !core::panic::unwind_safe::UnwindSafe for mssql_client::encryption::EncryptionContext
-impl<T, U> core::convert::Into<U> for mssql_client::encryption::EncryptionContext where U: core::convert::From<T>
-pub fn mssql_client::encryption::EncryptionContext::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for mssql_client::encryption::EncryptionContext where U: core::convert::Into<T>
-pub type mssql_client::encryption::EncryptionContext::Error = core::convert::Infallible
-pub fn mssql_client::encryption::EncryptionContext::try_from(U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for mssql_client::encryption::EncryptionContext where U: core::convert::TryFrom<T>
-pub type mssql_client::encryption::EncryptionContext::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn mssql_client::encryption::EncryptionContext::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for mssql_client::encryption::EncryptionContext where T: 'static + ?core::marker::Sized
-pub fn mssql_client::encryption::EncryptionContext::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for mssql_client::encryption::EncryptionContext where T: ?core::marker::Sized
-pub fn mssql_client::encryption::EncryptionContext::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for mssql_client::encryption::EncryptionContext where T: ?core::marker::Sized
-pub fn mssql_client::encryption::EncryptionContext::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for mssql_client::encryption::EncryptionContext
-pub fn mssql_client::encryption::EncryptionContext::from(T) -> T
-impl<T> opentelemetry::context::future_ext::FutureExt for mssql_client::encryption::EncryptionContext
-impl<T> tower_http::follow_redirect::policy::PolicyExt for mssql_client::encryption::EncryptionContext where T: ?core::marker::Sized
-pub fn mssql_client::encryption::EncryptionContext::and<P, B, E>(self, P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
-pub fn mssql_client::encryption::EncryptionContext::or<P, B, E>(self, P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
-impl<T> tracing::instrument::Instrument for mssql_client::encryption::EncryptionContext
-impl<T> tracing::instrument::WithSubscriber for mssql_client::encryption::EncryptionContext
-impl<T> typenum::type_operators::Same for mssql_client::encryption::EncryptionContext
-pub type mssql_client::encryption::EncryptionContext::Output = T
-impl<V, T> ppv_lite86::types::VZip<V> for mssql_client::encryption::EncryptionContext where V: ppv_lite86::types::MultiLane<T>
-pub fn mssql_client::encryption::EncryptionContext::vzip(self) -> V
-pub struct mssql_client::encryption::ParameterCryptoInfo
-pub mssql_client::encryption::ParameterCryptoInfo::algorithm_id: u8
-pub mssql_client::encryption::ParameterCryptoInfo::cek_ordinal: u16
-pub mssql_client::encryption::ParameterCryptoInfo::encryption_type: tds_protocol::crypto::EncryptionTypeWire
-pub mssql_client::encryption::ParameterCryptoInfo::normalization_rule_version: u8
-impl mssql_client::encryption::ParameterCryptoInfo
-pub fn mssql_client::encryption::ParameterCryptoInfo::new(u16, tds_protocol::crypto::EncryptionTypeWire, u8, u8) -> Self
-impl core::clone::Clone for mssql_client::encryption::ParameterCryptoInfo
-pub fn mssql_client::encryption::ParameterCryptoInfo::clone(&self) -> mssql_client::encryption::ParameterCryptoInfo
-impl core::fmt::Debug for mssql_client::encryption::ParameterCryptoInfo
-pub fn mssql_client::encryption::ParameterCryptoInfo::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::Freeze for mssql_client::encryption::ParameterCryptoInfo
-impl core::marker::Send for mssql_client::encryption::ParameterCryptoInfo
-impl core::marker::Sync for mssql_client::encryption::ParameterCryptoInfo
-impl core::marker::Unpin for mssql_client::encryption::ParameterCryptoInfo
-impl core::panic::unwind_safe::RefUnwindSafe for mssql_client::encryption::ParameterCryptoInfo
-impl core::panic::unwind_safe::UnwindSafe for mssql_client::encryption::ParameterCryptoInfo
-impl<T, U> core::convert::Into<U> for mssql_client::encryption::ParameterCryptoInfo where U: core::convert::From<T>
-pub fn mssql_client::encryption::ParameterCryptoInfo::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for mssql_client::encryption::ParameterCryptoInfo where U: core::convert::Into<T>
-pub type mssql_client::encryption::ParameterCryptoInfo::Error = core::convert::Infallible
-pub fn mssql_client::encryption::ParameterCryptoInfo::try_from(U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for mssql_client::encryption::ParameterCryptoInfo where U: core::convert::TryFrom<T>
-pub type mssql_client::encryption::ParameterCryptoInfo::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn mssql_client::encryption::ParameterCryptoInfo::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for mssql_client::encryption::ParameterCryptoInfo where T: core::clone::Clone
-pub type mssql_client::encryption::ParameterCryptoInfo::Owned = T
-pub fn mssql_client::encryption::ParameterCryptoInfo::clone_into(&self, &mut T)
-pub fn mssql_client::encryption::ParameterCryptoInfo::to_owned(&self) -> T
-impl<T> core::any::Any for mssql_client::encryption::ParameterCryptoInfo where T: 'static + ?core::marker::Sized
-pub fn mssql_client::encryption::ParameterCryptoInfo::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for mssql_client::encryption::ParameterCryptoInfo where T: ?core::marker::Sized
-pub fn mssql_client::encryption::ParameterCryptoInfo::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for mssql_client::encryption::ParameterCryptoInfo where T: ?core::marker::Sized
-pub fn mssql_client::encryption::ParameterCryptoInfo::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for mssql_client::encryption::ParameterCryptoInfo where T: core::clone::Clone
-pub unsafe fn mssql_client::encryption::ParameterCryptoInfo::clone_to_uninit(&self, *mut u8)
-impl<T> core::convert::From<T> for mssql_client::encryption::ParameterCryptoInfo
-pub fn mssql_client::encryption::ParameterCryptoInfo::from(T) -> T
-impl<T> dyn_clone::DynClone for mssql_client::encryption::ParameterCryptoInfo where T: core::clone::Clone
-pub fn mssql_client::encryption::ParameterCryptoInfo::__clone_box(&self, dyn_clone::sealed::Private) -> *mut ()
-impl<T> opentelemetry::context::future_ext::FutureExt for mssql_client::encryption::ParameterCryptoInfo
-impl<T> tower_http::follow_redirect::policy::PolicyExt for mssql_client::encryption::ParameterCryptoInfo where T: ?core::marker::Sized
-pub fn mssql_client::encryption::ParameterCryptoInfo::and<P, B, E>(self, P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
-pub fn mssql_client::encryption::ParameterCryptoInfo::or<P, B, E>(self, P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
-impl<T> tracing::instrument::Instrument for mssql_client::encryption::ParameterCryptoInfo
-impl<T> tracing::instrument::WithSubscriber for mssql_client::encryption::ParameterCryptoInfo
-impl<T> typenum::type_operators::Same for mssql_client::encryption::ParameterCryptoInfo
-pub type mssql_client::encryption::ParameterCryptoInfo::Output = T
-impl<V, T> ppv_lite86::types::VZip<V> for mssql_client::encryption::ParameterCryptoInfo where V: ppv_lite86::types::MultiLane<T>
-pub fn mssql_client::encryption::ParameterCryptoInfo::vzip(self) -> V
-pub struct mssql_client::encryption::ParameterEncryptionInfo
-pub mssql_client::encryption::ParameterEncryptionInfo::cek_table: tds_protocol::crypto::CekTable
-pub mssql_client::encryption::ParameterEncryptionInfo::parameters: std::collections::hash::map::HashMap<alloc::string::String, mssql_client::encryption::ParameterCryptoInfo>
-impl mssql_client::encryption::ParameterEncryptionInfo
-pub fn mssql_client::encryption::ParameterEncryptionInfo::add_parameter(&mut self, alloc::string::String, mssql_client::encryption::ParameterCryptoInfo)
-pub fn mssql_client::encryption::ParameterEncryptionInfo::get_parameter(&self, &str) -> core::option::Option<&mssql_client::encryption::ParameterCryptoInfo>
-pub fn mssql_client::encryption::ParameterEncryptionInfo::needs_encryption(&self, &str) -> bool
-pub fn mssql_client::encryption::ParameterEncryptionInfo::new() -> Self
-impl core::clone::Clone for mssql_client::encryption::ParameterEncryptionInfo
-pub fn mssql_client::encryption::ParameterEncryptionInfo::clone(&self) -> mssql_client::encryption::ParameterEncryptionInfo
-impl core::default::Default for mssql_client::encryption::ParameterEncryptionInfo
-pub fn mssql_client::encryption::ParameterEncryptionInfo::default() -> Self
-impl core::fmt::Debug for mssql_client::encryption::ParameterEncryptionInfo
-pub fn mssql_client::encryption::ParameterEncryptionInfo::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::Freeze for mssql_client::encryption::ParameterEncryptionInfo
-impl core::marker::Send for mssql_client::encryption::ParameterEncryptionInfo
-impl core::marker::Sync for mssql_client::encryption::ParameterEncryptionInfo
-impl core::marker::Unpin for mssql_client::encryption::ParameterEncryptionInfo
-impl core::panic::unwind_safe::RefUnwindSafe for mssql_client::encryption::ParameterEncryptionInfo
-impl core::panic::unwind_safe::UnwindSafe for mssql_client::encryption::ParameterEncryptionInfo
-impl<T, U> core::convert::Into<U> for mssql_client::encryption::ParameterEncryptionInfo where U: core::convert::From<T>
-pub fn mssql_client::encryption::ParameterEncryptionInfo::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for mssql_client::encryption::ParameterEncryptionInfo where U: core::convert::Into<T>
-pub type mssql_client::encryption::ParameterEncryptionInfo::Error = core::convert::Infallible
-pub fn mssql_client::encryption::ParameterEncryptionInfo::try_from(U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for mssql_client::encryption::ParameterEncryptionInfo where U: core::convert::TryFrom<T>
-pub type mssql_client::encryption::ParameterEncryptionInfo::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn mssql_client::encryption::ParameterEncryptionInfo::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for mssql_client::encryption::ParameterEncryptionInfo where T: core::clone::Clone
-pub type mssql_client::encryption::ParameterEncryptionInfo::Owned = T
-pub fn mssql_client::encryption::ParameterEncryptionInfo::clone_into(&self, &mut T)
-pub fn mssql_client::encryption::ParameterEncryptionInfo::to_owned(&self) -> T
-impl<T> core::any::Any for mssql_client::encryption::ParameterEncryptionInfo where T: 'static + ?core::marker::Sized
-pub fn mssql_client::encryption::ParameterEncryptionInfo::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for mssql_client::encryption::ParameterEncryptionInfo where T: ?core::marker::Sized
-pub fn mssql_client::encryption::ParameterEncryptionInfo::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for mssql_client::encryption::ParameterEncryptionInfo where T: ?core::marker::Sized
-pub fn mssql_client::encryption::ParameterEncryptionInfo::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for mssql_client::encryption::ParameterEncryptionInfo where T: core::clone::Clone
-pub unsafe fn mssql_client::encryption::ParameterEncryptionInfo::clone_to_uninit(&self, *mut u8)
-impl<T> core::convert::From<T> for mssql_client::encryption::ParameterEncryptionInfo
-pub fn mssql_client::encryption::ParameterEncryptionInfo::from(T) -> T
-impl<T> dyn_clone::DynClone for mssql_client::encryption::ParameterEncryptionInfo where T: core::clone::Clone
-pub fn mssql_client::encryption::ParameterEncryptionInfo::__clone_box(&self, dyn_clone::sealed::Private) -> *mut ()
-impl<T> opentelemetry::context::future_ext::FutureExt for mssql_client::encryption::ParameterEncryptionInfo
-impl<T> tower_http::follow_redirect::policy::PolicyExt for mssql_client::encryption::ParameterEncryptionInfo where T: ?core::marker::Sized
-pub fn mssql_client::encryption::ParameterEncryptionInfo::and<P, B, E>(self, P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
-pub fn mssql_client::encryption::ParameterEncryptionInfo::or<P, B, E>(self, P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
-impl<T> tracing::instrument::Instrument for mssql_client::encryption::ParameterEncryptionInfo
-impl<T> tracing::instrument::WithSubscriber for mssql_client::encryption::ParameterEncryptionInfo
-impl<T> typenum::type_operators::Same for mssql_client::encryption::ParameterEncryptionInfo
-pub type mssql_client::encryption::ParameterEncryptionInfo::Output = T
-impl<V, T> ppv_lite86::types::VZip<V> for mssql_client::encryption::ParameterEncryptionInfo where V: ppv_lite86::types::MultiLane<T>
-pub fn mssql_client::encryption::ParameterEncryptionInfo::vzip(self) -> V
-pub struct mssql_client::encryption::ResultSetEncryptionInfo
-pub mssql_client::encryption::ResultSetEncryptionInfo::cek_table: tds_protocol::crypto::CekTable
-pub mssql_client::encryption::ResultSetEncryptionInfo::column_crypto: alloc::vec::Vec<core::option::Option<tds_protocol::crypto::CryptoMetadata>>
-impl mssql_client::encryption::ResultSetEncryptionInfo
-pub fn mssql_client::encryption::ResultSetEncryptionInfo::get_cek_for_column(&self, usize) -> core::option::Option<&tds_protocol::crypto::CekTableEntry>
-pub fn mssql_client::encryption::ResultSetEncryptionInfo::get_encryption_type(&self, usize) -> core::option::Option<tds_protocol::crypto::EncryptionTypeWire>
-pub fn mssql_client::encryption::ResultSetEncryptionInfo::is_column_encrypted(&self, usize) -> bool
-pub fn mssql_client::encryption::ResultSetEncryptionInfo::new(tds_protocol::crypto::CekTable, usize) -> Self
-pub fn mssql_client::encryption::ResultSetEncryptionInfo::set_column_crypto(&mut self, usize, tds_protocol::crypto::CryptoMetadata)
-impl core::clone::Clone for mssql_client::encryption::ResultSetEncryptionInfo
-pub fn mssql_client::encryption::ResultSetEncryptionInfo::clone(&self) -> mssql_client::encryption::ResultSetEncryptionInfo
-impl core::fmt::Debug for mssql_client::encryption::ResultSetEncryptionInfo
-pub fn mssql_client::encryption::ResultSetEncryptionInfo::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::Freeze for mssql_client::encryption::ResultSetEncryptionInfo
-impl core::marker::Send for mssql_client::encryption::ResultSetEncryptionInfo
-impl core::marker::Sync for mssql_client::encryption::ResultSetEncryptionInfo
-impl core::marker::Unpin for mssql_client::encryption::ResultSetEncryptionInfo
-impl core::panic::unwind_safe::RefUnwindSafe for mssql_client::encryption::ResultSetEncryptionInfo
-impl core::panic::unwind_safe::UnwindSafe for mssql_client::encryption::ResultSetEncryptionInfo
-impl<T, U> core::convert::Into<U> for mssql_client::encryption::ResultSetEncryptionInfo where U: core::convert::From<T>
-pub fn mssql_client::encryption::ResultSetEncryptionInfo::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for mssql_client::encryption::ResultSetEncryptionInfo where U: core::convert::Into<T>
-pub type mssql_client::encryption::ResultSetEncryptionInfo::Error = core::convert::Infallible
-pub fn mssql_client::encryption::ResultSetEncryptionInfo::try_from(U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for mssql_client::encryption::ResultSetEncryptionInfo where U: core::convert::TryFrom<T>
-pub type mssql_client::encryption::ResultSetEncryptionInfo::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn mssql_client::encryption::ResultSetEncryptionInfo::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for mssql_client::encryption::ResultSetEncryptionInfo where T: core::clone::Clone
-pub type mssql_client::encryption::ResultSetEncryptionInfo::Owned = T
-pub fn mssql_client::encryption::ResultSetEncryptionInfo::clone_into(&self, &mut T)
-pub fn mssql_client::encryption::ResultSetEncryptionInfo::to_owned(&self) -> T
-impl<T> core::any::Any for mssql_client::encryption::ResultSetEncryptionInfo where T: 'static + ?core::marker::Sized
-pub fn mssql_client::encryption::ResultSetEncryptionInfo::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for mssql_client::encryption::ResultSetEncryptionInfo where T: ?core::marker::Sized
-pub fn mssql_client::encryption::ResultSetEncryptionInfo::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for mssql_client::encryption::ResultSetEncryptionInfo where T: ?core::marker::Sized
-pub fn mssql_client::encryption::ResultSetEncryptionInfo::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for mssql_client::encryption::ResultSetEncryptionInfo where T: core::clone::Clone
-pub unsafe fn mssql_client::encryption::ResultSetEncryptionInfo::clone_to_uninit(&self, *mut u8)
-impl<T> core::convert::From<T> for mssql_client::encryption::ResultSetEncryptionInfo
-pub fn mssql_client::encryption::ResultSetEncryptionInfo::from(T) -> T
-impl<T> dyn_clone::DynClone for mssql_client::encryption::ResultSetEncryptionInfo where T: core::clone::Clone
-pub fn mssql_client::encryption::ResultSetEncryptionInfo::__clone_box(&self, dyn_clone::sealed::Private) -> *mut ()
-impl<T> opentelemetry::context::future_ext::FutureExt for mssql_client::encryption::ResultSetEncryptionInfo
-impl<T> tower_http::follow_redirect::policy::PolicyExt for mssql_client::encryption::ResultSetEncryptionInfo where T: ?core::marker::Sized
-pub fn mssql_client::encryption::ResultSetEncryptionInfo::and<P, B, E>(self, P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
-pub fn mssql_client::encryption::ResultSetEncryptionInfo::or<P, B, E>(self, P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
-impl<T> tracing::instrument::Instrument for mssql_client::encryption::ResultSetEncryptionInfo
-impl<T> tracing::instrument::WithSubscriber for mssql_client::encryption::ResultSetEncryptionInfo
-impl<T> typenum::type_operators::Same for mssql_client::encryption::ResultSetEncryptionInfo
-pub type mssql_client::encryption::ResultSetEncryptionInfo::Output = T
-impl<V, T> ppv_lite86::types::VZip<V> for mssql_client::encryption::ResultSetEncryptionInfo where V: ppv_lite86::types::MultiLane<T>
-pub fn mssql_client::encryption::ResultSetEncryptionInfo::vzip(self) -> V
 pub fn mssql_client::encryption::normalize_for_encryption(&mssql_types::value::SqlValue, core::option::Option<mssql_types::to_sql::EncryptedParamType>) -> core::result::Result<alloc::vec::Vec<u8>, mssql_auth::encryption::EncryptionError>
 pub mod mssql_client::error
 #[non_exhaustive] pub enum mssql_client::error::Error
@@ -2530,46 +2327,11 @@ impl<T> typenum::type_operators::Same for mssql_client::state::StateMarker<S>
 pub type mssql_client::state::StateMarker<S>::Output = T
 impl<V, T> ppv_lite86::types::VZip<V> for mssql_client::state::StateMarker<S> where V: ppv_lite86::types::MultiLane<T>
 pub fn mssql_client::state::StateMarker<S>::vzip(self) -> V
-pub struct mssql_client::state::Streaming
-impl mssql_client::state::ConnectionState for mssql_client::state::Streaming
-impl core::marker::Freeze for mssql_client::state::Streaming
-impl core::marker::Send for mssql_client::state::Streaming
-impl core::marker::Sync for mssql_client::state::Streaming
-impl core::marker::Unpin for mssql_client::state::Streaming
-impl core::panic::unwind_safe::RefUnwindSafe for mssql_client::state::Streaming
-impl core::panic::unwind_safe::UnwindSafe for mssql_client::state::Streaming
-impl<T, U> core::convert::Into<U> for mssql_client::state::Streaming where U: core::convert::From<T>
-pub fn mssql_client::state::Streaming::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for mssql_client::state::Streaming where U: core::convert::Into<T>
-pub type mssql_client::state::Streaming::Error = core::convert::Infallible
-pub fn mssql_client::state::Streaming::try_from(U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for mssql_client::state::Streaming where U: core::convert::TryFrom<T>
-pub type mssql_client::state::Streaming::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn mssql_client::state::Streaming::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for mssql_client::state::Streaming where T: 'static + ?core::marker::Sized
-pub fn mssql_client::state::Streaming::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for mssql_client::state::Streaming where T: ?core::marker::Sized
-pub fn mssql_client::state::Streaming::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for mssql_client::state::Streaming where T: ?core::marker::Sized
-pub fn mssql_client::state::Streaming::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for mssql_client::state::Streaming
-pub fn mssql_client::state::Streaming::from(T) -> T
-impl<T> opentelemetry::context::future_ext::FutureExt for mssql_client::state::Streaming
-impl<T> tower_http::follow_redirect::policy::PolicyExt for mssql_client::state::Streaming where T: ?core::marker::Sized
-pub fn mssql_client::state::Streaming::and<P, B, E>(self, P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
-pub fn mssql_client::state::Streaming::or<P, B, E>(self, P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
-impl<T> tracing::instrument::Instrument for mssql_client::state::Streaming
-impl<T> tracing::instrument::WithSubscriber for mssql_client::state::Streaming
-impl<T> typenum::type_operators::Same for mssql_client::state::Streaming
-pub type mssql_client::state::Streaming::Output = T
-impl<V, T> ppv_lite86::types::VZip<V> for mssql_client::state::Streaming where V: ppv_lite86::types::MultiLane<T>
-pub fn mssql_client::state::Streaming::vzip(self) -> V
 pub trait mssql_client::state::ConnectionState: mssql_client::state::private::Sealed
 impl mssql_client::state::ConnectionState for mssql_client::state::Connected
 impl mssql_client::state::ConnectionState for mssql_client::state::Disconnected
 impl mssql_client::state::ConnectionState for mssql_client::state::InTransaction
 impl mssql_client::state::ConnectionState for mssql_client::state::Ready
-impl mssql_client::state::ConnectionState for mssql_client::state::Streaming
 pub mod mssql_client::stream
 #[non_exhaustive] pub struct mssql_client::stream::ExecuteResult
 pub mssql_client::stream::ExecuteResult::output_params: alloc::vec::Vec<mssql_client::stream::OutputParam>
@@ -3835,7 +3597,6 @@ pub fn mssql_client::bulk::BulkInsert::take_packets(&mut self) -> alloc::vec::Ve
 pub fn mssql_client::bulk::BulkInsert::total_rows(&self) -> u64
 impl mssql_client::bulk::BulkInsert
 pub fn mssql_client::bulk::BulkInsert::new(alloc::vec::Vec<mssql_client::bulk::BulkColumn>, usize) -> Self
-pub fn mssql_client::bulk::BulkInsert::new_with_server_metadata(alloc::vec::Vec<mssql_client::bulk::BulkColumn>, usize, core::option::Option<bytes::bytes::Bytes>, core::option::Option<&[tds_protocol::token::ColumnData]>) -> Self
 pub fn mssql_client::bulk::BulkInsert::send_row<T: mssql_types::to_sql::ToSql>(&mut self, &[T]) -> core::result::Result<(), mssql_client::error::Error>
 pub fn mssql_client::bulk::BulkInsert::send_row_values(&mut self, &[mssql_types::value::SqlValue]) -> core::result::Result<(), mssql_client::error::Error>
 impl core::marker::Freeze for mssql_client::bulk::BulkInsert
@@ -4295,7 +4056,6 @@ impl<S: mssql_client::state::ConnectionState> mssql_client::client::Client<S>
 pub async fn mssql_client::client::Client<S>::bulk_insert(&mut self, &mssql_client::bulk::BulkInsertBuilder) -> mssql_client::error::Result<mssql_client::bulk::BulkWriter<'_, S>>
 pub async fn mssql_client::client::Client<S>::bulk_insert_without_schema_discovery(&mut self, &mssql_client::bulk::BulkInsertBuilder) -> mssql_client::error::Result<mssql_client::bulk::BulkWriter<'_, S>>
 pub async fn mssql_client::client::Client<S>::call_procedure(&mut self, &str, &[&(dyn mssql_types::to_sql::ToSql + core::marker::Sync)]) -> mssql_client::error::Result<mssql_client::stream::ProcedureResult>
-pub async fn mssql_client::client::Client<S>::describe_parameter_encryption(&mut self, &str, &str) -> mssql_client::error::Result<mssql_client::encryption::ParameterEncryptionInfo>
 pub async fn mssql_client::client::Client<S>::execute_named(&mut self, &str, &[mssql_client::to_params::NamedParam]) -> mssql_client::error::Result<u64>
 pub fn mssql_client::client::Client<S>::procedure(&mut self, &str) -> mssql_client::error::Result<mssql_client::procedure::ProcedureBuilder<'_, S>>
 pub async fn mssql_client::client::Client<S>::query_named<'a>(&'a mut self, &str, &[mssql_client::to_params::NamedParam]) -> mssql_client::error::Result<mssql_client::stream::QueryStream<'a>>
@@ -4649,49 +4409,6 @@ impl<T> typenum::type_operators::Same for mssql_client::encryption::EncryptionCo
 pub type mssql_client::encryption::EncryptionConfig::Output = T
 impl<V, T> ppv_lite86::types::VZip<V> for mssql_client::encryption::EncryptionConfig where V: ppv_lite86::types::MultiLane<T>
 pub fn mssql_client::encryption::EncryptionConfig::vzip(self) -> V
-pub struct mssql_client::EncryptionContext
-impl mssql_client::encryption::EncryptionContext
-pub fn mssql_client::encryption::EncryptionContext::clear_cache(&self)
-pub async fn mssql_client::encryption::EncryptionContext::decrypt_value(&self, &[u8], &tds_protocol::crypto::CekTableEntry) -> core::result::Result<alloc::vec::Vec<u8>, mssql_auth::encryption::EncryptionError>
-pub async fn mssql_client::encryption::EncryptionContext::encrypt_value(&self, &[u8], &tds_protocol::crypto::CekTableEntry, tds_protocol::crypto::EncryptionTypeWire) -> core::result::Result<alloc::vec::Vec<u8>, mssql_auth::encryption::EncryptionError>
-pub fn mssql_client::encryption::EncryptionContext::from_arc(alloc::sync::Arc<mssql_client::encryption::EncryptionConfig>) -> Self
-pub async fn mssql_client::encryption::EncryptionContext::get_encryptor(&self, &tds_protocol::crypto::CekTableEntry) -> core::result::Result<alloc::sync::Arc<mssql_auth::aead::AeadEncryptor>, mssql_auth::encryption::EncryptionError>
-pub fn mssql_client::encryption::EncryptionContext::has_provider(&self, &str) -> bool
-pub fn mssql_client::encryption::EncryptionContext::new(mssql_client::encryption::EncryptionConfig) -> Self
-impl core::fmt::Debug for mssql_client::encryption::EncryptionContext
-pub fn mssql_client::encryption::EncryptionContext::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl !core::marker::Freeze for mssql_client::encryption::EncryptionContext
-impl core::marker::Send for mssql_client::encryption::EncryptionContext
-impl core::marker::Sync for mssql_client::encryption::EncryptionContext
-impl core::marker::Unpin for mssql_client::encryption::EncryptionContext
-impl !core::panic::unwind_safe::RefUnwindSafe for mssql_client::encryption::EncryptionContext
-impl !core::panic::unwind_safe::UnwindSafe for mssql_client::encryption::EncryptionContext
-impl<T, U> core::convert::Into<U> for mssql_client::encryption::EncryptionContext where U: core::convert::From<T>
-pub fn mssql_client::encryption::EncryptionContext::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for mssql_client::encryption::EncryptionContext where U: core::convert::Into<T>
-pub type mssql_client::encryption::EncryptionContext::Error = core::convert::Infallible
-pub fn mssql_client::encryption::EncryptionContext::try_from(U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for mssql_client::encryption::EncryptionContext where U: core::convert::TryFrom<T>
-pub type mssql_client::encryption::EncryptionContext::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn mssql_client::encryption::EncryptionContext::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for mssql_client::encryption::EncryptionContext where T: 'static + ?core::marker::Sized
-pub fn mssql_client::encryption::EncryptionContext::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for mssql_client::encryption::EncryptionContext where T: ?core::marker::Sized
-pub fn mssql_client::encryption::EncryptionContext::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for mssql_client::encryption::EncryptionContext where T: ?core::marker::Sized
-pub fn mssql_client::encryption::EncryptionContext::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for mssql_client::encryption::EncryptionContext
-pub fn mssql_client::encryption::EncryptionContext::from(T) -> T
-impl<T> opentelemetry::context::future_ext::FutureExt for mssql_client::encryption::EncryptionContext
-impl<T> tower_http::follow_redirect::policy::PolicyExt for mssql_client::encryption::EncryptionContext where T: ?core::marker::Sized
-pub fn mssql_client::encryption::EncryptionContext::and<P, B, E>(self, P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
-pub fn mssql_client::encryption::EncryptionContext::or<P, B, E>(self, P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
-impl<T> tracing::instrument::Instrument for mssql_client::encryption::EncryptionContext
-impl<T> tracing::instrument::WithSubscriber for mssql_client::encryption::EncryptionContext
-impl<T> typenum::type_operators::Same for mssql_client::encryption::EncryptionContext
-pub type mssql_client::encryption::EncryptionContext::Output = T
-impl<V, T> ppv_lite86::types::VZip<V> for mssql_client::encryption::EncryptionContext where V: ppv_lite86::types::MultiLane<T>
-pub fn mssql_client::encryption::EncryptionContext::vzip(self) -> V
 #[non_exhaustive] pub struct mssql_client::ExecuteResult
 pub mssql_client::ExecuteResult::output_params: alloc::vec::Vec<mssql_client::stream::OutputParam>
 pub mssql_client::ExecuteResult::rows_affected: u64
@@ -5081,111 +4798,6 @@ impl<T> typenum::type_operators::Same for mssql_client::to_params::ParamList
 pub type mssql_client::to_params::ParamList::Output = T
 impl<V, T> ppv_lite86::types::VZip<V> for mssql_client::to_params::ParamList where V: ppv_lite86::types::MultiLane<T>
 pub fn mssql_client::to_params::ParamList::vzip(self) -> V
-pub struct mssql_client::ParameterCryptoInfo
-pub mssql_client::ParameterCryptoInfo::algorithm_id: u8
-pub mssql_client::ParameterCryptoInfo::cek_ordinal: u16
-pub mssql_client::ParameterCryptoInfo::encryption_type: tds_protocol::crypto::EncryptionTypeWire
-pub mssql_client::ParameterCryptoInfo::normalization_rule_version: u8
-impl mssql_client::encryption::ParameterCryptoInfo
-pub fn mssql_client::encryption::ParameterCryptoInfo::new(u16, tds_protocol::crypto::EncryptionTypeWire, u8, u8) -> Self
-impl core::clone::Clone for mssql_client::encryption::ParameterCryptoInfo
-pub fn mssql_client::encryption::ParameterCryptoInfo::clone(&self) -> mssql_client::encryption::ParameterCryptoInfo
-impl core::fmt::Debug for mssql_client::encryption::ParameterCryptoInfo
-pub fn mssql_client::encryption::ParameterCryptoInfo::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::Freeze for mssql_client::encryption::ParameterCryptoInfo
-impl core::marker::Send for mssql_client::encryption::ParameterCryptoInfo
-impl core::marker::Sync for mssql_client::encryption::ParameterCryptoInfo
-impl core::marker::Unpin for mssql_client::encryption::ParameterCryptoInfo
-impl core::panic::unwind_safe::RefUnwindSafe for mssql_client::encryption::ParameterCryptoInfo
-impl core::panic::unwind_safe::UnwindSafe for mssql_client::encryption::ParameterCryptoInfo
-impl<T, U> core::convert::Into<U> for mssql_client::encryption::ParameterCryptoInfo where U: core::convert::From<T>
-pub fn mssql_client::encryption::ParameterCryptoInfo::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for mssql_client::encryption::ParameterCryptoInfo where U: core::convert::Into<T>
-pub type mssql_client::encryption::ParameterCryptoInfo::Error = core::convert::Infallible
-pub fn mssql_client::encryption::ParameterCryptoInfo::try_from(U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for mssql_client::encryption::ParameterCryptoInfo where U: core::convert::TryFrom<T>
-pub type mssql_client::encryption::ParameterCryptoInfo::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn mssql_client::encryption::ParameterCryptoInfo::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for mssql_client::encryption::ParameterCryptoInfo where T: core::clone::Clone
-pub type mssql_client::encryption::ParameterCryptoInfo::Owned = T
-pub fn mssql_client::encryption::ParameterCryptoInfo::clone_into(&self, &mut T)
-pub fn mssql_client::encryption::ParameterCryptoInfo::to_owned(&self) -> T
-impl<T> core::any::Any for mssql_client::encryption::ParameterCryptoInfo where T: 'static + ?core::marker::Sized
-pub fn mssql_client::encryption::ParameterCryptoInfo::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for mssql_client::encryption::ParameterCryptoInfo where T: ?core::marker::Sized
-pub fn mssql_client::encryption::ParameterCryptoInfo::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for mssql_client::encryption::ParameterCryptoInfo where T: ?core::marker::Sized
-pub fn mssql_client::encryption::ParameterCryptoInfo::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for mssql_client::encryption::ParameterCryptoInfo where T: core::clone::Clone
-pub unsafe fn mssql_client::encryption::ParameterCryptoInfo::clone_to_uninit(&self, *mut u8)
-impl<T> core::convert::From<T> for mssql_client::encryption::ParameterCryptoInfo
-pub fn mssql_client::encryption::ParameterCryptoInfo::from(T) -> T
-impl<T> dyn_clone::DynClone for mssql_client::encryption::ParameterCryptoInfo where T: core::clone::Clone
-pub fn mssql_client::encryption::ParameterCryptoInfo::__clone_box(&self, dyn_clone::sealed::Private) -> *mut ()
-impl<T> opentelemetry::context::future_ext::FutureExt for mssql_client::encryption::ParameterCryptoInfo
-impl<T> tower_http::follow_redirect::policy::PolicyExt for mssql_client::encryption::ParameterCryptoInfo where T: ?core::marker::Sized
-pub fn mssql_client::encryption::ParameterCryptoInfo::and<P, B, E>(self, P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
-pub fn mssql_client::encryption::ParameterCryptoInfo::or<P, B, E>(self, P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
-impl<T> tracing::instrument::Instrument for mssql_client::encryption::ParameterCryptoInfo
-impl<T> tracing::instrument::WithSubscriber for mssql_client::encryption::ParameterCryptoInfo
-impl<T> typenum::type_operators::Same for mssql_client::encryption::ParameterCryptoInfo
-pub type mssql_client::encryption::ParameterCryptoInfo::Output = T
-impl<V, T> ppv_lite86::types::VZip<V> for mssql_client::encryption::ParameterCryptoInfo where V: ppv_lite86::types::MultiLane<T>
-pub fn mssql_client::encryption::ParameterCryptoInfo::vzip(self) -> V
-pub struct mssql_client::ParameterEncryptionInfo
-pub mssql_client::ParameterEncryptionInfo::cek_table: tds_protocol::crypto::CekTable
-pub mssql_client::ParameterEncryptionInfo::parameters: std::collections::hash::map::HashMap<alloc::string::String, mssql_client::encryption::ParameterCryptoInfo>
-impl mssql_client::encryption::ParameterEncryptionInfo
-pub fn mssql_client::encryption::ParameterEncryptionInfo::add_parameter(&mut self, alloc::string::String, mssql_client::encryption::ParameterCryptoInfo)
-pub fn mssql_client::encryption::ParameterEncryptionInfo::get_parameter(&self, &str) -> core::option::Option<&mssql_client::encryption::ParameterCryptoInfo>
-pub fn mssql_client::encryption::ParameterEncryptionInfo::needs_encryption(&self, &str) -> bool
-pub fn mssql_client::encryption::ParameterEncryptionInfo::new() -> Self
-impl core::clone::Clone for mssql_client::encryption::ParameterEncryptionInfo
-pub fn mssql_client::encryption::ParameterEncryptionInfo::clone(&self) -> mssql_client::encryption::ParameterEncryptionInfo
-impl core::default::Default for mssql_client::encryption::ParameterEncryptionInfo
-pub fn mssql_client::encryption::ParameterEncryptionInfo::default() -> Self
-impl core::fmt::Debug for mssql_client::encryption::ParameterEncryptionInfo
-pub fn mssql_client::encryption::ParameterEncryptionInfo::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::Freeze for mssql_client::encryption::ParameterEncryptionInfo
-impl core::marker::Send for mssql_client::encryption::ParameterEncryptionInfo
-impl core::marker::Sync for mssql_client::encryption::ParameterEncryptionInfo
-impl core::marker::Unpin for mssql_client::encryption::ParameterEncryptionInfo
-impl core::panic::unwind_safe::RefUnwindSafe for mssql_client::encryption::ParameterEncryptionInfo
-impl core::panic::unwind_safe::UnwindSafe for mssql_client::encryption::ParameterEncryptionInfo
-impl<T, U> core::convert::Into<U> for mssql_client::encryption::ParameterEncryptionInfo where U: core::convert::From<T>
-pub fn mssql_client::encryption::ParameterEncryptionInfo::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for mssql_client::encryption::ParameterEncryptionInfo where U: core::convert::Into<T>
-pub type mssql_client::encryption::ParameterEncryptionInfo::Error = core::convert::Infallible
-pub fn mssql_client::encryption::ParameterEncryptionInfo::try_from(U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for mssql_client::encryption::ParameterEncryptionInfo where U: core::convert::TryFrom<T>
-pub type mssql_client::encryption::ParameterEncryptionInfo::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn mssql_client::encryption::ParameterEncryptionInfo::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for mssql_client::encryption::ParameterEncryptionInfo where T: core::clone::Clone
-pub type mssql_client::encryption::ParameterEncryptionInfo::Owned = T
-pub fn mssql_client::encryption::ParameterEncryptionInfo::clone_into(&self, &mut T)
-pub fn mssql_client::encryption::ParameterEncryptionInfo::to_owned(&self) -> T
-impl<T> core::any::Any for mssql_client::encryption::ParameterEncryptionInfo where T: 'static + ?core::marker::Sized
-pub fn mssql_client::encryption::ParameterEncryptionInfo::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for mssql_client::encryption::ParameterEncryptionInfo where T: ?core::marker::Sized
-pub fn mssql_client::encryption::ParameterEncryptionInfo::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for mssql_client::encryption::ParameterEncryptionInfo where T: ?core::marker::Sized
-pub fn mssql_client::encryption::ParameterEncryptionInfo::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for mssql_client::encryption::ParameterEncryptionInfo where T: core::clone::Clone
-pub unsafe fn mssql_client::encryption::ParameterEncryptionInfo::clone_to_uninit(&self, *mut u8)
-impl<T> core::convert::From<T> for mssql_client::encryption::ParameterEncryptionInfo
-pub fn mssql_client::encryption::ParameterEncryptionInfo::from(T) -> T
-impl<T> dyn_clone::DynClone for mssql_client::encryption::ParameterEncryptionInfo where T: core::clone::Clone
-pub fn mssql_client::encryption::ParameterEncryptionInfo::__clone_box(&self, dyn_clone::sealed::Private) -> *mut ()
-impl<T> opentelemetry::context::future_ext::FutureExt for mssql_client::encryption::ParameterEncryptionInfo
-impl<T> tower_http::follow_redirect::policy::PolicyExt for mssql_client::encryption::ParameterEncryptionInfo where T: ?core::marker::Sized
-pub fn mssql_client::encryption::ParameterEncryptionInfo::and<P, B, E>(self, P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
-pub fn mssql_client::encryption::ParameterEncryptionInfo::or<P, B, E>(self, P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
-impl<T> tracing::instrument::Instrument for mssql_client::encryption::ParameterEncryptionInfo
-impl<T> tracing::instrument::WithSubscriber for mssql_client::encryption::ParameterEncryptionInfo
-impl<T> typenum::type_operators::Same for mssql_client::encryption::ParameterEncryptionInfo
-pub type mssql_client::encryption::ParameterEncryptionInfo::Output = T
-impl<V, T> ppv_lite86::types::VZip<V> for mssql_client::encryption::ParameterEncryptionInfo where V: ppv_lite86::types::MultiLane<T>
-pub fn mssql_client::encryption::ParameterEncryptionInfo::vzip(self) -> V
 pub struct mssql_client::ProcedureBuilder<'a, S: mssql_client::state::ConnectionState>
 impl<'a, S: mssql_client::state::ConnectionState> mssql_client::procedure::ProcedureBuilder<'a, S>
 pub async fn mssql_client::procedure::ProcedureBuilder<'a, S>::execute(&mut self) -> mssql_client::error::Result<mssql_client::stream::ProcedureResult>
@@ -5484,59 +5096,6 @@ impl<T> typenum::type_operators::Same for mssql_client::stream::ResultSet
 pub type mssql_client::stream::ResultSet::Output = T
 impl<V, T> ppv_lite86::types::VZip<V> for mssql_client::stream::ResultSet where V: ppv_lite86::types::MultiLane<T>
 pub fn mssql_client::stream::ResultSet::vzip(self) -> V
-pub struct mssql_client::ResultSetEncryptionInfo
-pub mssql_client::ResultSetEncryptionInfo::cek_table: tds_protocol::crypto::CekTable
-pub mssql_client::ResultSetEncryptionInfo::column_crypto: alloc::vec::Vec<core::option::Option<tds_protocol::crypto::CryptoMetadata>>
-impl mssql_client::encryption::ResultSetEncryptionInfo
-pub fn mssql_client::encryption::ResultSetEncryptionInfo::get_cek_for_column(&self, usize) -> core::option::Option<&tds_protocol::crypto::CekTableEntry>
-pub fn mssql_client::encryption::ResultSetEncryptionInfo::get_encryption_type(&self, usize) -> core::option::Option<tds_protocol::crypto::EncryptionTypeWire>
-pub fn mssql_client::encryption::ResultSetEncryptionInfo::is_column_encrypted(&self, usize) -> bool
-pub fn mssql_client::encryption::ResultSetEncryptionInfo::new(tds_protocol::crypto::CekTable, usize) -> Self
-pub fn mssql_client::encryption::ResultSetEncryptionInfo::set_column_crypto(&mut self, usize, tds_protocol::crypto::CryptoMetadata)
-impl core::clone::Clone for mssql_client::encryption::ResultSetEncryptionInfo
-pub fn mssql_client::encryption::ResultSetEncryptionInfo::clone(&self) -> mssql_client::encryption::ResultSetEncryptionInfo
-impl core::fmt::Debug for mssql_client::encryption::ResultSetEncryptionInfo
-pub fn mssql_client::encryption::ResultSetEncryptionInfo::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::Freeze for mssql_client::encryption::ResultSetEncryptionInfo
-impl core::marker::Send for mssql_client::encryption::ResultSetEncryptionInfo
-impl core::marker::Sync for mssql_client::encryption::ResultSetEncryptionInfo
-impl core::marker::Unpin for mssql_client::encryption::ResultSetEncryptionInfo
-impl core::panic::unwind_safe::RefUnwindSafe for mssql_client::encryption::ResultSetEncryptionInfo
-impl core::panic::unwind_safe::UnwindSafe for mssql_client::encryption::ResultSetEncryptionInfo
-impl<T, U> core::convert::Into<U> for mssql_client::encryption::ResultSetEncryptionInfo where U: core::convert::From<T>
-pub fn mssql_client::encryption::ResultSetEncryptionInfo::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for mssql_client::encryption::ResultSetEncryptionInfo where U: core::convert::Into<T>
-pub type mssql_client::encryption::ResultSetEncryptionInfo::Error = core::convert::Infallible
-pub fn mssql_client::encryption::ResultSetEncryptionInfo::try_from(U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for mssql_client::encryption::ResultSetEncryptionInfo where U: core::convert::TryFrom<T>
-pub type mssql_client::encryption::ResultSetEncryptionInfo::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn mssql_client::encryption::ResultSetEncryptionInfo::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for mssql_client::encryption::ResultSetEncryptionInfo where T: core::clone::Clone
-pub type mssql_client::encryption::ResultSetEncryptionInfo::Owned = T
-pub fn mssql_client::encryption::ResultSetEncryptionInfo::clone_into(&self, &mut T)
-pub fn mssql_client::encryption::ResultSetEncryptionInfo::to_owned(&self) -> T
-impl<T> core::any::Any for mssql_client::encryption::ResultSetEncryptionInfo where T: 'static + ?core::marker::Sized
-pub fn mssql_client::encryption::ResultSetEncryptionInfo::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for mssql_client::encryption::ResultSetEncryptionInfo where T: ?core::marker::Sized
-pub fn mssql_client::encryption::ResultSetEncryptionInfo::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for mssql_client::encryption::ResultSetEncryptionInfo where T: ?core::marker::Sized
-pub fn mssql_client::encryption::ResultSetEncryptionInfo::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for mssql_client::encryption::ResultSetEncryptionInfo where T: core::clone::Clone
-pub unsafe fn mssql_client::encryption::ResultSetEncryptionInfo::clone_to_uninit(&self, *mut u8)
-impl<T> core::convert::From<T> for mssql_client::encryption::ResultSetEncryptionInfo
-pub fn mssql_client::encryption::ResultSetEncryptionInfo::from(T) -> T
-impl<T> dyn_clone::DynClone for mssql_client::encryption::ResultSetEncryptionInfo where T: core::clone::Clone
-pub fn mssql_client::encryption::ResultSetEncryptionInfo::__clone_box(&self, dyn_clone::sealed::Private) -> *mut ()
-impl<T> opentelemetry::context::future_ext::FutureExt for mssql_client::encryption::ResultSetEncryptionInfo
-impl<T> tower_http::follow_redirect::policy::PolicyExt for mssql_client::encryption::ResultSetEncryptionInfo where T: ?core::marker::Sized
-pub fn mssql_client::encryption::ResultSetEncryptionInfo::and<P, B, E>(self, P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
-pub fn mssql_client::encryption::ResultSetEncryptionInfo::or<P, B, E>(self, P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
-impl<T> tracing::instrument::Instrument for mssql_client::encryption::ResultSetEncryptionInfo
-impl<T> tracing::instrument::WithSubscriber for mssql_client::encryption::ResultSetEncryptionInfo
-impl<T> typenum::type_operators::Same for mssql_client::encryption::ResultSetEncryptionInfo
-pub type mssql_client::encryption::ResultSetEncryptionInfo::Output = T
-impl<V, T> ppv_lite86::types::VZip<V> for mssql_client::encryption::ResultSetEncryptionInfo where V: ppv_lite86::types::MultiLane<T>
-pub fn mssql_client::encryption::ResultSetEncryptionInfo::vzip(self) -> V
 pub struct mssql_client::RetryPolicy
 pub mssql_client::RetryPolicy::backoff_multiplier: f64
 pub mssql_client::RetryPolicy::initial_backoff: core::time::Duration
@@ -5860,40 +5419,6 @@ impl<T> typenum::type_operators::Same for mssql_client::error::SharedIoError
 pub type mssql_client::error::SharedIoError::Output = T
 impl<V, T> ppv_lite86::types::VZip<V> for mssql_client::error::SharedIoError where V: ppv_lite86::types::MultiLane<T>
 pub fn mssql_client::error::SharedIoError::vzip(self) -> V
-pub struct mssql_client::Streaming
-impl mssql_client::state::ConnectionState for mssql_client::state::Streaming
-impl core::marker::Freeze for mssql_client::state::Streaming
-impl core::marker::Send for mssql_client::state::Streaming
-impl core::marker::Sync for mssql_client::state::Streaming
-impl core::marker::Unpin for mssql_client::state::Streaming
-impl core::panic::unwind_safe::RefUnwindSafe for mssql_client::state::Streaming
-impl core::panic::unwind_safe::UnwindSafe for mssql_client::state::Streaming
-impl<T, U> core::convert::Into<U> for mssql_client::state::Streaming where U: core::convert::From<T>
-pub fn mssql_client::state::Streaming::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for mssql_client::state::Streaming where U: core::convert::Into<T>
-pub type mssql_client::state::Streaming::Error = core::convert::Infallible
-pub fn mssql_client::state::Streaming::try_from(U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for mssql_client::state::Streaming where U: core::convert::TryFrom<T>
-pub type mssql_client::state::Streaming::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn mssql_client::state::Streaming::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for mssql_client::state::Streaming where T: 'static + ?core::marker::Sized
-pub fn mssql_client::state::Streaming::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for mssql_client::state::Streaming where T: ?core::marker::Sized
-pub fn mssql_client::state::Streaming::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for mssql_client::state::Streaming where T: ?core::marker::Sized
-pub fn mssql_client::state::Streaming::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for mssql_client::state::Streaming
-pub fn mssql_client::state::Streaming::from(T) -> T
-impl<T> opentelemetry::context::future_ext::FutureExt for mssql_client::state::Streaming
-impl<T> tower_http::follow_redirect::policy::PolicyExt for mssql_client::state::Streaming where T: ?core::marker::Sized
-pub fn mssql_client::state::Streaming::and<P, B, E>(self, P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
-pub fn mssql_client::state::Streaming::or<P, B, E>(self, P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
-impl<T> tracing::instrument::Instrument for mssql_client::state::Streaming
-impl<T> tracing::instrument::WithSubscriber for mssql_client::state::Streaming
-impl<T> typenum::type_operators::Same for mssql_client::state::Streaming
-pub type mssql_client::state::Streaming::Output = T
-impl<V, T> ppv_lite86::types::VZip<V> for mssql_client::state::Streaming where V: ppv_lite86::types::MultiLane<T>
-pub fn mssql_client::state::Streaming::vzip(self) -> V
 pub struct mssql_client::TimeoutConfig
 pub mssql_client::TimeoutConfig::command_timeout: core::time::Duration
 pub mssql_client::TimeoutConfig::connect_timeout: core::time::Duration
@@ -6155,7 +5680,6 @@ impl mssql_client::state::ConnectionState for mssql_client::state::Connected
 impl mssql_client::state::ConnectionState for mssql_client::state::Disconnected
 impl mssql_client::state::ConnectionState for mssql_client::state::InTransaction
 impl mssql_client::state::ConnectionState for mssql_client::state::Ready
-impl mssql_client::state::ConnectionState for mssql_client::state::Streaming
 pub trait mssql_client::FromRow: core::marker::Sized
 pub fn mssql_client::FromRow::from_row(&mssql_client::row::Row) -> core::result::Result<Self, mssql_client::error::Error>
 pub trait mssql_client::RowIteratorExt: core::iter::traits::iterator::Iterator<Item = core::result::Result<mssql_client::row::Row, mssql_client::error::Error>> + core::marker::Sized

--- a/public-api/mssql-client.windows.txt
+++ b/public-api/mssql-client.windows.txt
@@ -212,7 +212,6 @@ pub fn mssql_client::bulk::BulkInsert::take_packets(&mut self) -> alloc::vec::Ve
 pub fn mssql_client::bulk::BulkInsert::total_rows(&self) -> u64
 impl mssql_client::bulk::BulkInsert
 pub fn mssql_client::bulk::BulkInsert::new(alloc::vec::Vec<mssql_client::bulk::BulkColumn>, usize) -> Self
-pub fn mssql_client::bulk::BulkInsert::new_with_server_metadata(alloc::vec::Vec<mssql_client::bulk::BulkColumn>, usize, core::option::Option<bytes::bytes::Bytes>, core::option::Option<&[tds_protocol::token::ColumnData]>) -> Self
 pub fn mssql_client::bulk::BulkInsert::send_row<T: mssql_types::to_sql::ToSql>(&mut self, &[T]) -> core::result::Result<(), mssql_client::error::Error>
 pub fn mssql_client::bulk::BulkInsert::send_row_values(&mut self, &[mssql_types::value::SqlValue]) -> core::result::Result<(), mssql_client::error::Error>
 impl core::marker::Freeze for mssql_client::bulk::BulkInsert
@@ -1123,146 +1122,6 @@ impl<T> typenum::type_operators::Same for mssql_client::encryption::EncryptionCo
 pub type mssql_client::encryption::EncryptionConfig::Output = T
 impl<V, T> ppv_lite86::types::VZip<V> for mssql_client::encryption::EncryptionConfig where V: ppv_lite86::types::MultiLane<T>
 pub fn mssql_client::encryption::EncryptionConfig::vzip(self) -> V
-pub struct mssql_client::encryption::ParameterCryptoInfo
-pub mssql_client::encryption::ParameterCryptoInfo::algorithm_id: u8
-pub mssql_client::encryption::ParameterCryptoInfo::cek_ordinal: u16
-pub mssql_client::encryption::ParameterCryptoInfo::encryption_type: tds_protocol::crypto::EncryptionTypeWire
-pub mssql_client::encryption::ParameterCryptoInfo::normalization_rule_version: u8
-impl mssql_client::encryption::ParameterCryptoInfo
-pub fn mssql_client::encryption::ParameterCryptoInfo::new(u16, tds_protocol::crypto::EncryptionTypeWire, u8, u8) -> Self
-impl core::clone::Clone for mssql_client::encryption::ParameterCryptoInfo
-pub fn mssql_client::encryption::ParameterCryptoInfo::clone(&self) -> mssql_client::encryption::ParameterCryptoInfo
-impl core::fmt::Debug for mssql_client::encryption::ParameterCryptoInfo
-pub fn mssql_client::encryption::ParameterCryptoInfo::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::Freeze for mssql_client::encryption::ParameterCryptoInfo
-impl core::marker::Send for mssql_client::encryption::ParameterCryptoInfo
-impl core::marker::Sync for mssql_client::encryption::ParameterCryptoInfo
-impl core::marker::Unpin for mssql_client::encryption::ParameterCryptoInfo
-impl core::panic::unwind_safe::RefUnwindSafe for mssql_client::encryption::ParameterCryptoInfo
-impl core::panic::unwind_safe::UnwindSafe for mssql_client::encryption::ParameterCryptoInfo
-impl<T, U> core::convert::Into<U> for mssql_client::encryption::ParameterCryptoInfo where U: core::convert::From<T>
-pub fn mssql_client::encryption::ParameterCryptoInfo::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for mssql_client::encryption::ParameterCryptoInfo where U: core::convert::Into<T>
-pub type mssql_client::encryption::ParameterCryptoInfo::Error = core::convert::Infallible
-pub fn mssql_client::encryption::ParameterCryptoInfo::try_from(U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for mssql_client::encryption::ParameterCryptoInfo where U: core::convert::TryFrom<T>
-pub type mssql_client::encryption::ParameterCryptoInfo::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn mssql_client::encryption::ParameterCryptoInfo::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for mssql_client::encryption::ParameterCryptoInfo where T: core::clone::Clone
-pub type mssql_client::encryption::ParameterCryptoInfo::Owned = T
-pub fn mssql_client::encryption::ParameterCryptoInfo::clone_into(&self, &mut T)
-pub fn mssql_client::encryption::ParameterCryptoInfo::to_owned(&self) -> T
-impl<T> core::any::Any for mssql_client::encryption::ParameterCryptoInfo where T: 'static + ?core::marker::Sized
-pub fn mssql_client::encryption::ParameterCryptoInfo::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for mssql_client::encryption::ParameterCryptoInfo where T: ?core::marker::Sized
-pub fn mssql_client::encryption::ParameterCryptoInfo::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for mssql_client::encryption::ParameterCryptoInfo where T: ?core::marker::Sized
-pub fn mssql_client::encryption::ParameterCryptoInfo::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for mssql_client::encryption::ParameterCryptoInfo where T: core::clone::Clone
-pub unsafe fn mssql_client::encryption::ParameterCryptoInfo::clone_to_uninit(&self, *mut u8)
-impl<T> core::convert::From<T> for mssql_client::encryption::ParameterCryptoInfo
-pub fn mssql_client::encryption::ParameterCryptoInfo::from(T) -> T
-impl<T> tracing::instrument::Instrument for mssql_client::encryption::ParameterCryptoInfo
-impl<T> tracing::instrument::WithSubscriber for mssql_client::encryption::ParameterCryptoInfo
-impl<T> typenum::type_operators::Same for mssql_client::encryption::ParameterCryptoInfo
-pub type mssql_client::encryption::ParameterCryptoInfo::Output = T
-impl<V, T> ppv_lite86::types::VZip<V> for mssql_client::encryption::ParameterCryptoInfo where V: ppv_lite86::types::MultiLane<T>
-pub fn mssql_client::encryption::ParameterCryptoInfo::vzip(self) -> V
-pub struct mssql_client::encryption::ParameterEncryptionInfo
-pub mssql_client::encryption::ParameterEncryptionInfo::cek_table: tds_protocol::crypto::CekTable
-pub mssql_client::encryption::ParameterEncryptionInfo::parameters: std::collections::hash::map::HashMap<alloc::string::String, mssql_client::encryption::ParameterCryptoInfo>
-impl mssql_client::encryption::ParameterEncryptionInfo
-pub fn mssql_client::encryption::ParameterEncryptionInfo::add_parameter(&mut self, alloc::string::String, mssql_client::encryption::ParameterCryptoInfo)
-pub fn mssql_client::encryption::ParameterEncryptionInfo::get_parameter(&self, &str) -> core::option::Option<&mssql_client::encryption::ParameterCryptoInfo>
-pub fn mssql_client::encryption::ParameterEncryptionInfo::needs_encryption(&self, &str) -> bool
-pub fn mssql_client::encryption::ParameterEncryptionInfo::new() -> Self
-impl core::clone::Clone for mssql_client::encryption::ParameterEncryptionInfo
-pub fn mssql_client::encryption::ParameterEncryptionInfo::clone(&self) -> mssql_client::encryption::ParameterEncryptionInfo
-impl core::default::Default for mssql_client::encryption::ParameterEncryptionInfo
-pub fn mssql_client::encryption::ParameterEncryptionInfo::default() -> Self
-impl core::fmt::Debug for mssql_client::encryption::ParameterEncryptionInfo
-pub fn mssql_client::encryption::ParameterEncryptionInfo::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::Freeze for mssql_client::encryption::ParameterEncryptionInfo
-impl core::marker::Send for mssql_client::encryption::ParameterEncryptionInfo
-impl core::marker::Sync for mssql_client::encryption::ParameterEncryptionInfo
-impl core::marker::Unpin for mssql_client::encryption::ParameterEncryptionInfo
-impl core::panic::unwind_safe::RefUnwindSafe for mssql_client::encryption::ParameterEncryptionInfo
-impl core::panic::unwind_safe::UnwindSafe for mssql_client::encryption::ParameterEncryptionInfo
-impl<T, U> core::convert::Into<U> for mssql_client::encryption::ParameterEncryptionInfo where U: core::convert::From<T>
-pub fn mssql_client::encryption::ParameterEncryptionInfo::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for mssql_client::encryption::ParameterEncryptionInfo where U: core::convert::Into<T>
-pub type mssql_client::encryption::ParameterEncryptionInfo::Error = core::convert::Infallible
-pub fn mssql_client::encryption::ParameterEncryptionInfo::try_from(U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for mssql_client::encryption::ParameterEncryptionInfo where U: core::convert::TryFrom<T>
-pub type mssql_client::encryption::ParameterEncryptionInfo::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn mssql_client::encryption::ParameterEncryptionInfo::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for mssql_client::encryption::ParameterEncryptionInfo where T: core::clone::Clone
-pub type mssql_client::encryption::ParameterEncryptionInfo::Owned = T
-pub fn mssql_client::encryption::ParameterEncryptionInfo::clone_into(&self, &mut T)
-pub fn mssql_client::encryption::ParameterEncryptionInfo::to_owned(&self) -> T
-impl<T> core::any::Any for mssql_client::encryption::ParameterEncryptionInfo where T: 'static + ?core::marker::Sized
-pub fn mssql_client::encryption::ParameterEncryptionInfo::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for mssql_client::encryption::ParameterEncryptionInfo where T: ?core::marker::Sized
-pub fn mssql_client::encryption::ParameterEncryptionInfo::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for mssql_client::encryption::ParameterEncryptionInfo where T: ?core::marker::Sized
-pub fn mssql_client::encryption::ParameterEncryptionInfo::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for mssql_client::encryption::ParameterEncryptionInfo where T: core::clone::Clone
-pub unsafe fn mssql_client::encryption::ParameterEncryptionInfo::clone_to_uninit(&self, *mut u8)
-impl<T> core::convert::From<T> for mssql_client::encryption::ParameterEncryptionInfo
-pub fn mssql_client::encryption::ParameterEncryptionInfo::from(T) -> T
-impl<T> tracing::instrument::Instrument for mssql_client::encryption::ParameterEncryptionInfo
-impl<T> tracing::instrument::WithSubscriber for mssql_client::encryption::ParameterEncryptionInfo
-impl<T> typenum::type_operators::Same for mssql_client::encryption::ParameterEncryptionInfo
-pub type mssql_client::encryption::ParameterEncryptionInfo::Output = T
-impl<V, T> ppv_lite86::types::VZip<V> for mssql_client::encryption::ParameterEncryptionInfo where V: ppv_lite86::types::MultiLane<T>
-pub fn mssql_client::encryption::ParameterEncryptionInfo::vzip(self) -> V
-pub struct mssql_client::encryption::ResultSetEncryptionInfo
-pub mssql_client::encryption::ResultSetEncryptionInfo::cek_table: tds_protocol::crypto::CekTable
-pub mssql_client::encryption::ResultSetEncryptionInfo::column_crypto: alloc::vec::Vec<core::option::Option<tds_protocol::crypto::CryptoMetadata>>
-impl mssql_client::encryption::ResultSetEncryptionInfo
-pub fn mssql_client::encryption::ResultSetEncryptionInfo::get_cek_for_column(&self, usize) -> core::option::Option<&tds_protocol::crypto::CekTableEntry>
-pub fn mssql_client::encryption::ResultSetEncryptionInfo::get_encryption_type(&self, usize) -> core::option::Option<tds_protocol::crypto::EncryptionTypeWire>
-pub fn mssql_client::encryption::ResultSetEncryptionInfo::is_column_encrypted(&self, usize) -> bool
-pub fn mssql_client::encryption::ResultSetEncryptionInfo::new(tds_protocol::crypto::CekTable, usize) -> Self
-pub fn mssql_client::encryption::ResultSetEncryptionInfo::set_column_crypto(&mut self, usize, tds_protocol::crypto::CryptoMetadata)
-impl core::clone::Clone for mssql_client::encryption::ResultSetEncryptionInfo
-pub fn mssql_client::encryption::ResultSetEncryptionInfo::clone(&self) -> mssql_client::encryption::ResultSetEncryptionInfo
-impl core::fmt::Debug for mssql_client::encryption::ResultSetEncryptionInfo
-pub fn mssql_client::encryption::ResultSetEncryptionInfo::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::Freeze for mssql_client::encryption::ResultSetEncryptionInfo
-impl core::marker::Send for mssql_client::encryption::ResultSetEncryptionInfo
-impl core::marker::Sync for mssql_client::encryption::ResultSetEncryptionInfo
-impl core::marker::Unpin for mssql_client::encryption::ResultSetEncryptionInfo
-impl core::panic::unwind_safe::RefUnwindSafe for mssql_client::encryption::ResultSetEncryptionInfo
-impl core::panic::unwind_safe::UnwindSafe for mssql_client::encryption::ResultSetEncryptionInfo
-impl<T, U> core::convert::Into<U> for mssql_client::encryption::ResultSetEncryptionInfo where U: core::convert::From<T>
-pub fn mssql_client::encryption::ResultSetEncryptionInfo::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for mssql_client::encryption::ResultSetEncryptionInfo where U: core::convert::Into<T>
-pub type mssql_client::encryption::ResultSetEncryptionInfo::Error = core::convert::Infallible
-pub fn mssql_client::encryption::ResultSetEncryptionInfo::try_from(U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for mssql_client::encryption::ResultSetEncryptionInfo where U: core::convert::TryFrom<T>
-pub type mssql_client::encryption::ResultSetEncryptionInfo::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn mssql_client::encryption::ResultSetEncryptionInfo::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for mssql_client::encryption::ResultSetEncryptionInfo where T: core::clone::Clone
-pub type mssql_client::encryption::ResultSetEncryptionInfo::Owned = T
-pub fn mssql_client::encryption::ResultSetEncryptionInfo::clone_into(&self, &mut T)
-pub fn mssql_client::encryption::ResultSetEncryptionInfo::to_owned(&self) -> T
-impl<T> core::any::Any for mssql_client::encryption::ResultSetEncryptionInfo where T: 'static + ?core::marker::Sized
-pub fn mssql_client::encryption::ResultSetEncryptionInfo::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for mssql_client::encryption::ResultSetEncryptionInfo where T: ?core::marker::Sized
-pub fn mssql_client::encryption::ResultSetEncryptionInfo::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for mssql_client::encryption::ResultSetEncryptionInfo where T: ?core::marker::Sized
-pub fn mssql_client::encryption::ResultSetEncryptionInfo::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for mssql_client::encryption::ResultSetEncryptionInfo where T: core::clone::Clone
-pub unsafe fn mssql_client::encryption::ResultSetEncryptionInfo::clone_to_uninit(&self, *mut u8)
-impl<T> core::convert::From<T> for mssql_client::encryption::ResultSetEncryptionInfo
-pub fn mssql_client::encryption::ResultSetEncryptionInfo::from(T) -> T
-impl<T> tracing::instrument::Instrument for mssql_client::encryption::ResultSetEncryptionInfo
-impl<T> tracing::instrument::WithSubscriber for mssql_client::encryption::ResultSetEncryptionInfo
-impl<T> typenum::type_operators::Same for mssql_client::encryption::ResultSetEncryptionInfo
-pub type mssql_client::encryption::ResultSetEncryptionInfo::Output = T
-impl<V, T> ppv_lite86::types::VZip<V> for mssql_client::encryption::ResultSetEncryptionInfo where V: ppv_lite86::types::MultiLane<T>
-pub fn mssql_client::encryption::ResultSetEncryptionInfo::vzip(self) -> V
 pub mod mssql_client::error
 #[non_exhaustive] pub enum mssql_client::error::Error
 pub mssql_client::error::Error::Authentication(mssql_auth::error::AuthError)
@@ -2344,42 +2203,11 @@ impl<T> typenum::type_operators::Same for mssql_client::state::StateMarker<S>
 pub type mssql_client::state::StateMarker<S>::Output = T
 impl<V, T> ppv_lite86::types::VZip<V> for mssql_client::state::StateMarker<S> where V: ppv_lite86::types::MultiLane<T>
 pub fn mssql_client::state::StateMarker<S>::vzip(self) -> V
-pub struct mssql_client::state::Streaming
-impl mssql_client::state::ConnectionState for mssql_client::state::Streaming
-impl core::marker::Freeze for mssql_client::state::Streaming
-impl core::marker::Send for mssql_client::state::Streaming
-impl core::marker::Sync for mssql_client::state::Streaming
-impl core::marker::Unpin for mssql_client::state::Streaming
-impl core::panic::unwind_safe::RefUnwindSafe for mssql_client::state::Streaming
-impl core::panic::unwind_safe::UnwindSafe for mssql_client::state::Streaming
-impl<T, U> core::convert::Into<U> for mssql_client::state::Streaming where U: core::convert::From<T>
-pub fn mssql_client::state::Streaming::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for mssql_client::state::Streaming where U: core::convert::Into<T>
-pub type mssql_client::state::Streaming::Error = core::convert::Infallible
-pub fn mssql_client::state::Streaming::try_from(U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for mssql_client::state::Streaming where U: core::convert::TryFrom<T>
-pub type mssql_client::state::Streaming::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn mssql_client::state::Streaming::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for mssql_client::state::Streaming where T: 'static + ?core::marker::Sized
-pub fn mssql_client::state::Streaming::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for mssql_client::state::Streaming where T: ?core::marker::Sized
-pub fn mssql_client::state::Streaming::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for mssql_client::state::Streaming where T: ?core::marker::Sized
-pub fn mssql_client::state::Streaming::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for mssql_client::state::Streaming
-pub fn mssql_client::state::Streaming::from(T) -> T
-impl<T> tracing::instrument::Instrument for mssql_client::state::Streaming
-impl<T> tracing::instrument::WithSubscriber for mssql_client::state::Streaming
-impl<T> typenum::type_operators::Same for mssql_client::state::Streaming
-pub type mssql_client::state::Streaming::Output = T
-impl<V, T> ppv_lite86::types::VZip<V> for mssql_client::state::Streaming where V: ppv_lite86::types::MultiLane<T>
-pub fn mssql_client::state::Streaming::vzip(self) -> V
 pub trait mssql_client::state::ConnectionState: mssql_client::state::private::Sealed
 impl mssql_client::state::ConnectionState for mssql_client::state::Connected
 impl mssql_client::state::ConnectionState for mssql_client::state::Disconnected
 impl mssql_client::state::ConnectionState for mssql_client::state::InTransaction
 impl mssql_client::state::ConnectionState for mssql_client::state::Ready
-impl mssql_client::state::ConnectionState for mssql_client::state::Streaming
 pub mod mssql_client::stream
 #[non_exhaustive] pub struct mssql_client::stream::ExecuteResult
 pub mssql_client::stream::ExecuteResult::output_params: alloc::vec::Vec<mssql_client::stream::OutputParam>
@@ -3564,7 +3392,6 @@ pub fn mssql_client::bulk::BulkInsert::take_packets(&mut self) -> alloc::vec::Ve
 pub fn mssql_client::bulk::BulkInsert::total_rows(&self) -> u64
 impl mssql_client::bulk::BulkInsert
 pub fn mssql_client::bulk::BulkInsert::new(alloc::vec::Vec<mssql_client::bulk::BulkColumn>, usize) -> Self
-pub fn mssql_client::bulk::BulkInsert::new_with_server_metadata(alloc::vec::Vec<mssql_client::bulk::BulkColumn>, usize, core::option::Option<bytes::bytes::Bytes>, core::option::Option<&[tds_protocol::token::ColumnData]>) -> Self
 pub fn mssql_client::bulk::BulkInsert::send_row<T: mssql_types::to_sql::ToSql>(&mut self, &[T]) -> core::result::Result<(), mssql_client::error::Error>
 pub fn mssql_client::bulk::BulkInsert::send_row_values(&mut self, &[mssql_types::value::SqlValue]) -> core::result::Result<(), mssql_client::error::Error>
 impl core::marker::Freeze for mssql_client::bulk::BulkInsert
@@ -4699,99 +4526,6 @@ impl<T> typenum::type_operators::Same for mssql_client::to_params::ParamList
 pub type mssql_client::to_params::ParamList::Output = T
 impl<V, T> ppv_lite86::types::VZip<V> for mssql_client::to_params::ParamList where V: ppv_lite86::types::MultiLane<T>
 pub fn mssql_client::to_params::ParamList::vzip(self) -> V
-pub struct mssql_client::ParameterCryptoInfo
-pub mssql_client::ParameterCryptoInfo::algorithm_id: u8
-pub mssql_client::ParameterCryptoInfo::cek_ordinal: u16
-pub mssql_client::ParameterCryptoInfo::encryption_type: tds_protocol::crypto::EncryptionTypeWire
-pub mssql_client::ParameterCryptoInfo::normalization_rule_version: u8
-impl mssql_client::encryption::ParameterCryptoInfo
-pub fn mssql_client::encryption::ParameterCryptoInfo::new(u16, tds_protocol::crypto::EncryptionTypeWire, u8, u8) -> Self
-impl core::clone::Clone for mssql_client::encryption::ParameterCryptoInfo
-pub fn mssql_client::encryption::ParameterCryptoInfo::clone(&self) -> mssql_client::encryption::ParameterCryptoInfo
-impl core::fmt::Debug for mssql_client::encryption::ParameterCryptoInfo
-pub fn mssql_client::encryption::ParameterCryptoInfo::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::Freeze for mssql_client::encryption::ParameterCryptoInfo
-impl core::marker::Send for mssql_client::encryption::ParameterCryptoInfo
-impl core::marker::Sync for mssql_client::encryption::ParameterCryptoInfo
-impl core::marker::Unpin for mssql_client::encryption::ParameterCryptoInfo
-impl core::panic::unwind_safe::RefUnwindSafe for mssql_client::encryption::ParameterCryptoInfo
-impl core::panic::unwind_safe::UnwindSafe for mssql_client::encryption::ParameterCryptoInfo
-impl<T, U> core::convert::Into<U> for mssql_client::encryption::ParameterCryptoInfo where U: core::convert::From<T>
-pub fn mssql_client::encryption::ParameterCryptoInfo::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for mssql_client::encryption::ParameterCryptoInfo where U: core::convert::Into<T>
-pub type mssql_client::encryption::ParameterCryptoInfo::Error = core::convert::Infallible
-pub fn mssql_client::encryption::ParameterCryptoInfo::try_from(U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for mssql_client::encryption::ParameterCryptoInfo where U: core::convert::TryFrom<T>
-pub type mssql_client::encryption::ParameterCryptoInfo::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn mssql_client::encryption::ParameterCryptoInfo::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for mssql_client::encryption::ParameterCryptoInfo where T: core::clone::Clone
-pub type mssql_client::encryption::ParameterCryptoInfo::Owned = T
-pub fn mssql_client::encryption::ParameterCryptoInfo::clone_into(&self, &mut T)
-pub fn mssql_client::encryption::ParameterCryptoInfo::to_owned(&self) -> T
-impl<T> core::any::Any for mssql_client::encryption::ParameterCryptoInfo where T: 'static + ?core::marker::Sized
-pub fn mssql_client::encryption::ParameterCryptoInfo::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for mssql_client::encryption::ParameterCryptoInfo where T: ?core::marker::Sized
-pub fn mssql_client::encryption::ParameterCryptoInfo::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for mssql_client::encryption::ParameterCryptoInfo where T: ?core::marker::Sized
-pub fn mssql_client::encryption::ParameterCryptoInfo::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for mssql_client::encryption::ParameterCryptoInfo where T: core::clone::Clone
-pub unsafe fn mssql_client::encryption::ParameterCryptoInfo::clone_to_uninit(&self, *mut u8)
-impl<T> core::convert::From<T> for mssql_client::encryption::ParameterCryptoInfo
-pub fn mssql_client::encryption::ParameterCryptoInfo::from(T) -> T
-impl<T> tracing::instrument::Instrument for mssql_client::encryption::ParameterCryptoInfo
-impl<T> tracing::instrument::WithSubscriber for mssql_client::encryption::ParameterCryptoInfo
-impl<T> typenum::type_operators::Same for mssql_client::encryption::ParameterCryptoInfo
-pub type mssql_client::encryption::ParameterCryptoInfo::Output = T
-impl<V, T> ppv_lite86::types::VZip<V> for mssql_client::encryption::ParameterCryptoInfo where V: ppv_lite86::types::MultiLane<T>
-pub fn mssql_client::encryption::ParameterCryptoInfo::vzip(self) -> V
-pub struct mssql_client::ParameterEncryptionInfo
-pub mssql_client::ParameterEncryptionInfo::cek_table: tds_protocol::crypto::CekTable
-pub mssql_client::ParameterEncryptionInfo::parameters: std::collections::hash::map::HashMap<alloc::string::String, mssql_client::encryption::ParameterCryptoInfo>
-impl mssql_client::encryption::ParameterEncryptionInfo
-pub fn mssql_client::encryption::ParameterEncryptionInfo::add_parameter(&mut self, alloc::string::String, mssql_client::encryption::ParameterCryptoInfo)
-pub fn mssql_client::encryption::ParameterEncryptionInfo::get_parameter(&self, &str) -> core::option::Option<&mssql_client::encryption::ParameterCryptoInfo>
-pub fn mssql_client::encryption::ParameterEncryptionInfo::needs_encryption(&self, &str) -> bool
-pub fn mssql_client::encryption::ParameterEncryptionInfo::new() -> Self
-impl core::clone::Clone for mssql_client::encryption::ParameterEncryptionInfo
-pub fn mssql_client::encryption::ParameterEncryptionInfo::clone(&self) -> mssql_client::encryption::ParameterEncryptionInfo
-impl core::default::Default for mssql_client::encryption::ParameterEncryptionInfo
-pub fn mssql_client::encryption::ParameterEncryptionInfo::default() -> Self
-impl core::fmt::Debug for mssql_client::encryption::ParameterEncryptionInfo
-pub fn mssql_client::encryption::ParameterEncryptionInfo::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::Freeze for mssql_client::encryption::ParameterEncryptionInfo
-impl core::marker::Send for mssql_client::encryption::ParameterEncryptionInfo
-impl core::marker::Sync for mssql_client::encryption::ParameterEncryptionInfo
-impl core::marker::Unpin for mssql_client::encryption::ParameterEncryptionInfo
-impl core::panic::unwind_safe::RefUnwindSafe for mssql_client::encryption::ParameterEncryptionInfo
-impl core::panic::unwind_safe::UnwindSafe for mssql_client::encryption::ParameterEncryptionInfo
-impl<T, U> core::convert::Into<U> for mssql_client::encryption::ParameterEncryptionInfo where U: core::convert::From<T>
-pub fn mssql_client::encryption::ParameterEncryptionInfo::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for mssql_client::encryption::ParameterEncryptionInfo where U: core::convert::Into<T>
-pub type mssql_client::encryption::ParameterEncryptionInfo::Error = core::convert::Infallible
-pub fn mssql_client::encryption::ParameterEncryptionInfo::try_from(U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for mssql_client::encryption::ParameterEncryptionInfo where U: core::convert::TryFrom<T>
-pub type mssql_client::encryption::ParameterEncryptionInfo::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn mssql_client::encryption::ParameterEncryptionInfo::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for mssql_client::encryption::ParameterEncryptionInfo where T: core::clone::Clone
-pub type mssql_client::encryption::ParameterEncryptionInfo::Owned = T
-pub fn mssql_client::encryption::ParameterEncryptionInfo::clone_into(&self, &mut T)
-pub fn mssql_client::encryption::ParameterEncryptionInfo::to_owned(&self) -> T
-impl<T> core::any::Any for mssql_client::encryption::ParameterEncryptionInfo where T: 'static + ?core::marker::Sized
-pub fn mssql_client::encryption::ParameterEncryptionInfo::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for mssql_client::encryption::ParameterEncryptionInfo where T: ?core::marker::Sized
-pub fn mssql_client::encryption::ParameterEncryptionInfo::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for mssql_client::encryption::ParameterEncryptionInfo where T: ?core::marker::Sized
-pub fn mssql_client::encryption::ParameterEncryptionInfo::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for mssql_client::encryption::ParameterEncryptionInfo where T: core::clone::Clone
-pub unsafe fn mssql_client::encryption::ParameterEncryptionInfo::clone_to_uninit(&self, *mut u8)
-impl<T> core::convert::From<T> for mssql_client::encryption::ParameterEncryptionInfo
-pub fn mssql_client::encryption::ParameterEncryptionInfo::from(T) -> T
-impl<T> tracing::instrument::Instrument for mssql_client::encryption::ParameterEncryptionInfo
-impl<T> tracing::instrument::WithSubscriber for mssql_client::encryption::ParameterEncryptionInfo
-impl<T> typenum::type_operators::Same for mssql_client::encryption::ParameterEncryptionInfo
-pub type mssql_client::encryption::ParameterEncryptionInfo::Output = T
-impl<V, T> ppv_lite86::types::VZip<V> for mssql_client::encryption::ParameterEncryptionInfo where V: ppv_lite86::types::MultiLane<T>
-pub fn mssql_client::encryption::ParameterEncryptionInfo::vzip(self) -> V
 pub struct mssql_client::ProcedureBuilder<'a, S: mssql_client::state::ConnectionState>
 impl<'a, S: mssql_client::state::ConnectionState> mssql_client::procedure::ProcedureBuilder<'a, S>
 pub async fn mssql_client::procedure::ProcedureBuilder<'a, S>::execute(&mut self) -> mssql_client::error::Result<mssql_client::stream::ProcedureResult>
@@ -5058,53 +4792,6 @@ impl<T> typenum::type_operators::Same for mssql_client::stream::ResultSet
 pub type mssql_client::stream::ResultSet::Output = T
 impl<V, T> ppv_lite86::types::VZip<V> for mssql_client::stream::ResultSet where V: ppv_lite86::types::MultiLane<T>
 pub fn mssql_client::stream::ResultSet::vzip(self) -> V
-pub struct mssql_client::ResultSetEncryptionInfo
-pub mssql_client::ResultSetEncryptionInfo::cek_table: tds_protocol::crypto::CekTable
-pub mssql_client::ResultSetEncryptionInfo::column_crypto: alloc::vec::Vec<core::option::Option<tds_protocol::crypto::CryptoMetadata>>
-impl mssql_client::encryption::ResultSetEncryptionInfo
-pub fn mssql_client::encryption::ResultSetEncryptionInfo::get_cek_for_column(&self, usize) -> core::option::Option<&tds_protocol::crypto::CekTableEntry>
-pub fn mssql_client::encryption::ResultSetEncryptionInfo::get_encryption_type(&self, usize) -> core::option::Option<tds_protocol::crypto::EncryptionTypeWire>
-pub fn mssql_client::encryption::ResultSetEncryptionInfo::is_column_encrypted(&self, usize) -> bool
-pub fn mssql_client::encryption::ResultSetEncryptionInfo::new(tds_protocol::crypto::CekTable, usize) -> Self
-pub fn mssql_client::encryption::ResultSetEncryptionInfo::set_column_crypto(&mut self, usize, tds_protocol::crypto::CryptoMetadata)
-impl core::clone::Clone for mssql_client::encryption::ResultSetEncryptionInfo
-pub fn mssql_client::encryption::ResultSetEncryptionInfo::clone(&self) -> mssql_client::encryption::ResultSetEncryptionInfo
-impl core::fmt::Debug for mssql_client::encryption::ResultSetEncryptionInfo
-pub fn mssql_client::encryption::ResultSetEncryptionInfo::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-impl core::marker::Freeze for mssql_client::encryption::ResultSetEncryptionInfo
-impl core::marker::Send for mssql_client::encryption::ResultSetEncryptionInfo
-impl core::marker::Sync for mssql_client::encryption::ResultSetEncryptionInfo
-impl core::marker::Unpin for mssql_client::encryption::ResultSetEncryptionInfo
-impl core::panic::unwind_safe::RefUnwindSafe for mssql_client::encryption::ResultSetEncryptionInfo
-impl core::panic::unwind_safe::UnwindSafe for mssql_client::encryption::ResultSetEncryptionInfo
-impl<T, U> core::convert::Into<U> for mssql_client::encryption::ResultSetEncryptionInfo where U: core::convert::From<T>
-pub fn mssql_client::encryption::ResultSetEncryptionInfo::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for mssql_client::encryption::ResultSetEncryptionInfo where U: core::convert::Into<T>
-pub type mssql_client::encryption::ResultSetEncryptionInfo::Error = core::convert::Infallible
-pub fn mssql_client::encryption::ResultSetEncryptionInfo::try_from(U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for mssql_client::encryption::ResultSetEncryptionInfo where U: core::convert::TryFrom<T>
-pub type mssql_client::encryption::ResultSetEncryptionInfo::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn mssql_client::encryption::ResultSetEncryptionInfo::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> alloc::borrow::ToOwned for mssql_client::encryption::ResultSetEncryptionInfo where T: core::clone::Clone
-pub type mssql_client::encryption::ResultSetEncryptionInfo::Owned = T
-pub fn mssql_client::encryption::ResultSetEncryptionInfo::clone_into(&self, &mut T)
-pub fn mssql_client::encryption::ResultSetEncryptionInfo::to_owned(&self) -> T
-impl<T> core::any::Any for mssql_client::encryption::ResultSetEncryptionInfo where T: 'static + ?core::marker::Sized
-pub fn mssql_client::encryption::ResultSetEncryptionInfo::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for mssql_client::encryption::ResultSetEncryptionInfo where T: ?core::marker::Sized
-pub fn mssql_client::encryption::ResultSetEncryptionInfo::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for mssql_client::encryption::ResultSetEncryptionInfo where T: ?core::marker::Sized
-pub fn mssql_client::encryption::ResultSetEncryptionInfo::borrow_mut(&mut self) -> &mut T
-impl<T> core::clone::CloneToUninit for mssql_client::encryption::ResultSetEncryptionInfo where T: core::clone::Clone
-pub unsafe fn mssql_client::encryption::ResultSetEncryptionInfo::clone_to_uninit(&self, *mut u8)
-impl<T> core::convert::From<T> for mssql_client::encryption::ResultSetEncryptionInfo
-pub fn mssql_client::encryption::ResultSetEncryptionInfo::from(T) -> T
-impl<T> tracing::instrument::Instrument for mssql_client::encryption::ResultSetEncryptionInfo
-impl<T> tracing::instrument::WithSubscriber for mssql_client::encryption::ResultSetEncryptionInfo
-impl<T> typenum::type_operators::Same for mssql_client::encryption::ResultSetEncryptionInfo
-pub type mssql_client::encryption::ResultSetEncryptionInfo::Output = T
-impl<V, T> ppv_lite86::types::VZip<V> for mssql_client::encryption::ResultSetEncryptionInfo where V: ppv_lite86::types::MultiLane<T>
-pub fn mssql_client::encryption::ResultSetEncryptionInfo::vzip(self) -> V
 pub struct mssql_client::RetryPolicy
 pub mssql_client::RetryPolicy::backoff_multiplier: f64
 pub mssql_client::RetryPolicy::initial_backoff: core::time::Duration
@@ -5392,36 +5079,6 @@ impl<T> typenum::type_operators::Same for mssql_client::error::SharedIoError
 pub type mssql_client::error::SharedIoError::Output = T
 impl<V, T> ppv_lite86::types::VZip<V> for mssql_client::error::SharedIoError where V: ppv_lite86::types::MultiLane<T>
 pub fn mssql_client::error::SharedIoError::vzip(self) -> V
-pub struct mssql_client::Streaming
-impl mssql_client::state::ConnectionState for mssql_client::state::Streaming
-impl core::marker::Freeze for mssql_client::state::Streaming
-impl core::marker::Send for mssql_client::state::Streaming
-impl core::marker::Sync for mssql_client::state::Streaming
-impl core::marker::Unpin for mssql_client::state::Streaming
-impl core::panic::unwind_safe::RefUnwindSafe for mssql_client::state::Streaming
-impl core::panic::unwind_safe::UnwindSafe for mssql_client::state::Streaming
-impl<T, U> core::convert::Into<U> for mssql_client::state::Streaming where U: core::convert::From<T>
-pub fn mssql_client::state::Streaming::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for mssql_client::state::Streaming where U: core::convert::Into<T>
-pub type mssql_client::state::Streaming::Error = core::convert::Infallible
-pub fn mssql_client::state::Streaming::try_from(U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for mssql_client::state::Streaming where U: core::convert::TryFrom<T>
-pub type mssql_client::state::Streaming::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn mssql_client::state::Streaming::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for mssql_client::state::Streaming where T: 'static + ?core::marker::Sized
-pub fn mssql_client::state::Streaming::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for mssql_client::state::Streaming where T: ?core::marker::Sized
-pub fn mssql_client::state::Streaming::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for mssql_client::state::Streaming where T: ?core::marker::Sized
-pub fn mssql_client::state::Streaming::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for mssql_client::state::Streaming
-pub fn mssql_client::state::Streaming::from(T) -> T
-impl<T> tracing::instrument::Instrument for mssql_client::state::Streaming
-impl<T> tracing::instrument::WithSubscriber for mssql_client::state::Streaming
-impl<T> typenum::type_operators::Same for mssql_client::state::Streaming
-pub type mssql_client::state::Streaming::Output = T
-impl<V, T> ppv_lite86::types::VZip<V> for mssql_client::state::Streaming where V: ppv_lite86::types::MultiLane<T>
-pub fn mssql_client::state::Streaming::vzip(self) -> V
 pub struct mssql_client::TimeoutConfig
 pub mssql_client::TimeoutConfig::command_timeout: core::time::Duration
 pub mssql_client::TimeoutConfig::connect_timeout: core::time::Duration
@@ -5655,7 +5312,6 @@ impl mssql_client::state::ConnectionState for mssql_client::state::Connected
 impl mssql_client::state::ConnectionState for mssql_client::state::Disconnected
 impl mssql_client::state::ConnectionState for mssql_client::state::InTransaction
 impl mssql_client::state::ConnectionState for mssql_client::state::Ready
-impl mssql_client::state::ConnectionState for mssql_client::state::Streaming
 pub trait mssql_client::FromRow: core::marker::Sized
 pub fn mssql_client::FromRow::from_row(&mssql_client::row::Row) -> core::result::Result<Self, mssql_client::error::Error>
 pub trait mssql_client::RowIteratorExt: core::iter::traits::iterator::Iterator<Item = core::result::Result<mssql_client::row::Row, mssql_client::error::Error>> + core::marker::Sized


### PR DESCRIPTION
## Summary

Two pre-1.0 public-surface reductions on one branch (one snapshot regen), from the commit-review ledger (U4-F2, M1/U2-F1/U2-F2). Changing these after 1.0 would be breaking, so they land now as a free minor bump and set the new baseline. Order: #286 (delete) → #285 (pub(crate)) → snapshot.

### #286 — remove the dead `Streaming` type-state
`Client<Streaming>` was the originally-planned streaming architecture, superseded by the `&mut`-borrow model. Nothing returns or implements `Client<Streaming>`; the marker only lived in the frozen public-api snapshot and two send/sync asserts. Removed the struct, its `ConnectionState`/`Sealed` impls, the `lib.rs` re-export, and the asserts.

### #285 — `pub(crate)` the Always Encrypted crypto surface
`EncryptionContext` (+ raw `get_encryptor`/`encrypt_value`/`decrypt_value`), `ParameterEncryptionInfo`, `ParameterCryptoInfo`, and `ResultSetEncryptionInfo` were `pub` but are accidental plumbing (no example/guide/README/doctest use; rustdoc describes internal state; CHANGELOG names them only as bug-fix subjects). Made them `pub(crate)` and dropped the `lib.rs` re-exports (`EncryptionConfig` stays public).

The change forced two internal-only items off the surface as well:
- `Client::describe_parameter_encryption` → `pub(crate)` (its return type is now internal; its only public caller was one `#[ignore]` live test, deleted — the path stays covered transitively by the AE write-path round-trip tests).
- `BulkInsert::new_with_server_metadata` → `pub(crate)`, removing the **last `tds_protocol::token::ColumnData` leak**.

With the types no longer public, the compiler revealed genuinely dead items they had kept alive. Deleted `ResultSetEncryptionInfo` (never constructed), `EncryptionContext::{new,decrypt_value,clear_cache}`, `ParameterEncryptionInfo::{add_parameter,needs_encryption}`, `ParameterCryptoInfo::new`, and the unit/integration tests that only exercised the deleted methods. Gated the remaining AE-only parameter types behind `always-encrypted` so they aren't dead without it.

**Result:** zero `tds_protocol::crypto::*` and zero `token::ColumnData` references remain on the frozen `mssql-client` surface.

### STABILITY.md (auto-resolves U2-F2)
`EncryptionContext` removed from the stable-API table; the stable surface no longer exposes `tds_protocol::crypto` types, resolving the "stable API exposes unstable types" contradiction.

### Public-API snapshots
One regen at the end. Linux baseline: **−476 lines, 0 additions**. Windows baseline: the same 344 platform-agnostic lines removed (the always-encrypted-gated items were never in it, as the Windows job builds without that feature); no Windows-only surface affected.

## Test plan
- `just ci-all` — fmt, clippy `--all-features --all-targets -D warnings`, nextest (919 passed), `cargo doc -D warnings`, examples ✅
- `just typos` ✅
- `just check-feature-flags` (cargo-hack `--each-feature`) — validates the `always-encrypted` gating ✅
- `just public-api` (Linux) ✅
- `just doc-consistency` ✅
- No live SQL Server needed.

## Notes for review
- Two decisions were made beyond the literal prompt scope (the prompt didn't anticipate them) and are open to reversal: making `describe_parameter_encryption` internal + deleting its live test, and deleting the revealed dead code (vs `#[allow(dead_code)]`).
- The Windows baseline was edited by removing the identical platform-agnostic lines (it can't be regenerated on Linux). The `public-api-windows` CI job will confirm it matches the live Windows surface.

Closes #285
Closes #286

## Related (not folded in)
- #242 — cross-crate wire-codec helpers; separate design-first prompt, rebases on this new baseline.
- #281 — protocol-layer dead-code sibling of #286.