### PR TITLE
chore: fix #289 no_std std-feature symmetry and 2017 CI-suite wording

### DIFF
--- a/LIMITATIONS.md
+++ b/LIMITATIONS.md
@@ -293,8 +293,9 @@ the full rationale.
 | TDS 8.0 | SQL Server 2022+ strict mode | `TdsVersion::V8_0` or `Encrypt=strict` |
 
 **How each version is validated:** SQL Server **2017, 2019, and 2022 are
-CI-verified** — the integration suite runs the full `#[ignore]`d test suite
-against all three on every change. SQL Server **2008–2016** (TDS 7.3A/7.3B) and
+CI-verified** — the integration suite runs the full applicable `#[ignore]`d
+test suite against all three on every change (the 2017 leg excludes
+`test_utf8_varchar_decoding`, since UTF-8 collations are a 2019+ feature). SQL Server **2008–2016** (TDS 7.3A/7.3B) and
 Azure SQL are **validated manually** against real servers, not in CI, so
 regressions on those versions are caught later than on the CI-verified ones.
 

--- a/crates/tds-protocol/Cargo.toml
+++ b/crates/tds-protocol/Cargo.toml
@@ -16,7 +16,7 @@ all-features = true
 
 [features]
 default = ["std", "encoding"]
-std = ["bytes/std"]
+std = ["bytes/std", "thiserror/std"]
 alloc = []
 # Collation-aware string encoding/decoding support
 # Enables Collation::encoding() method for proper VARCHAR decoding


### PR DESCRIPTION
## Summary

Two trivial cleanups from the `v0.16.0..HEAD` review (findings U5-F1, U6-F1).

## Linked issues

Closes #289

## Type of change

- [x] Documentation only
- [x] Build / CI / tooling

## Changes

1. **`crates/tds-protocol/Cargo.toml`** — gate `thiserror/std` under the `std` feature: `std = ["bytes/std", "thiserror/std"]`. The workspace `thiserror` dep is `default-features = false`, so without this the crate's `std` feature never re-enabled thiserror's `std`. Harmless today (thiserror 2.0 uses `core::error::Error`), but now correct and matches the #271 PR description.
2. **`LIMITATIONS.md`** — the 2017 CI leg runs the full *applicable* `#[ignore]`d suite, excluding `test_utf8_varchar_decoding` (UTF-8 collations are a 2019+ feature). Reworded to say so.

## Test plan

- [x] `just ci-all` passes (fmt + clippy `-D warnings` + nextest all-features + doc + examples)
- [x] `just typos` passes

No behavioral change.