### PR TITLE
refactor(api)!: seal cross-crate wire-codec helpers off the frozen public surface (#242)

### DIFF
--- a/crates/mssql-client/src/bulk.rs
+++ b/crates/mssql-client/src/bulk.rs
@@ -1000,13 +1000,13 @@ impl BulkInsert {
             SqlValue::Uuid(u) => {
                 buf.put_u8(16); // Length
                 // Use mssql_types encode function
-                mssql_types::encode::encode_uuid(*u, buf);
+                mssql_types::__private::encode_uuid(*u, buf);
             }
 
             #[cfg(feature = "chrono")]
             SqlValue::Date(d) => {
                 buf.put_u8(3); // Length
-                mssql_types::encode::encode_date(*d, buf)?;
+                mssql_types::__private::encode_date(*d, buf)?;
             }
 
             #[cfg(feature = "chrono")]
@@ -1030,8 +1030,8 @@ impl BulkInsert {
                         buf.put_u8(total_len);
                     }
                     match total_len {
-                        8 => mssql_types::encode::encode_datetime_legacy(*dt, buf),
-                        4 => mssql_types::encode::encode_smalldatetime(*dt, buf)?,
+                        8 => mssql_types::__private::encode_datetime_legacy(*dt, buf),
+                        4 => mssql_types::__private::encode_smalldatetime(*dt, buf)?,
                         _ => {
                             return Err(TypeError::InvalidDateTime(format!(
                                 "DATETIMEN max_length must be 4 or 8, got {total_len}"
@@ -1045,7 +1045,7 @@ impl BulkInsert {
                     buf.put_u8(total_len);
                     // Encode time then date
                     encode_time_with_scale(dt.time(), scale, buf);
-                    mssql_types::encode::encode_date(dt.date(), buf)?;
+                    mssql_types::__private::encode_date(dt.date(), buf)?;
                 }
             }
             #[cfg(feature = "chrono")]
@@ -1055,7 +1055,7 @@ impl BulkInsert {
                 if !is_fixed {
                     buf.put_u8(4);
                 }
-                mssql_types::encode::encode_smalldatetime(*dt, buf)?;
+                mssql_types::__private::encode_smalldatetime(*dt, buf)?;
             }
             #[cfg(feature = "decimal")]
             SqlValue::Money(d) => {
@@ -1063,14 +1063,14 @@ impl BulkInsert {
                 if !is_fixed {
                     buf.put_u8(8);
                 }
-                mssql_types::encode::encode_money(*d, buf)?;
+                mssql_types::__private::encode_money(*d, buf)?;
             }
             #[cfg(feature = "decimal")]
             SqlValue::SmallMoney(d) => {
                 if !is_fixed {
                     buf.put_u8(4);
                 }
-                mssql_types::encode::encode_smallmoney(*d, buf)?;
+                mssql_types::__private::encode_smallmoney(*d, buf)?;
             }
 
             #[cfg(feature = "chrono")]
@@ -1083,7 +1083,7 @@ impl BulkInsert {
                 // not the local wall-clock.
                 let utc = dto.naive_utc();
                 encode_time_with_scale(utc.time(), scale, buf);
-                mssql_types::encode::encode_date(utc.date(), buf)?;
+                mssql_types::__private::encode_date(utc.date(), buf)?;
                 // Timezone offset in minutes
                 use chrono::Offset;
                 let offset_minutes = (dto.offset().fix().local_minus_utc() / 60) as i16;
@@ -1137,8 +1137,8 @@ fn encode_money_value(
         buf.put_u8(money_bytes);
     }
     match money_bytes {
-        4 => mssql_types::encode::encode_smallmoney(value, buf),
-        8 => mssql_types::encode::encode_money(value, buf),
+        4 => mssql_types::__private::encode_smallmoney(value, buf),
+        8 => mssql_types::__private::encode_money(value, buf),
         _ => Err(TypeError::InvalidDecimal(format!(
             "MONEY column has invalid max_length: {money_bytes}"
         ))),
@@ -1212,10 +1212,10 @@ fn encode_plp_binary(data: &[u8], buf: &mut BytesMut) {
 
 /// Encode a Rust string into single-byte VARCHAR bytes using the column's collation.
 ///
-/// Delegates to [`tds_protocol::collation::encode_str_for_collation`] so the
+/// Delegates to [`tds_protocol::__private::encode_str_for_collation`] so the
 /// RPC parameter path and the bulk insert path share one implementation.
 fn encode_varchar_for_collation(value: &str, collation: Option<&Collation>) -> Vec<u8> {
-    tds_protocol::collation::encode_str_for_collation(value, collation)
+    tds_protocol::__private::encode_str_for_collation(value, collation)
 }
 
 /// Encode time with specific scale (for bulk copy).

--- a/crates/mssql-client/src/client.rs
+++ b/crates/mssql-client/src/client.rs
@@ -335,8 +335,10 @@ impl<S: ConnectionState> Client<S> {
         // does not pick up the old response's bytes.
         self.cancel_in_flight_response().await?;
 
-        let payload =
-            tds_protocol::encode_sql_batch_with_transaction(sql, self.transaction_descriptor);
+        let payload = tds_protocol::__private::encode_sql_batch_with_transaction(
+            sql,
+            self.transaction_descriptor,
+        );
         let max_packet = self.config.packet_size as usize;
 
         // Check if we need to reset the connection on this request

--- a/crates/mssql-client/src/client/params.rs
+++ b/crates/mssql-client/src/client/params.rs
@@ -4,18 +4,18 @@
 //! RPC parameters, including Table-Valued Parameter (TVP) encoding.
 
 use bytes::BytesMut;
-use tds_protocol::rpc::{RpcParam, TypeInfo as RpcTypeInfo};
 #[cfg(feature = "decimal")]
-use tds_protocol::tvp::encode_tvp_decimal;
-use tds_protocol::tvp::{
-    TvpColumnDef as TvpWireColumnDef, TvpEncoder, TvpWireType, encode_tvp_bit, encode_tvp_float,
-    encode_tvp_int, encode_tvp_null, encode_tvp_nvarchar, encode_tvp_varbinary,
-    encode_tvp_varchar_with_collation,
+use tds_protocol::__private::encode_tvp_decimal;
+use tds_protocol::__private::{
+    encode_tvp_bit, encode_tvp_float, encode_tvp_int, encode_tvp_null, encode_tvp_nvarchar,
+    encode_tvp_varbinary, encode_tvp_varchar_with_collation,
 };
 #[cfg(feature = "chrono")]
-use tds_protocol::tvp::{encode_tvp_datetime, encode_tvp_smalldatetime};
+use tds_protocol::__private::{encode_tvp_datetime, encode_tvp_smalldatetime};
 #[cfg(feature = "decimal")]
-use tds_protocol::tvp::{encode_tvp_money, encode_tvp_smallmoney};
+use tds_protocol::__private::{encode_tvp_money, encode_tvp_smallmoney};
+use tds_protocol::rpc::{RpcParam, TypeInfo as RpcTypeInfo};
+use tds_protocol::tvp::{TvpColumnDef as TvpWireColumnDef, TvpEncoder, TvpWireType};
 
 use crate::error::{Error, Result};
 use crate::state::ConnectionState;
@@ -106,50 +106,50 @@ impl<S: ConnectionState> Client<S> {
             #[cfg(feature = "decimal")]
             SqlValue::Decimal(d) => {
                 let mut buf = BytesMut::with_capacity(17);
-                mssql_types::encode::encode_decimal(*d, &mut buf);
+                mssql_types::__private::encode_decimal(*d, &mut buf);
                 let scale = d.scale() as u8;
                 RpcParam::new(name, RpcTypeInfo::decimal(38, scale), buf.freeze())
             }
             #[cfg(feature = "decimal")]
             SqlValue::Money(d) => {
                 let mut buf = BytesMut::with_capacity(8);
-                mssql_types::encode::encode_money(*d, &mut buf)?;
+                mssql_types::__private::encode_money(*d, &mut buf)?;
                 RpcParam::new(name, RpcTypeInfo::money(), buf.freeze())
             }
             #[cfg(feature = "decimal")]
             SqlValue::SmallMoney(d) => {
                 let mut buf = BytesMut::with_capacity(4);
-                mssql_types::encode::encode_smallmoney(*d, &mut buf)?;
+                mssql_types::__private::encode_smallmoney(*d, &mut buf)?;
                 RpcParam::new(name, RpcTypeInfo::smallmoney(), buf.freeze())
             }
             #[cfg(feature = "chrono")]
             SqlValue::Date(d) => {
                 let mut buf = BytesMut::with_capacity(3);
-                mssql_types::encode::encode_date(*d, &mut buf)?;
+                mssql_types::__private::encode_date(*d, &mut buf)?;
                 RpcParam::new(name, RpcTypeInfo::date(), buf.freeze())
             }
             #[cfg(feature = "chrono")]
             SqlValue::Time(t) => {
                 let mut buf = BytesMut::with_capacity(5);
-                mssql_types::encode::encode_time(*t, &mut buf);
+                mssql_types::__private::encode_time(*t, &mut buf);
                 RpcParam::new(name, RpcTypeInfo::time(7), buf.freeze())
             }
             #[cfg(feature = "chrono")]
             SqlValue::DateTime(dt) => {
                 let mut buf = BytesMut::with_capacity(8);
-                mssql_types::encode::encode_datetime2(*dt, &mut buf)?;
+                mssql_types::__private::encode_datetime2(*dt, &mut buf)?;
                 RpcParam::new(name, RpcTypeInfo::datetime2(7), buf.freeze())
             }
             #[cfg(feature = "chrono")]
             SqlValue::SmallDateTime(dt) => {
                 let mut buf = BytesMut::with_capacity(4);
-                mssql_types::encode::encode_smalldatetime(*dt, &mut buf)?;
+                mssql_types::__private::encode_smalldatetime(*dt, &mut buf)?;
                 RpcParam::new(name, RpcTypeInfo::smalldatetime(), buf.freeze())
             }
             #[cfg(feature = "chrono")]
             SqlValue::DateTimeOffset(dto) => {
                 let mut buf = BytesMut::with_capacity(10);
-                mssql_types::encode::encode_datetimeoffset(*dto, &mut buf)?;
+                mssql_types::__private::encode_datetimeoffset(*dto, &mut buf)?;
                 RpcParam::new(name, RpcTypeInfo::datetimeoffset(7), buf.freeze())
             }
             #[cfg(feature = "json")]
@@ -434,11 +434,11 @@ impl<S: ConnectionState> Client<S> {
                 // authoritative dispatch key.
                 match wire_type {
                     TvpWireType::Money => {
-                        let scaled = mssql_types::encode::decimal_to_money_cents_i64(*d)?;
+                        let scaled = mssql_types::__private::decimal_to_money_cents_i64(*d)?;
                         encode_tvp_money(scaled, buf);
                     }
                     TvpWireType::SmallMoney => {
-                        let scaled = mssql_types::encode::decimal_to_smallmoney_cents_i32(*d)?;
+                        let scaled = mssql_types::__private::decimal_to_smallmoney_cents_i32(*d)?;
                         encode_tvp_smallmoney(scaled, buf);
                     }
                     _ => {
@@ -451,7 +451,7 @@ impl<S: ConnectionState> Client<S> {
             #[cfg(feature = "uuid")]
             SqlValue::Uuid(u) => {
                 let bytes = u.as_bytes();
-                tds_protocol::tvp::encode_tvp_guid(bytes, buf);
+                tds_protocol::__private::encode_tvp_guid(bytes, buf);
             }
             #[cfg(feature = "chrono")]
             SqlValue::Date(d) => {
@@ -459,7 +459,7 @@ impl<S: ConnectionState> Client<S> {
                 let base =
                     chrono::NaiveDate::from_ymd_opt(1, 1, 1).expect("epoch 0001-01-01 is valid");
                 let days = d.signed_duration_since(base).num_days() as u32;
-                tds_protocol::tvp::encode_tvp_date(days, buf);
+                tds_protocol::__private::encode_tvp_date(days, buf);
             }
             #[cfg(feature = "chrono")]
             SqlValue::Time(t) => {
@@ -471,7 +471,7 @@ impl<S: ConnectionState> Client<S> {
                     TvpWireType::Time { scale } => *scale,
                     _ => 7,
                 };
-                tds_protocol::tvp::encode_tvp_time(intervals, scale, buf);
+                tds_protocol::__private::encode_tvp_time(intervals, scale, buf);
             }
             #[cfg(feature = "chrono")]
             SqlValue::DateTime(dt) | SqlValue::SmallDateTime(dt) => {
@@ -481,12 +481,13 @@ impl<S: ConnectionState> Client<S> {
                 // gets the DATETIME2 time+date format.
                 match wire_type {
                     TvpWireType::DateTime => {
-                        let (days, ticks) = mssql_types::encode::datetime_to_legacy_days_ticks(*dt);
+                        let (days, ticks) =
+                            mssql_types::__private::datetime_to_legacy_days_ticks(*dt);
                         encode_tvp_datetime(days, ticks, buf);
                     }
                     TvpWireType::SmallDateTime => {
                         let (days, minutes) =
-                            mssql_types::encode::datetime_to_smalldatetime_days_minutes(*dt)?;
+                            mssql_types::__private::datetime_to_smalldatetime_days_minutes(*dt)?;
                         encode_tvp_smalldatetime(days, minutes, buf);
                     }
                     _ => {
@@ -503,7 +504,7 @@ impl<S: ConnectionState> Client<S> {
                             TvpWireType::DateTime2 { scale } => *scale,
                             _ => 7,
                         };
-                        tds_protocol::tvp::encode_tvp_datetime2(intervals, days, scale, buf);
+                        tds_protocol::__private::encode_tvp_datetime2(intervals, days, scale, buf);
                     }
                 }
             }
@@ -527,7 +528,7 @@ impl<S: ConnectionState> Client<S> {
                     TvpWireType::DateTimeOffset { scale } => *scale,
                     _ => 7,
                 };
-                tds_protocol::tvp::encode_tvp_datetimeoffset(
+                tds_protocol::__private::encode_tvp_datetimeoffset(
                     intervals,
                     days,
                     offset_minutes,

--- a/crates/mssql-client/src/encryption.rs
+++ b/crates/mssql-client/src/encryption.rs
@@ -629,7 +629,7 @@ pub fn normalize_for_encryption(
             }
             (Some(E::DateTime), SqlValue::DateTime(dt)) => {
                 let mut buf = bytes::BytesMut::with_capacity(8);
-                mssql_types::encode::encode_datetime_legacy(*dt, &mut buf);
+                mssql_types::__private::encode_datetime_legacy(*dt, &mut buf);
                 return Ok(buf.to_vec());
             }
             _ => {}
@@ -692,7 +692,7 @@ pub fn normalize_for_encryption(
         #[cfg(feature = "chrono")]
         SqlValue::SmallDateTime(dt) => {
             let mut buf = bytes::BytesMut::with_capacity(4);
-            mssql_types::encode::encode_smalldatetime(*dt, &mut buf).map_err(|e| {
+            mssql_types::__private::encode_smalldatetime(*dt, &mut buf).map_err(|e| {
                 EncryptionError::UnsupportedOperation(format!("SMALLDATETIME: {e}"))
             })?;
             Ok(buf.to_vec())

--- a/crates/mssql-client/src/row.rs
+++ b/crates/mssql-client/src/row.rs
@@ -16,7 +16,8 @@ use std::sync::Arc;
 
 use bytes::Bytes;
 
-use mssql_types::decode::{TypeInfo, decode_value};
+use mssql_types::__private::decode_value;
+use mssql_types::decode::TypeInfo;
 use mssql_types::{FromSql, SqlValue, TypeError};
 
 use crate::blob::BlobReader;

--- a/crates/mssql-types/src/decode.rs
+++ b/crates/mssql-types/src/decode.rs
@@ -195,52 +195,61 @@ impl TypeInfo {
     }
 }
 
-/// Decode a SQL value based on type information.
-pub fn decode_value(buf: &mut Bytes, type_info: &TypeInfo) -> Result<SqlValue, TypeError> {
-    match type_info.type_id {
-        // Fixed-length types
-        0x1F => Ok(SqlValue::Null),   // NULLTYPE
-        0x32 => decode_bit(buf),      // BITTYPE
-        0x30 => decode_tinyint(buf),  // INT1TYPE
-        0x34 => decode_smallint(buf), // INT2TYPE
-        0x38 => decode_int(buf),      // INT4TYPE
-        0x7F => decode_bigint(buf),   // INT8TYPE
-        0x3B => decode_float(buf),    // FLT4TYPE
-        0x3E => decode_double(buf),   // FLT8TYPE
+/// Low-level TDS value decoder shared across the workspace crates.
+///
+/// Internal plumbing reached cross-crate only via [`crate::__private`]; not
+/// public API and exempt from semver guarantees (see #242). The per-type
+/// helpers it dispatches to remain module-private below.
+pub(crate) mod sealed {
+    use super::*;
 
-        // Nullable integer types (INTNTYPE)
-        0x26 => decode_intn(buf, type_info),
+    /// Decode a SQL value based on type information.
+    pub fn decode_value(buf: &mut Bytes, type_info: &TypeInfo) -> Result<SqlValue, TypeError> {
+        match type_info.type_id {
+            // Fixed-length types
+            0x1F => Ok(SqlValue::Null),   // NULLTYPE
+            0x32 => decode_bit(buf),      // BITTYPE
+            0x30 => decode_tinyint(buf),  // INT1TYPE
+            0x34 => decode_smallint(buf), // INT2TYPE
+            0x38 => decode_int(buf),      // INT4TYPE
+            0x7F => decode_bigint(buf),   // INT8TYPE
+            0x3B => decode_float(buf),    // FLT4TYPE
+            0x3E => decode_double(buf),   // FLT8TYPE
 
-        // Variable-length string types
-        0xE7 => decode_nvarchar(buf, type_info), // NVARCHARTYPE
-        0xAF => decode_varchar(buf, type_info),  // BIGCHARTYPE
-        0xA7 => decode_varchar(buf, type_info),  // BIGVARCHARTYPE
+            // Nullable integer types (INTNTYPE)
+            0x26 => decode_intn(buf, type_info),
 
-        // Binary types
-        0xA5 => decode_varbinary(buf, type_info), // BIGVARBINTYPE
-        0xAD => decode_varbinary(buf, type_info), // BIGBINARYTYPE
+            // Variable-length string types
+            0xE7 => decode_nvarchar(buf, type_info), // NVARCHARTYPE
+            0xAF => decode_varchar(buf, type_info),  // BIGCHARTYPE
+            0xA7 => decode_varchar(buf, type_info),  // BIGVARCHARTYPE
 
-        // GUID
-        0x24 => decode_guid(buf),
+            // Binary types
+            0xA5 => decode_varbinary(buf, type_info), // BIGVARBINTYPE
+            0xAD => decode_varbinary(buf, type_info), // BIGBINARYTYPE
 
-        // Decimal/Numeric
-        0x6C | 0x6A => decode_decimal(buf, type_info),
+            // GUID
+            0x24 => decode_guid(buf),
 
-        // Date/Time types
-        0x28 => decode_date(buf),                      // DATETYPE
-        0x29 => decode_time(buf, type_info),           // TIMETYPE
-        0x2A => decode_datetime2(buf, type_info),      // DATETIME2TYPE
-        0x2B => decode_datetimeoffset(buf, type_info), // DATETIMEOFFSETTYPE
-        0x3D => decode_datetime(buf),                  // DATETIMETYPE
-        0x3F => decode_smalldatetime(buf),             // SMALLDATETIMETYPE
+            // Decimal/Numeric
+            0x6C | 0x6A => decode_decimal(buf, type_info),
 
-        // XML
-        0xF1 => decode_xml(buf),
+            // Date/Time types
+            0x28 => decode_date(buf),                      // DATETYPE
+            0x29 => decode_time(buf, type_info),           // TIMETYPE
+            0x2A => decode_datetime2(buf, type_info),      // DATETIME2TYPE
+            0x2B => decode_datetimeoffset(buf, type_info), // DATETIMEOFFSETTYPE
+            0x3D => decode_datetime(buf),                  // DATETIMETYPE
+            0x3F => decode_smalldatetime(buf),             // SMALLDATETIMETYPE
 
-        _ => Err(TypeError::UnsupportedConversion {
-            from: format!("TDS type 0x{:02X}", type_info.type_id),
-            to: "SqlValue",
-        }),
+            // XML
+            0xF1 => decode_xml(buf),
+
+            _ => Err(TypeError::UnsupportedConversion {
+                from: format!("TDS type 0x{:02X}", type_info.type_id),
+                to: "SqlValue",
+            }),
+        }
     }
 }
 
@@ -1075,6 +1084,7 @@ fn intervals_to_time(intervals: u64, scale: u8) -> chrono::NaiveTime {
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::panic)]
 mod tests {
+    use super::sealed::decode_value;
     use super::*;
 
     #[test]

--- a/crates/mssql-types/src/encode.rs
+++ b/crates/mssql-types/src/encode.rs
@@ -177,290 +177,309 @@ pub fn encode_utf16_string(s: &str, buf: &mut BytesMut) {
     }
 }
 
-/// Encode a UUID in SQL Server's mixed-endian format.
+/// Low-level TDS wire encoders shared across the workspace crates.
 ///
-/// SQL Server stores UUIDs in a unique byte order:
-/// - First 4 bytes: little-endian
-/// - Next 2 bytes: little-endian
-/// - Next 2 bytes: little-endian
-/// - Last 8 bytes: big-endian (as-is)
-#[cfg(feature = "uuid")]
-pub fn encode_uuid(uuid: uuid::Uuid, buf: &mut BytesMut) {
-    let bytes = uuid.as_bytes();
+/// Internal plumbing reached cross-crate only via [`crate::__private`]; not
+/// public API and exempt from semver guarantees (see #242).
+pub(crate) mod sealed {
+    // Every encoder here is `#[cfg(feature = ...)]`-gated (uuid / decimal /
+    // chrono), so this module — and the glob imports of it — can be empty under
+    // `--no-default-features`.
+    #[allow(unused_imports)]
+    use super::*;
 
-    // First group (4 bytes) - reverse for little-endian
-    buf.put_u8(bytes[3]);
-    buf.put_u8(bytes[2]);
-    buf.put_u8(bytes[1]);
-    buf.put_u8(bytes[0]);
+    /// Encode a UUID in SQL Server's mixed-endian format.
+    ///
+    /// SQL Server stores UUIDs in a unique byte order:
+    /// - First 4 bytes: little-endian
+    /// - Next 2 bytes: little-endian
+    /// - Next 2 bytes: little-endian
+    /// - Last 8 bytes: big-endian (as-is)
+    #[cfg(feature = "uuid")]
+    pub fn encode_uuid(uuid: uuid::Uuid, buf: &mut BytesMut) {
+        let bytes = uuid.as_bytes();
 
-    // Second group (2 bytes) - reverse for little-endian
-    buf.put_u8(bytes[5]);
-    buf.put_u8(bytes[4]);
+        // First group (4 bytes) - reverse for little-endian
+        buf.put_u8(bytes[3]);
+        buf.put_u8(bytes[2]);
+        buf.put_u8(bytes[1]);
+        buf.put_u8(bytes[0]);
 
-    // Third group (2 bytes) - reverse for little-endian
-    buf.put_u8(bytes[7]);
-    buf.put_u8(bytes[6]);
+        // Second group (2 bytes) - reverse for little-endian
+        buf.put_u8(bytes[5]);
+        buf.put_u8(bytes[4]);
 
-    // Last 8 bytes - big-endian (keep as-is)
-    buf.put_slice(&bytes[8..16]);
-}
+        // Third group (2 bytes) - reverse for little-endian
+        buf.put_u8(bytes[7]);
+        buf.put_u8(bytes[6]);
 
-/// Encode a decimal value.
-///
-/// TDS DECIMAL format:
-/// - 1 byte: sign (0 = negative, 1 = positive)
-/// - Remaining bytes: absolute value in little-endian
-#[cfg(feature = "decimal")]
-pub fn encode_decimal(decimal: rust_decimal::Decimal, buf: &mut BytesMut) {
-    let sign = if decimal.is_sign_negative() { 0u8 } else { 1u8 };
-    buf.put_u8(sign);
+        // Last 8 bytes - big-endian (keep as-is)
+        buf.put_slice(&bytes[8..16]);
+    }
 
-    // Get the mantissa and encode as 128-bit integer
-    let mantissa = decimal.mantissa().unsigned_abs();
-    buf.put_u128_le(mantissa);
-}
+    /// Encode a decimal value.
+    ///
+    /// TDS DECIMAL format:
+    /// - 1 byte: sign (0 = negative, 1 = positive)
+    /// - Remaining bytes: absolute value in little-endian
+    #[cfg(feature = "decimal")]
+    pub fn encode_decimal(decimal: rust_decimal::Decimal, buf: &mut BytesMut) {
+        let sign = if decimal.is_sign_negative() { 0u8 } else { 1u8 };
+        buf.put_u8(sign);
 
-/// Rescale a decimal to MONEY's 4-decimal fixed-point representation.
-///
-/// Returns the signed 128-bit integer representing the value multiplied by
-/// 10_000. Excess precision past 4 decimal places is truncated toward zero.
-#[cfg(feature = "decimal")]
-fn decimal_to_money_cents(value: rust_decimal::Decimal) -> Result<i128, TypeError> {
-    let mantissa: i128 = value.mantissa();
-    let scale: u32 = value.scale();
-    if scale <= 4 {
-        let factor = 10_i128.pow(4 - scale);
-        mantissa.checked_mul(factor).ok_or(TypeError::OutOfRange {
+        // Get the mantissa and encode as 128-bit integer
+        let mantissa = decimal.mantissa().unsigned_abs();
+        buf.put_u128_le(mantissa);
+    }
+
+    /// Rescale a decimal to MONEY's 4-decimal fixed-point representation.
+    ///
+    /// Returns the signed 128-bit integer representing the value multiplied by
+    /// 10_000. Excess precision past 4 decimal places is truncated toward zero.
+    #[cfg(feature = "decimal")]
+    fn decimal_to_money_cents(value: rust_decimal::Decimal) -> Result<i128, TypeError> {
+        let mantissa: i128 = value.mantissa();
+        let scale: u32 = value.scale();
+        if scale <= 4 {
+            let factor = 10_i128.pow(4 - scale);
+            mantissa.checked_mul(factor).ok_or(TypeError::OutOfRange {
+                target_type: "MONEY",
+            })
+        } else {
+            let factor = 10_i128.pow(scale - 4);
+            Ok(mantissa / factor)
+        }
+    }
+
+    /// Convert a decimal to the scaled i64 used on the MONEY wire.
+    ///
+    /// This is the shared pre-encoding step for both RPC parameter encoding and
+    /// TVP column encoding — each path knows how to frame the payload, but they
+    /// agree on how to derive the scaled integer from the decimal.
+    #[cfg(feature = "decimal")]
+    pub fn decimal_to_money_cents_i64(value: rust_decimal::Decimal) -> Result<i64, TypeError> {
+        let cents_i128 = decimal_to_money_cents(value)?;
+        i64::try_from(cents_i128).map_err(|_| TypeError::OutOfRange {
             target_type: "MONEY",
         })
-    } else {
-        let factor = 10_i128.pow(scale - 4);
-        Ok(mantissa / factor)
     }
-}
 
-/// Convert a decimal to the scaled i64 used on the MONEY wire.
-///
-/// This is the shared pre-encoding step for both RPC parameter encoding and
-/// TVP column encoding — each path knows how to frame the payload, but they
-/// agree on how to derive the scaled integer from the decimal.
-#[cfg(feature = "decimal")]
-pub fn decimal_to_money_cents_i64(value: rust_decimal::Decimal) -> Result<i64, TypeError> {
-    let cents_i128 = decimal_to_money_cents(value)?;
-    i64::try_from(cents_i128).map_err(|_| TypeError::OutOfRange {
-        target_type: "MONEY",
-    })
-}
+    /// Convert a decimal to the scaled i32 used on the SMALLMONEY wire.
+    #[cfg(feature = "decimal")]
+    pub fn decimal_to_smallmoney_cents_i32(value: rust_decimal::Decimal) -> Result<i32, TypeError> {
+        let cents_i128 = decimal_to_money_cents(value)?;
+        i32::try_from(cents_i128).map_err(|_| TypeError::OutOfRange {
+            target_type: "SMALLMONEY",
+        })
+    }
 
-/// Convert a decimal to the scaled i32 used on the SMALLMONEY wire.
-#[cfg(feature = "decimal")]
-pub fn decimal_to_smallmoney_cents_i32(value: rust_decimal::Decimal) -> Result<i32, TypeError> {
-    let cents_i128 = decimal_to_money_cents(value)?;
-    i32::try_from(cents_i128).map_err(|_| TypeError::OutOfRange {
-        target_type: "SMALLMONEY",
-    })
-}
+    /// Encode a decimal as MONEY (8 bytes): the signed 64-bit scaled integer is
+    /// written as the high 32 bits LE followed by the low 32 bits LE, per
+    /// MS-TDS §2.2.5.5.1.2.
+    #[cfg(feature = "decimal")]
+    pub fn encode_money(value: rust_decimal::Decimal, buf: &mut BytesMut) -> Result<(), TypeError> {
+        let cents = decimal_to_money_cents_i64(value)?;
+        let high = (cents >> 32) as i32;
+        let low = (cents & 0xFFFF_FFFF) as u32;
+        buf.put_i32_le(high);
+        buf.put_u32_le(low);
+        Ok(())
+    }
 
-/// Encode a decimal as MONEY (8 bytes): the signed 64-bit scaled integer is
-/// written as the high 32 bits LE followed by the low 32 bits LE, per
-/// MS-TDS §2.2.5.5.1.2.
-#[cfg(feature = "decimal")]
-pub fn encode_money(value: rust_decimal::Decimal, buf: &mut BytesMut) -> Result<(), TypeError> {
-    let cents = decimal_to_money_cents_i64(value)?;
-    let high = (cents >> 32) as i32;
-    let low = (cents & 0xFFFF_FFFF) as u32;
-    buf.put_i32_le(high);
-    buf.put_u32_le(low);
-    Ok(())
-}
+    /// Encode a decimal as SMALLMONEY (4 bytes): the signed 32-bit scaled integer
+    /// is written little-endian.
+    #[cfg(feature = "decimal")]
+    pub fn encode_smallmoney(
+        value: rust_decimal::Decimal,
+        buf: &mut BytesMut,
+    ) -> Result<(), TypeError> {
+        let cents = decimal_to_smallmoney_cents_i32(value)?;
+        buf.put_i32_le(cents);
+        Ok(())
+    }
 
-/// Encode a decimal as SMALLMONEY (4 bytes): the signed 32-bit scaled integer
-/// is written little-endian.
-#[cfg(feature = "decimal")]
-pub fn encode_smallmoney(
-    value: rust_decimal::Decimal,
-    buf: &mut BytesMut,
-) -> Result<(), TypeError> {
-    let cents = decimal_to_smallmoney_cents_i32(value)?;
-    buf.put_i32_le(cents);
-    Ok(())
-}
+    /// Convert a NaiveDateTime to the DATETIME wire representation.
+    ///
+    /// Returns `(days_since_1900_i32, ticks_u32)` where each tick is 1/300 second.
+    /// This is the shared pre-encoding step for both RPC parameter encoding and
+    /// TVP column encoding.
+    #[cfg(feature = "chrono")]
+    pub fn datetime_to_legacy_days_ticks(dt: chrono::NaiveDateTime) -> (i32, u32) {
+        use chrono::Timelike;
+        let epoch = chrono::NaiveDate::from_ymd_opt(1900, 1, 1).expect("epoch 1900-01-01 is valid");
+        let days = (dt.date() - epoch).num_days() as i32;
 
-/// Convert a NaiveDateTime to the DATETIME wire representation.
-///
-/// Returns `(days_since_1900_i32, ticks_u32)` where each tick is 1/300 second.
-/// This is the shared pre-encoding step for both RPC parameter encoding and
-/// TVP column encoding.
-#[cfg(feature = "chrono")]
-pub fn datetime_to_legacy_days_ticks(dt: chrono::NaiveDateTime) -> (i32, u32) {
-    use chrono::Timelike;
-    let epoch = chrono::NaiveDate::from_ymd_opt(1900, 1, 1).expect("epoch 1900-01-01 is valid");
-    let days = (dt.date() - epoch).num_days() as i32;
+        let since_midnight = dt.time().num_seconds_from_midnight() as u64 * 1000
+            + u64::from(dt.time().nanosecond()) / 1_000_000;
+        // Convert ms → 1/300s ticks: ticks = round(ms * 300 / 1000) = round(ms * 3 / 10)
+        let ticks = ((since_midnight * 3 + 5) / 10) as u32;
+        (days, ticks)
+    }
 
-    let since_midnight = dt.time().num_seconds_from_midnight() as u64 * 1000
-        + u64::from(dt.time().nanosecond()) / 1_000_000;
-    // Convert ms → 1/300s ticks: ticks = round(ms * 300 / 1000) = round(ms * 3 / 10)
-    let ticks = ((since_midnight * 3 + 5) / 10) as u32;
-    (days, ticks)
-}
+    /// Encode a DATETIME value (8 bytes): days since 1900 (`i32` LE) + time units
+    /// since midnight (`u32` LE) where each unit is 1/300 of a second.
+    #[cfg(feature = "chrono")]
+    pub fn encode_datetime_legacy(dt: chrono::NaiveDateTime, buf: &mut BytesMut) {
+        let (days, ticks) = datetime_to_legacy_days_ticks(dt);
+        buf.put_i32_le(days);
+        buf.put_u32_le(ticks);
+    }
 
-/// Encode a DATETIME value (8 bytes): days since 1900 (`i32` LE) + time units
-/// since midnight (`u32` LE) where each unit is 1/300 of a second.
-#[cfg(feature = "chrono")]
-pub fn encode_datetime_legacy(dt: chrono::NaiveDateTime, buf: &mut BytesMut) {
-    let (days, ticks) = datetime_to_legacy_days_ticks(dt);
-    buf.put_i32_le(days);
-    buf.put_u32_le(ticks);
-}
+    /// Convert a NaiveDateTime to the SMALLDATETIME wire representation.
+    ///
+    /// Returns `(days_since_1900_u16, minutes_since_midnight_u16)`. Seconds are
+    /// rounded to the nearest minute (30s rounds up per SQL Server semantics); when
+    /// that rounding lands on or past 24:00 the carry propagates into the next day
+    /// — e.g. 23:59:45 → next day 00:00 — so the result stays within SQL Server's
+    /// valid minute range of 0..1439. Returns `Err` if the resulting date is
+    /// outside the SMALLDATETIME range (1900-01-01 through 2079-06-06).
+    #[cfg(feature = "chrono")]
+    pub fn datetime_to_smalldatetime_days_minutes(
+        dt: chrono::NaiveDateTime,
+    ) -> Result<(u16, u16), TypeError> {
+        use chrono::Timelike;
+        let epoch = chrono::NaiveDate::from_ymd_opt(1900, 1, 1).expect("epoch 1900-01-01 is valid");
 
-/// Convert a NaiveDateTime to the SMALLDATETIME wire representation.
-///
-/// Returns `(days_since_1900_u16, minutes_since_midnight_u16)`. Seconds are
-/// rounded to the nearest minute (30s rounds up per SQL Server semantics); when
-/// that rounding lands on or past 24:00 the carry propagates into the next day
-/// — e.g. 23:59:45 → next day 00:00 — so the result stays within SQL Server's
-/// valid minute range of 0..1439. Returns `Err` if the resulting date is
-/// outside the SMALLDATETIME range (1900-01-01 through 2079-06-06).
-#[cfg(feature = "chrono")]
-pub fn datetime_to_smalldatetime_days_minutes(
-    dt: chrono::NaiveDateTime,
-) -> Result<(u16, u16), TypeError> {
-    use chrono::Timelike;
-    let epoch = chrono::NaiveDate::from_ymd_opt(1900, 1, 1).expect("epoch 1900-01-01 is valid");
+        let total_seconds = dt.time().hour() * 3600 + dt.time().minute() * 60 + dt.time().second();
+        let minutes_raw = (total_seconds + 30) / 60;
+        // Carry over into the next day when seconds round up past 24:00 so that
+        // the returned minute count stays within SQL Server's valid 0..1439 range.
+        // SQL Server itself does the same thing when casting 23:59:45 to
+        // SMALLDATETIME — sending minutes=1440 directly on the wire is rejected
+        // as "invalid instance of data type smalldatetime".
+        let (day_carry, minutes) = if minutes_raw >= 1440 {
+            (1i64, 0u16)
+        } else {
+            (0i64, minutes_raw as u16)
+        };
 
-    let total_seconds = dt.time().hour() * 3600 + dt.time().minute() * 60 + dt.time().second();
-    let minutes_raw = (total_seconds + 30) / 60;
-    // Carry over into the next day when seconds round up past 24:00 so that
-    // the returned minute count stays within SQL Server's valid 0..1439 range.
-    // SQL Server itself does the same thing when casting 23:59:45 to
-    // SMALLDATETIME — sending minutes=1440 directly on the wire is rejected
-    // as "invalid instance of data type smalldatetime".
-    let (day_carry, minutes) = if minutes_raw >= 1440 {
-        (1i64, 0u16)
-    } else {
-        (0i64, minutes_raw as u16)
-    };
-
-    let days_i64 = (dt.date() - epoch).num_days() + day_carry;
-    let days: u16 = u16::try_from(days_i64).map_err(|_| {
+        let days_i64 = (dt.date() - epoch).num_days() + day_carry;
+        let days: u16 = u16::try_from(days_i64).map_err(|_| {
         TypeError::InvalidDateTime(format!(
             "SMALLDATETIME year must be 1900-2079, got date with {days_i64} days since 1900-01-01"
         ))
     })?;
 
-    Ok((days, minutes))
-}
-
-/// Encode a SMALLDATETIME value (4 bytes): days since 1900 (`u16` LE) +
-/// minutes since midnight (`u16` LE). Seconds are rounded to the nearest
-/// minute (30s rounds up per SQL Server semantics).
-///
-/// # Errors
-///
-/// Returns an error if the date is outside the SMALLDATETIME range
-/// (1900-01-01 through 2079-06-06).
-#[cfg(feature = "chrono")]
-pub fn encode_smalldatetime(
-    dt: chrono::NaiveDateTime,
-    buf: &mut BytesMut,
-) -> Result<(), TypeError> {
-    let (days, minutes) = datetime_to_smalldatetime_days_minutes(dt)?;
-    buf.put_u16_le(days);
-    buf.put_u16_le(minutes);
-    Ok(())
-}
-
-/// Encode a DATE value.
-///
-/// TDS DATE is the number of days since 0001-01-01.
-///
-/// # Errors
-///
-/// Returns an error if the date is outside SQL Server's DATE range
-/// (0001-01-01 through 9999-12-31). chrono permits dates beyond both ends,
-/// which previously wrapped silently into garbage wire values.
-#[cfg(feature = "chrono")]
-pub fn encode_date(date: chrono::NaiveDate, buf: &mut BytesMut) -> Result<(), TypeError> {
-    /// Days from 0001-01-01 to 9999-12-31, the last representable DATE.
-    const MAX_DAYS: i64 = 3_652_058;
-
-    let base = chrono::NaiveDate::from_ymd_opt(1, 1, 1).expect("valid date");
-    let days = date.signed_duration_since(base).num_days();
-    if !(0..=MAX_DAYS).contains(&days) {
-        return Err(TypeError::InvalidDateTime(format!(
-            "DATE must be between 0001-01-01 and 9999-12-31, got {date}"
-        )));
+        Ok((days, minutes))
     }
-    let days = days as u32;
 
-    // DATE is encoded as 3 bytes (little-endian)
-    buf.put_u8((days & 0xFF) as u8);
-    buf.put_u8(((days >> 8) & 0xFF) as u8);
-    buf.put_u8(((days >> 16) & 0xFF) as u8);
-    Ok(())
+    /// Encode a SMALLDATETIME value (4 bytes): days since 1900 (`u16` LE) +
+    /// minutes since midnight (`u16` LE). Seconds are rounded to the nearest
+    /// minute (30s rounds up per SQL Server semantics).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the date is outside the SMALLDATETIME range
+    /// (1900-01-01 through 2079-06-06).
+    #[cfg(feature = "chrono")]
+    pub fn encode_smalldatetime(
+        dt: chrono::NaiveDateTime,
+        buf: &mut BytesMut,
+    ) -> Result<(), TypeError> {
+        let (days, minutes) = datetime_to_smalldatetime_days_minutes(dt)?;
+        buf.put_u16_le(days);
+        buf.put_u16_le(minutes);
+        Ok(())
+    }
+
+    /// Encode a DATE value.
+    ///
+    /// TDS DATE is the number of days since 0001-01-01.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the date is outside SQL Server's DATE range
+    /// (0001-01-01 through 9999-12-31). chrono permits dates beyond both ends,
+    /// which previously wrapped silently into garbage wire values.
+    #[cfg(feature = "chrono")]
+    pub fn encode_date(date: chrono::NaiveDate, buf: &mut BytesMut) -> Result<(), TypeError> {
+        /// Days from 0001-01-01 to 9999-12-31, the last representable DATE.
+        const MAX_DAYS: i64 = 3_652_058;
+
+        let base = chrono::NaiveDate::from_ymd_opt(1, 1, 1).expect("valid date");
+        let days = date.signed_duration_since(base).num_days();
+        if !(0..=MAX_DAYS).contains(&days) {
+            return Err(TypeError::InvalidDateTime(format!(
+                "DATE must be between 0001-01-01 and 9999-12-31, got {date}"
+            )));
+        }
+        let days = days as u32;
+
+        // DATE is encoded as 3 bytes (little-endian)
+        buf.put_u8((days & 0xFF) as u8);
+        buf.put_u8(((days >> 8) & 0xFF) as u8);
+        buf.put_u8(((days >> 16) & 0xFF) as u8);
+        Ok(())
+    }
+
+    /// Encode a TIME value.
+    ///
+    /// TDS TIME is encoded as 100-nanosecond intervals since midnight.
+    #[cfg(feature = "chrono")]
+    pub fn encode_time(time: chrono::NaiveTime, buf: &mut BytesMut) {
+        use chrono::Timelike;
+
+        // Calculate 100-ns intervals since midnight
+        // Scale = 7 (100-nanosecond precision)
+        let nanos =
+            time.num_seconds_from_midnight() as u64 * 1_000_000_000 + time.nanosecond() as u64;
+        let intervals = nanos / 100;
+
+        // TIME with scale 7 uses 5 bytes
+        buf.put_u8((intervals & 0xFF) as u8);
+        buf.put_u8(((intervals >> 8) & 0xFF) as u8);
+        buf.put_u8(((intervals >> 16) & 0xFF) as u8);
+        buf.put_u8(((intervals >> 24) & 0xFF) as u8);
+        buf.put_u8(((intervals >> 32) & 0xFF) as u8);
+    }
+
+    /// Encode a DATETIME2 value.
+    ///
+    /// DATETIME2 is encoded as TIME followed by DATE.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the date portion is outside the DATE range; see
+    /// [`encode_date`].
+    #[cfg(feature = "chrono")]
+    pub fn encode_datetime2(
+        datetime: chrono::NaiveDateTime,
+        buf: &mut BytesMut,
+    ) -> Result<(), TypeError> {
+        encode_time(datetime.time(), buf);
+        encode_date(datetime.date(), buf)
+    }
+
+    /// Encode a DATETIMEOFFSET value.
+    ///
+    /// DATETIMEOFFSET is encoded as TIME + DATE + offset (in minutes). Per
+    /// MS-TDS §2.2.5.5.1.9 the date/time portion is the **UTC** instant, not the
+    /// local wall-clock; the offset is carried separately.
+    #[cfg(feature = "chrono")]
+    pub fn encode_datetimeoffset(
+        datetime: chrono::DateTime<chrono::FixedOffset>,
+        buf: &mut BytesMut,
+    ) -> Result<(), TypeError> {
+        use chrono::Offset;
+
+        // Encode the UTC date/time components
+        let utc = datetime.naive_utc();
+        encode_time(utc.time(), buf);
+        encode_date(utc.date(), buf)?;
+
+        // Encode timezone offset in minutes (signed 16-bit)
+        let offset_seconds = datetime.offset().fix().local_minus_utc();
+        let offset_minutes = (offset_seconds / 60) as i16;
+        buf.put_i16_le(offset_minutes);
+        Ok(())
+    }
 }
 
-/// Encode a TIME value.
-///
-/// TDS TIME is encoded as 100-nanosecond intervals since midnight.
-#[cfg(feature = "chrono")]
-pub fn encode_time(time: chrono::NaiveTime, buf: &mut BytesMut) {
-    use chrono::Timelike;
-
-    // Calculate 100-ns intervals since midnight
-    // Scale = 7 (100-nanosecond precision)
-    let nanos = time.num_seconds_from_midnight() as u64 * 1_000_000_000 + time.nanosecond() as u64;
-    let intervals = nanos / 100;
-
-    // TIME with scale 7 uses 5 bytes
-    buf.put_u8((intervals & 0xFF) as u8);
-    buf.put_u8(((intervals >> 8) & 0xFF) as u8);
-    buf.put_u8(((intervals >> 16) & 0xFF) as u8);
-    buf.put_u8(((intervals >> 24) & 0xFF) as u8);
-    buf.put_u8(((intervals >> 32) & 0xFF) as u8);
-}
-
-/// Encode a DATETIME2 value.
-///
-/// DATETIME2 is encoded as TIME followed by DATE.
-///
-/// # Errors
-///
-/// Returns an error if the date portion is outside the DATE range; see
-/// [`encode_date`].
-#[cfg(feature = "chrono")]
-pub fn encode_datetime2(
-    datetime: chrono::NaiveDateTime,
-    buf: &mut BytesMut,
-) -> Result<(), TypeError> {
-    encode_time(datetime.time(), buf);
-    encode_date(datetime.date(), buf)
-}
-
-/// Encode a DATETIMEOFFSET value.
-///
-/// DATETIMEOFFSET is encoded as TIME + DATE + offset (in minutes). Per
-/// MS-TDS §2.2.5.5.1.9 the date/time portion is the **UTC** instant, not the
-/// local wall-clock; the offset is carried separately.
-#[cfg(feature = "chrono")]
-pub fn encode_datetimeoffset(
-    datetime: chrono::DateTime<chrono::FixedOffset>,
-    buf: &mut BytesMut,
-) -> Result<(), TypeError> {
-    use chrono::Offset;
-
-    // Encode the UTC date/time components
-    let utc = datetime.naive_utc();
-    encode_time(utc.time(), buf);
-    encode_date(utc.date(), buf)?;
-
-    // Encode timezone offset in minutes (signed 16-bit)
-    let offset_seconds = datetime.offset().fix().local_minus_utc();
-    let offset_minutes = (offset_seconds / 60) as i16;
-    buf.put_i16_le(offset_minutes);
-    Ok(())
-}
+// Re-export the sealed encoders into the module scope so intra-crate callers
+// (the `TdsEncode` impl above, sibling modules) keep using `crate::encode::*`.
+// Empty under `--no-default-features` (all encoders are feature-gated).
+#[allow(unused_imports)]
+pub(crate) use sealed::*;
 
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]

--- a/crates/mssql-types/src/lib.rs
+++ b/crates/mssql-types/src/lib.rs
@@ -42,7 +42,7 @@ pub mod to_sql;
 pub mod tvp;
 pub mod value;
 
-pub use decode::{Collation, TdsDecode, TypeInfo, decode_utf16_string, decode_value};
+pub use decode::{Collation, TdsDecode, TypeInfo, decode_utf16_string};
 pub use encode::{TdsEncode, encode_utf16_string};
 pub use error::TypeError;
 pub use from_sql::FromSql;
@@ -56,6 +56,20 @@ pub use to_sql::{
 #[cfg(feature = "decimal")]
 pub use to_sql::{Numeric, numeric};
 pub use tvp::{TvpColumnDef, TvpColumnType, TvpData, TvpError};
+
+/// Internal wire-codec helpers shared across the workspace crates.
+///
+/// **Not public API.** These are low-level TDS encoders/decoders consumed
+/// cross-crate by the rest of the driver; they are exempt from this crate's
+/// semver guarantees and must not be used from outside the workspace. See #242.
+#[doc(hidden)]
+#[allow(unused_imports)] // `encode::sealed` is empty under --no-default-features
+pub mod __private {
+    // Glob re-exports so the set tracks the `#[cfg(feature = ...)]` gating on the
+    // underlying encoders (uuid / decimal / chrono) without duplicating it here.
+    pub use crate::decode::sealed::*;
+    pub use crate::encode::sealed::*;
+}
 #[cfg(feature = "chrono")]
 pub use value::SmallDateTime;
 pub use value::SqlValue;

--- a/crates/tds-protocol/benches/protocol.rs
+++ b/crates/tds-protocol/benches/protocol.rs
@@ -5,8 +5,8 @@
 use bytes::{Bytes, BytesMut};
 use criterion::{Criterion, Throughput, criterion_group, criterion_main};
 use std::hint::black_box;
+use tds_protocol::__private::encode_sql_batch;
 use tds_protocol::{
-    encode_sql_batch,
     packet::{PACKET_HEADER_SIZE, PacketHeader, PacketStatus, PacketType},
     prelogin::{EncryptionLevel, PreLogin},
 };

--- a/crates/tds-protocol/src/collation.rs
+++ b/crates/tds-protocol/src/collation.rs
@@ -405,40 +405,52 @@ fn encode_lossy_question_mark(value: &str, encoding: &'static encoding_rs::Encod
     out
 }
 
-/// Transcode a Rust `&str` into single-byte VARCHAR bytes for the given collation.
+/// Low-level collation-aware string encoder shared across the workspace crates.
 ///
-/// - UTF-8 collations (SQL Server 2019+) pass through as raw UTF-8 bytes.
-/// - Known non-UTF-8 LCIDs transcode via the matching `encoding_rs` codec.
-/// - Unknown or `None` collations fall back to Windows-1252 (Latin1_General_CI_AS).
-///
-/// Characters not representable in the target codepage are replaced with `?`,
-/// matching SQL Server's own conversion behavior and the other first-party
-/// drivers. (Regardless of whether the `encoding` feature is enabled.)
-pub fn encode_str_for_collation(
-    value: &str,
-    collation: Option<&crate::token::Collation>,
-) -> Vec<u8> {
-    #[cfg(feature = "encoding")]
-    {
-        if let Some(c) = collation {
-            if c.is_utf8() {
-                return value.as_bytes().to_vec();
+/// Internal plumbing reached cross-crate only via [`crate::__private`]; not
+/// public API and exempt from semver guarantees (see #242).
+pub(crate) mod sealed {
+    use super::*;
+
+    /// Transcode a Rust `&str` into single-byte VARCHAR bytes for the given collation.
+    ///
+    /// - UTF-8 collations (SQL Server 2019+) pass through as raw UTF-8 bytes.
+    /// - Known non-UTF-8 LCIDs transcode via the matching `encoding_rs` codec.
+    /// - Unknown or `None` collations fall back to Windows-1252 (Latin1_General_CI_AS).
+    ///
+    /// Characters not representable in the target codepage are replaced with `?`,
+    /// matching SQL Server's own conversion behavior and the other first-party
+    /// drivers. (Regardless of whether the `encoding` feature is enabled.)
+    pub fn encode_str_for_collation(
+        value: &str,
+        collation: Option<&crate::token::Collation>,
+    ) -> Vec<u8> {
+        #[cfg(feature = "encoding")]
+        {
+            if let Some(c) = collation {
+                if c.is_utf8() {
+                    return value.as_bytes().to_vec();
+                }
+                if let Some(encoding) = c.encoding() {
+                    return encode_lossy_question_mark(value, encoding);
+                }
             }
-            if let Some(encoding) = c.encoding() {
-                return encode_lossy_question_mark(value, encoding);
-            }
+            encode_lossy_question_mark(value, encoding_rs::WINDOWS_1252)
         }
-        encode_lossy_question_mark(value, encoding_rs::WINDOWS_1252)
-    }
-    #[cfg(not(feature = "encoding"))]
-    {
-        let _ = collation;
-        value
-            .chars()
-            .map(|ch| if (ch as u32) <= 0xFF { ch as u8 } else { b'?' })
-            .collect()
+        #[cfg(not(feature = "encoding"))]
+        {
+            let _ = collation;
+            value
+                .chars()
+                .map(|ch| if (ch as u32) <= 0xFF { ch as u8 } else { b'?' })
+                .collect()
+        }
     }
 }
+
+// Keep the crate-private path `crate::collation::encode_str_for_collation`
+// working for intra-crate callers (rpc, tvp); off the public surface.
+pub(crate) use sealed::encode_str_for_collation;
 
 #[cfg(all(test, feature = "encoding"))]
 #[allow(clippy::unwrap_used)]

--- a/crates/tds-protocol/src/lib.rs
+++ b/crates/tds-protocol/src/lib.rs
@@ -120,7 +120,7 @@ pub use packet::{
 };
 pub use prelogin::{EncryptionLevel, PreLogin, PreLoginOption};
 pub use rpc::{ParamFlags, ProcId, RpcOptionFlags, RpcParam, RpcRequest, TypeInfo as RpcTypeInfo};
-pub use sql_batch::{SqlBatch, encode_sql_batch, encode_sql_batch_with_transaction};
+pub use sql_batch::SqlBatch;
 pub use token::{
     ColMetaData, Collation, ColumnData, Done, DoneInProc, DoneProc, DoneStatus, EnvChange,
     EnvChangeType, EnvChangeValue, FeatureExtAck, FedAuthInfo, LoginAck, NbcRow, Order, RawRow,
@@ -129,13 +129,24 @@ pub use token::{
 };
 pub use tvp::{
     TVP_END_TOKEN, TVP_ROW_TOKEN, TVP_TYPE_ID, TvpColumnDef as TvpWireColumnDef, TvpColumnFlags,
-    TvpEncoder, TvpWireType, encode_tvp_bit, encode_tvp_date, encode_tvp_datetime2,
-    encode_tvp_datetimeoffset, encode_tvp_decimal, encode_tvp_float, encode_tvp_guid,
-    encode_tvp_int, encode_tvp_null, encode_tvp_nvarchar, encode_tvp_time, encode_tvp_varbinary,
-    encode_tvp_varchar, encode_tvp_varchar_with_collation,
+    TvpEncoder, TvpWireType,
 };
 pub use types::{ColumnFlags, TypeId, Updateable};
 pub use version::{SqlServerVersion, TdsVersion};
+
+/// Internal wire-codec helpers shared across the workspace crates.
+///
+/// **Not public API.** These are low-level TDS encoders consumed cross-crate by
+/// the rest of the driver; they are exempt from this crate's semver guarantees
+/// and must not be used from outside the workspace. See #242.
+#[doc(hidden)]
+pub mod __private {
+    // Glob re-exports so the set tracks any `#[cfg(feature = ...)]` gating on the
+    // underlying encoders without duplicating it here.
+    pub use crate::collation::sealed::*;
+    pub use crate::sql_batch::sealed::*;
+    pub use crate::tvp::sealed::*;
+}
 
 // Always Encrypted metadata types
 pub use crypto::{

--- a/crates/tds-protocol/src/sql_batch.rs
+++ b/crates/tds-protocol/src/sql_batch.rs
@@ -10,81 +10,94 @@ use bytes::{BufMut, Bytes, BytesMut};
 use crate::codec::write_utf16_string;
 use crate::prelude::*;
 
-/// Encode a SQL batch request with auto-commit (no explicit transaction).
+/// Low-level `SQLBatch` wire encoders shared across the workspace crates.
 ///
-/// The SQL batch packet payload includes:
-/// 1. ALL_HEADERS section (required for TDS 7.2+)
-/// 2. SQL text encoded as UTF-16LE
-///
-/// This function returns the encoded payload (without the packet header).
-/// For requests within an explicit transaction, use [`encode_sql_batch_with_transaction`].
-///
-/// # Example
-///
-/// ```
-/// use tds_protocol::sql_batch::encode_sql_batch;
-///
-/// let sql = "SELECT * FROM users WHERE id = 1";
-/// let payload = encode_sql_batch(sql);
-///
-/// // Payload includes ALL_HEADERS + UTF-16LE encoded SQL
-/// assert!(!payload.is_empty());
-/// ```
-#[must_use]
-pub fn encode_sql_batch(sql: &str) -> Bytes {
-    encode_sql_batch_with_transaction(sql, 0)
+/// Internal plumbing reached cross-crate only via [`crate::__private`]; not
+/// public API and exempt from semver guarantees (see #242). The public
+/// [`SqlBatch`] builder below is the user-facing API.
+pub(crate) mod sealed {
+    use super::*;
+
+    /// Encode a SQL batch request with auto-commit (no explicit transaction).
+    ///
+    /// The SQL batch packet payload includes:
+    /// 1. ALL_HEADERS section (required for TDS 7.2+)
+    /// 2. SQL text encoded as UTF-16LE
+    ///
+    /// This function returns the encoded payload (without the packet header).
+    /// For requests within an explicit transaction, use [`encode_sql_batch_with_transaction`].
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use tds_protocol::sql_batch::encode_sql_batch;
+    ///
+    /// let sql = "SELECT * FROM users WHERE id = 1";
+    /// let payload = encode_sql_batch(sql);
+    ///
+    /// // Payload includes ALL_HEADERS + UTF-16LE encoded SQL
+    /// assert!(!payload.is_empty());
+    /// ```
+    #[must_use]
+    pub fn encode_sql_batch(sql: &str) -> Bytes {
+        encode_sql_batch_with_transaction(sql, 0)
+    }
+
+    /// Encode a SQL batch request with a transaction descriptor.
+    ///
+    /// Per MS-TDS spec, when executing within an explicit transaction:
+    /// - The `transaction_descriptor` MUST be the value returned by the server
+    ///   in the BeginTransaction EnvChange token.
+    /// - For auto-commit mode (no explicit transaction), use 0.
+    ///
+    /// # Arguments
+    ///
+    /// * `sql` - The SQL text to execute
+    /// * `transaction_descriptor` - The transaction descriptor from BeginTransaction EnvChange,
+    ///   or 0 for auto-commit mode.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use tds_protocol::sql_batch::encode_sql_batch_with_transaction;
+    ///
+    /// // Within a transaction with descriptor 0x1234567890ABCDEF
+    /// let sql = "INSERT INTO users VALUES (1, 'Alice')";
+    /// let tx_descriptor = 0x1234567890ABCDEF_u64;
+    /// let payload = encode_sql_batch_with_transaction(sql, tx_descriptor);
+    /// ```
+    #[must_use]
+    pub fn encode_sql_batch_with_transaction(sql: &str, transaction_descriptor: u64) -> Bytes {
+        // Capacity: ALL_HEADERS (22 bytes) + SQL UTF-16LE (sql.len() * 2)
+        let mut buf = BytesMut::with_capacity(22 + sql.len() * 2);
+
+        // ALL_HEADERS section (required for TDS 7.2+)
+        // Per MS-TDS spec: ALL_HEADERS = TotalLength + Headers
+        let all_headers_start = buf.len();
+        buf.put_u32_le(0); // Total length placeholder
+
+        // Transaction descriptor header (type 0x0002)
+        // Per MS-TDS 2.2.5.3: HeaderLength (4) + HeaderType (2) + TransactionDescriptor (8) + OutstandingRequestCount (4)
+        buf.put_u32_le(18); // Header length = 18 bytes
+        buf.put_u16_le(0x0002); // Header type: transaction descriptor
+        buf.put_u64_le(transaction_descriptor); // Transaction descriptor from BeginTransaction EnvChange
+        buf.put_u32_le(1); // Outstanding request count (1 for non-MARS connections)
+
+        // Fill in ALL_HEADERS total length
+        let all_headers_len = buf.len() - all_headers_start;
+        let len_bytes = (all_headers_len as u32).to_le_bytes();
+        buf[all_headers_start..all_headers_start + 4].copy_from_slice(&len_bytes);
+
+        // SQL text as UTF-16LE
+        write_utf16_string(&mut buf, sql);
+
+        buf.freeze()
+    }
 }
 
-/// Encode a SQL batch request with a transaction descriptor.
-///
-/// Per MS-TDS spec, when executing within an explicit transaction:
-/// - The `transaction_descriptor` MUST be the value returned by the server
-///   in the BeginTransaction EnvChange token.
-/// - For auto-commit mode (no explicit transaction), use 0.
-///
-/// # Arguments
-///
-/// * `sql` - The SQL text to execute
-/// * `transaction_descriptor` - The transaction descriptor from BeginTransaction EnvChange,
-///   or 0 for auto-commit mode.
-///
-/// # Example
-///
-/// ```
-/// use tds_protocol::sql_batch::encode_sql_batch_with_transaction;
-///
-/// // Within a transaction with descriptor 0x1234567890ABCDEF
-/// let sql = "INSERT INTO users VALUES (1, 'Alice')";
-/// let tx_descriptor = 0x1234567890ABCDEF_u64;
-/// let payload = encode_sql_batch_with_transaction(sql, tx_descriptor);
-/// ```
-#[must_use]
-pub fn encode_sql_batch_with_transaction(sql: &str, transaction_descriptor: u64) -> Bytes {
-    // Capacity: ALL_HEADERS (22 bytes) + SQL UTF-16LE (sql.len() * 2)
-    let mut buf = BytesMut::with_capacity(22 + sql.len() * 2);
-
-    // ALL_HEADERS section (required for TDS 7.2+)
-    // Per MS-TDS spec: ALL_HEADERS = TotalLength + Headers
-    let all_headers_start = buf.len();
-    buf.put_u32_le(0); // Total length placeholder
-
-    // Transaction descriptor header (type 0x0002)
-    // Per MS-TDS 2.2.5.3: HeaderLength (4) + HeaderType (2) + TransactionDescriptor (8) + OutstandingRequestCount (4)
-    buf.put_u32_le(18); // Header length = 18 bytes
-    buf.put_u16_le(0x0002); // Header type: transaction descriptor
-    buf.put_u64_le(transaction_descriptor); // Transaction descriptor from BeginTransaction EnvChange
-    buf.put_u32_le(1); // Outstanding request count (1 for non-MARS connections)
-
-    // Fill in ALL_HEADERS total length
-    let all_headers_len = buf.len() - all_headers_start;
-    let len_bytes = (all_headers_len as u32).to_le_bytes();
-    buf[all_headers_start..all_headers_start + 4].copy_from_slice(&len_bytes);
-
-    // SQL text as UTF-16LE
-    write_utf16_string(&mut buf, sql);
-
-    buf.freeze()
-}
+// Keep `encode_sql_batch` reachable for the intra-crate `SqlBatch::encode`
+// caller below; off the public surface (see crate::__private).
+pub(crate) use sealed::encode_sql_batch;
 
 /// SQL batch builder for more complex batches.
 ///

--- a/crates/tds-protocol/src/sql_batch.rs
+++ b/crates/tds-protocol/src/sql_batch.rs
@@ -30,7 +30,7 @@ pub(crate) mod sealed {
     /// # Example
     ///
     /// ```
-    /// use tds_protocol::sql_batch::encode_sql_batch;
+    /// use tds_protocol::__private::encode_sql_batch;
     ///
     /// let sql = "SELECT * FROM users WHERE id = 1";
     /// let payload = encode_sql_batch(sql);
@@ -59,7 +59,7 @@ pub(crate) mod sealed {
     /// # Example
     ///
     /// ```
-    /// use tds_protocol::sql_batch::encode_sql_batch_with_transaction;
+    /// use tds_protocol::__private::encode_sql_batch_with_transaction;
     ///
     /// // Within a transaction with descriptor 0x1234567890ABCDEF
     /// let sql = "INSERT INTO users VALUES (1, 'Alice')";

--- a/crates/tds-protocol/src/tvp.rs
+++ b/crates/tds-protocol/src/tvp.rs
@@ -159,7 +159,7 @@ impl TvpWireType {
     ///
     /// The collation declared here tells the server which codepage VARCHAR
     /// cell bytes are in. It must match the encoding used for the cell data
-    /// (see [`encode_tvp_varchar_with_collation`]). `None` falls back to
+    /// (see `encode_tvp_varchar_with_collation`). `None` falls back to
     /// [`DEFAULT_COLLATION`] (Latin1_General_CI_AS / Windows-1252).
     pub fn encode_type_info_with_collation(
         &self,
@@ -419,324 +419,336 @@ impl<'a> TvpEncoder<'a> {
     }
 }
 
-/// Encode a NULL value for a TVP column.
+/// Low-level per-type TVP value encoders shared across the workspace crates.
 ///
-/// Different types use different NULL indicators.
-pub fn encode_tvp_null(wire_type: &TvpWireType, buf: &mut BytesMut) {
-    match wire_type {
-        TvpWireType::NVarChar { max_length } | TvpWireType::VarChar { max_length } => {
-            if *max_length == 0xFFFF {
-                // MAX type uses PLP NULL
+/// Internal plumbing reached cross-crate only via [`crate::__private`]; not
+/// public API and exempt from semver guarantees (see #242). The public
+/// [`TvpEncoder`]/[`TvpColumnDef`] types above are the user-facing API.
+pub(crate) mod sealed {
+    use super::*;
+
+    /// Encode a NULL value for a TVP column.
+    ///
+    /// Different types use different NULL indicators.
+    pub fn encode_tvp_null(wire_type: &TvpWireType, buf: &mut BytesMut) {
+        match wire_type {
+            TvpWireType::NVarChar { max_length } | TvpWireType::VarChar { max_length } => {
+                if *max_length == 0xFFFF {
+                    // MAX type uses PLP NULL
+                    buf.put_u64_le(0xFFFFFFFFFFFFFFFF);
+                } else {
+                    // Regular type uses 0xFFFF
+                    buf.put_u16_le(0xFFFF);
+                }
+            }
+            TvpWireType::VarBinary { max_length } => {
+                if *max_length == 0xFFFF {
+                    buf.put_u64_le(0xFFFFFFFFFFFFFFFF);
+                } else {
+                    buf.put_u16_le(0xFFFF);
+                }
+            }
+            TvpWireType::Xml => {
+                // XML uses PLP NULL
                 buf.put_u64_le(0xFFFFFFFFFFFFFFFF);
-            } else {
-                // Regular type uses 0xFFFF
-                buf.put_u16_le(0xFFFF);
+            }
+            _ => {
+                // Most types use 0 length
+                buf.put_u8(0);
             }
         }
-        TvpWireType::VarBinary { max_length } => {
-            if *max_length == 0xFFFF {
-                buf.put_u64_le(0xFFFFFFFFFFFFFFFF);
-            } else {
-                buf.put_u16_le(0xFFFF);
+    }
+
+    /// Encode a BIT value for TVP.
+    pub fn encode_tvp_bit(value: bool, buf: &mut BytesMut) {
+        buf.put_u8(1); // Length
+        buf.put_u8(if value { 1 } else { 0 });
+    }
+
+    /// Encode an integer value for TVP.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `size` is not 1, 2, 4, or 8. Callers must use sizes derived
+    /// from `TvpWireType::Int { size }` which are always valid.
+    pub fn encode_tvp_int(value: i64, size: u8, buf: &mut BytesMut) {
+        buf.put_u8(size); // Length
+        match size {
+            1 => buf.put_i8(value as i8),
+            2 => buf.put_i16_le(value as i16),
+            4 => buf.put_i32_le(value as i32),
+            8 => buf.put_i64_le(value),
+            _ => unreachable!(
+                "encode_tvp_int called with invalid size {size}; expected 1, 2, 4, or 8"
+            ),
+        }
+    }
+
+    /// Encode a float value for TVP.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `size` is not 4 or 8. Callers must use sizes derived
+    /// from `TvpWireType::Float { size }` which are always valid.
+    pub fn encode_tvp_float(value: f64, size: u8, buf: &mut BytesMut) {
+        buf.put_u8(size); // Length
+        match size {
+            4 => buf.put_f32_le(value as f32),
+            8 => buf.put_f64_le(value),
+            _ => unreachable!("encode_tvp_float called with invalid size {size}; expected 4 or 8"),
+        }
+    }
+
+    /// Encode a NVARCHAR value for TVP.
+    pub fn encode_tvp_nvarchar(value: &str, max_length: u16, buf: &mut BytesMut) {
+        let utf16: Vec<u16> = value.encode_utf16().collect();
+        let byte_len = utf16.len() * 2;
+
+        if max_length == 0xFFFF {
+            // MAX type - use PLP format
+            buf.put_u64_le(byte_len as u64); // Total length
+            buf.put_u32_le(byte_len as u32); // Chunk length
+            for code_unit in utf16 {
+                buf.put_u16_le(code_unit);
+            }
+            buf.put_u32_le(0); // Terminator
+        } else {
+            // Regular type
+            buf.put_u16_le(byte_len as u16);
+            for code_unit in utf16 {
+                buf.put_u16_le(code_unit);
             }
         }
-        TvpWireType::Xml => {
-            // XML uses PLP NULL
-            buf.put_u64_le(0xFFFFFFFFFFFFFFFF);
-        }
-        _ => {
-            // Most types use 0 length
-            buf.put_u8(0);
-        }
     }
-}
 
-/// Encode a BIT value for TVP.
-pub fn encode_tvp_bit(value: bool, buf: &mut BytesMut) {
-    buf.put_u8(1); // Length
-    buf.put_u8(if value { 1 } else { 0 });
-}
-
-/// Encode an integer value for TVP.
-///
-/// # Panics
-///
-/// Panics if `size` is not 1, 2, 4, or 8. Callers must use sizes derived
-/// from `TvpWireType::Int { size }` which are always valid.
-pub fn encode_tvp_int(value: i64, size: u8, buf: &mut BytesMut) {
-    buf.put_u8(size); // Length
-    match size {
-        1 => buf.put_i8(value as i8),
-        2 => buf.put_i16_le(value as i16),
-        4 => buf.put_i32_le(value as i32),
-        8 => buf.put_i64_le(value),
-        _ => unreachable!("encode_tvp_int called with invalid size {size}; expected 1, 2, 4, or 8"),
+    /// Encode a VARCHAR value for TVP using single-byte codepage encoding.
+    ///
+    /// SQL Server stores VARCHAR data as single-byte characters using the column collation
+    /// code page. Passing UTF-16 bytes (as NVARCHAR) into a VARCHAR column corrupts every
+    /// character: "abc" would be stored as "a\0b\0c\0".
+    ///
+    /// Encodes using Windows-1252 (Latin1_General_CI_AS), matching [`DEFAULT_COLLATION`]
+    /// declared in TVP column metadata. Use
+    /// [`encode_tvp_varchar_with_collation`] to encode for the server's actual
+    /// collation.
+    pub fn encode_tvp_varchar(value: &str, max_length: u16, buf: &mut BytesMut) {
+        encode_tvp_varchar_with_collation(value, max_length, None, buf);
     }
-}
 
-/// Encode a float value for TVP.
-///
-/// # Panics
-///
-/// Panics if `size` is not 4 or 8. Callers must use sizes derived
-/// from `TvpWireType::Float { size }` which are always valid.
-pub fn encode_tvp_float(value: f64, size: u8, buf: &mut BytesMut) {
-    buf.put_u8(size); // Length
-    match size {
-        4 => buf.put_f32_le(value as f32),
-        8 => buf.put_f64_le(value),
-        _ => unreachable!("encode_tvp_float called with invalid size {size}; expected 4 or 8"),
-    }
-}
+    /// Encode a VARCHAR value for TVP using the codepage of `collation`.
+    ///
+    /// The collation must match the one declared in the TVP column metadata
+    /// (see [`TvpWireType::encode_type_info_with_collation`]) so the server
+    /// interprets the cell bytes in the codepage they were encoded with.
+    /// Characters not representable in the codepage are replaced with `?`.
+    pub fn encode_tvp_varchar_with_collation(
+        value: &str,
+        max_length: u16,
+        collation: Option<&crate::token::Collation>,
+        buf: &mut BytesMut,
+    ) {
+        let encoded = crate::collation::encode_str_for_collation(value, collation);
+        let byte_len = encoded.len();
 
-/// Encode a NVARCHAR value for TVP.
-pub fn encode_tvp_nvarchar(value: &str, max_length: u16, buf: &mut BytesMut) {
-    let utf16: Vec<u16> = value.encode_utf16().collect();
-    let byte_len = utf16.len() * 2;
-
-    if max_length == 0xFFFF {
-        // MAX type - use PLP format
-        buf.put_u64_le(byte_len as u64); // Total length
-        buf.put_u32_le(byte_len as u32); // Chunk length
-        for code_unit in utf16 {
-            buf.put_u16_le(code_unit);
-        }
-        buf.put_u32_le(0); // Terminator
-    } else {
-        // Regular type
-        buf.put_u16_le(byte_len as u16);
-        for code_unit in utf16 {
-            buf.put_u16_le(code_unit);
+        if max_length == 0xFFFF {
+            // MAX type - use PLP format
+            buf.put_u64_le(byte_len as u64); // Total length
+            buf.put_u32_le(byte_len as u32); // Chunk length
+            buf.put_slice(&encoded);
+            buf.put_u32_le(0); // Terminator
+        } else {
+            // Regular type
+            buf.put_u16_le(byte_len as u16);
+            buf.put_slice(&encoded);
         }
     }
-}
 
-/// Encode a VARCHAR value for TVP using single-byte codepage encoding.
-///
-/// SQL Server stores VARCHAR data as single-byte characters using the column collation
-/// code page. Passing UTF-16 bytes (as NVARCHAR) into a VARCHAR column corrupts every
-/// character: "abc" would be stored as "a\0b\0c\0".
-///
-/// Encodes using Windows-1252 (Latin1_General_CI_AS), matching [`DEFAULT_COLLATION`]
-/// declared in TVP column metadata. Use
-/// [`encode_tvp_varchar_with_collation`] to encode for the server's actual
-/// collation.
-pub fn encode_tvp_varchar(value: &str, max_length: u16, buf: &mut BytesMut) {
-    encode_tvp_varchar_with_collation(value, max_length, None, buf);
-}
-
-/// Encode a VARCHAR value for TVP using the codepage of `collation`.
-///
-/// The collation must match the one declared in the TVP column metadata
-/// (see [`TvpWireType::encode_type_info_with_collation`]) so the server
-/// interprets the cell bytes in the codepage they were encoded with.
-/// Characters not representable in the codepage are replaced with `?`.
-pub fn encode_tvp_varchar_with_collation(
-    value: &str,
-    max_length: u16,
-    collation: Option<&crate::token::Collation>,
-    buf: &mut BytesMut,
-) {
-    let encoded = crate::collation::encode_str_for_collation(value, collation);
-    let byte_len = encoded.len();
-
-    if max_length == 0xFFFF {
-        // MAX type - use PLP format
-        buf.put_u64_le(byte_len as u64); // Total length
-        buf.put_u32_le(byte_len as u32); // Chunk length
-        buf.put_slice(&encoded);
-        buf.put_u32_le(0); // Terminator
-    } else {
-        // Regular type
-        buf.put_u16_le(byte_len as u16);
-        buf.put_slice(&encoded);
-    }
-}
-
-/// Encode a VARBINARY value for TVP.
-pub fn encode_tvp_varbinary(value: &[u8], max_length: u16, buf: &mut BytesMut) {
-    if max_length == 0xFFFF {
-        // MAX type - use PLP format
-        buf.put_u64_le(value.len() as u64);
-        buf.put_u32_le(value.len() as u32);
-        buf.put_slice(value);
-        buf.put_u32_le(0); // Terminator
-    } else {
-        buf.put_u16_le(value.len() as u16);
-        buf.put_slice(value);
-    }
-}
-
-/// Encode a UNIQUEIDENTIFIER value for TVP.
-///
-/// SQL Server uses mixed-endian format for UUIDs.
-pub fn encode_tvp_guid(uuid_bytes: &[u8; 16], buf: &mut BytesMut) {
-    buf.put_u8(16); // Length
-
-    // Mixed-endian: first 3 groups little-endian, last 2 groups big-endian
-    buf.put_u8(uuid_bytes[3]);
-    buf.put_u8(uuid_bytes[2]);
-    buf.put_u8(uuid_bytes[1]);
-    buf.put_u8(uuid_bytes[0]);
-
-    buf.put_u8(uuid_bytes[5]);
-    buf.put_u8(uuid_bytes[4]);
-
-    buf.put_u8(uuid_bytes[7]);
-    buf.put_u8(uuid_bytes[6]);
-
-    buf.put_slice(&uuid_bytes[8..16]);
-}
-
-/// Encode a DATE value for TVP (days since 0001-01-01).
-pub fn encode_tvp_date(days: u32, buf: &mut BytesMut) {
-    // DATE is 3 bytes
-    buf.put_u8((days & 0xFF) as u8);
-    buf.put_u8(((days >> 8) & 0xFF) as u8);
-    buf.put_u8(((days >> 16) & 0xFF) as u8);
-}
-
-/// Encode a TIME value for TVP.
-///
-/// Time is encoded as 100-nanosecond intervals since midnight.
-pub fn encode_tvp_time(intervals: u64, scale: u8, buf: &mut BytesMut) {
-    // Length depends on scale
-    let len = match scale {
-        0..=2 => 3,
-        3..=4 => 4,
-        5..=7 => 5,
-        _ => 5,
-    };
-    buf.put_u8(len);
-
-    for i in 0..len {
-        buf.put_u8((intervals >> (8 * i)) as u8);
-    }
-}
-
-/// Encode a DATETIME2 value for TVP.
-///
-/// DATETIME2 is TIME followed by DATE.
-pub fn encode_tvp_datetime2(time_intervals: u64, days: u32, scale: u8, buf: &mut BytesMut) {
-    // Length depends on scale (time bytes + 3 date bytes)
-    let time_len = match scale {
-        0..=2 => 3,
-        3..=4 => 4,
-        5..=7 => 5,
-        _ => 5,
-    };
-    buf.put_u8(time_len + 3);
-
-    // Time component
-    for i in 0..time_len {
-        buf.put_u8((time_intervals >> (8 * i)) as u8);
+    /// Encode a VARBINARY value for TVP.
+    pub fn encode_tvp_varbinary(value: &[u8], max_length: u16, buf: &mut BytesMut) {
+        if max_length == 0xFFFF {
+            // MAX type - use PLP format
+            buf.put_u64_le(value.len() as u64);
+            buf.put_u32_le(value.len() as u32);
+            buf.put_slice(value);
+            buf.put_u32_le(0); // Terminator
+        } else {
+            buf.put_u16_le(value.len() as u16);
+            buf.put_slice(value);
+        }
     }
 
-    // Date component
-    buf.put_u8((days & 0xFF) as u8);
-    buf.put_u8(((days >> 8) & 0xFF) as u8);
-    buf.put_u8(((days >> 16) & 0xFF) as u8);
-}
+    /// Encode a UNIQUEIDENTIFIER value for TVP.
+    ///
+    /// SQL Server uses mixed-endian format for UUIDs.
+    pub fn encode_tvp_guid(uuid_bytes: &[u8; 16], buf: &mut BytesMut) {
+        buf.put_u8(16); // Length
 
-/// Encode a DATETIMEOFFSET value for TVP.
-///
-/// DATETIMEOFFSET is TIME followed by DATE followed by timezone offset.
-///
-/// # Arguments
-///
-/// * `time_intervals` - Time in 100-nanosecond intervals since midnight
-/// * `days` - Days since year 1 (0001-01-01)
-/// * `offset_minutes` - Timezone offset in minutes (e.g., -480 for UTC-8, 330 for UTC+5:30)
-/// * `scale` - Fractional seconds precision (0-7)
-pub fn encode_tvp_datetimeoffset(
-    time_intervals: u64,
-    days: u32,
-    offset_minutes: i16,
-    scale: u8,
-    buf: &mut BytesMut,
-) {
-    // Length depends on scale (time bytes + 3 date bytes + 2 offset bytes)
-    let time_len = match scale {
-        0..=2 => 3,
-        3..=4 => 4,
-        5..=7 => 5,
-        _ => 5,
-    };
-    buf.put_u8(time_len + 3 + 2); // time + date + offset
+        // Mixed-endian: first 3 groups little-endian, last 2 groups big-endian
+        buf.put_u8(uuid_bytes[3]);
+        buf.put_u8(uuid_bytes[2]);
+        buf.put_u8(uuid_bytes[1]);
+        buf.put_u8(uuid_bytes[0]);
 
-    // Time component
-    for i in 0..time_len {
-        buf.put_u8((time_intervals >> (8 * i)) as u8);
+        buf.put_u8(uuid_bytes[5]);
+        buf.put_u8(uuid_bytes[4]);
+
+        buf.put_u8(uuid_bytes[7]);
+        buf.put_u8(uuid_bytes[6]);
+
+        buf.put_slice(&uuid_bytes[8..16]);
     }
 
-    // Date component
-    buf.put_u8((days & 0xFF) as u8);
-    buf.put_u8(((days >> 8) & 0xFF) as u8);
-    buf.put_u8(((days >> 16) & 0xFF) as u8);
+    /// Encode a DATE value for TVP (days since 0001-01-01).
+    pub fn encode_tvp_date(days: u32, buf: &mut BytesMut) {
+        // DATE is 3 bytes
+        buf.put_u8((days & 0xFF) as u8);
+        buf.put_u8(((days >> 8) & 0xFF) as u8);
+        buf.put_u8(((days >> 16) & 0xFF) as u8);
+    }
 
-    // Timezone offset in minutes (signed 16-bit little-endian)
-    buf.put_i16_le(offset_minutes);
-}
+    /// Encode a TIME value for TVP.
+    ///
+    /// Time is encoded as 100-nanosecond intervals since midnight.
+    pub fn encode_tvp_time(intervals: u64, scale: u8, buf: &mut BytesMut) {
+        // Length depends on scale
+        let len = match scale {
+            0..=2 => 3,
+            3..=4 => 4,
+            5..=7 => 5,
+            _ => 5,
+        };
+        buf.put_u8(len);
 
-/// Encode a DECIMAL value for TVP.
-///
-/// # Arguments
-///
-/// * `sign` - 0 for negative, 1 for positive
-/// * `mantissa` - The absolute value as a 128-bit integer
-pub fn encode_tvp_decimal(sign: u8, mantissa: u128, buf: &mut BytesMut) {
-    buf.put_u8(17); // Length: 1 byte sign + 16 bytes mantissa
-    buf.put_u8(sign);
-    buf.put_u128_le(mantissa);
-}
+        for i in 0..len {
+            buf.put_u8((intervals >> (8 * i)) as u8);
+        }
+    }
 
-/// Encode a MONEY value for TVP (8 bytes).
-///
-/// The MONEY wire format is a 64-bit signed integer scaled by 10_000, written
-/// as the high 32 bits little-endian followed by the low 32 bits little-endian
-/// (MS-TDS §2.2.5.5.1.2). `scaled` is the already-scaled cents value — callers
-/// that hold a `Decimal` should multiply by 10_000 and truncate to `i64` before
-/// calling this (see `mssql_types::encode::encode_money`).
-pub fn encode_tvp_money(scaled: i64, buf: &mut BytesMut) {
-    buf.put_u8(8); // Length
-    let high = (scaled >> 32) as i32;
-    let low = (scaled & 0xFFFF_FFFF) as u32;
-    buf.put_i32_le(high);
-    buf.put_u32_le(low);
-}
+    /// Encode a DATETIME2 value for TVP.
+    ///
+    /// DATETIME2 is TIME followed by DATE.
+    pub fn encode_tvp_datetime2(time_intervals: u64, days: u32, scale: u8, buf: &mut BytesMut) {
+        // Length depends on scale (time bytes + 3 date bytes)
+        let time_len = match scale {
+            0..=2 => 3,
+            3..=4 => 4,
+            5..=7 => 5,
+            _ => 5,
+        };
+        buf.put_u8(time_len + 3);
 
-/// Encode a SMALLMONEY value for TVP (4 bytes).
-///
-/// `scaled` is the 32-bit signed integer scaled by 10_000, written
-/// little-endian.
-pub fn encode_tvp_smallmoney(scaled: i32, buf: &mut BytesMut) {
-    buf.put_u8(4); // Length
-    buf.put_i32_le(scaled);
-}
+        // Time component
+        for i in 0..time_len {
+            buf.put_u8((time_intervals >> (8 * i)) as u8);
+        }
 
-/// Encode a legacy DATETIME value for TVP (8 bytes).
-///
-/// DATETIME wire format: days since 1900-01-01 (i32 LE) + time units since
-/// midnight (u32 LE) where each unit is 1/300 of a second.
-pub fn encode_tvp_datetime(days: i32, ticks: u32, buf: &mut BytesMut) {
-    buf.put_u8(8); // Length
-    buf.put_i32_le(days);
-    buf.put_u32_le(ticks);
-}
+        // Date component
+        buf.put_u8((days & 0xFF) as u8);
+        buf.put_u8(((days >> 8) & 0xFF) as u8);
+        buf.put_u8(((days >> 16) & 0xFF) as u8);
+    }
 
-/// Encode a SMALLDATETIME value for TVP (4 bytes).
-///
-/// SMALLDATETIME wire format: days since 1900-01-01 (u16 LE) + minutes since
-/// midnight (u16 LE). Sub-minute precision is discarded by the caller.
-pub fn encode_tvp_smalldatetime(days: u16, minutes: u16, buf: &mut BytesMut) {
-    buf.put_u8(4); // Length
-    buf.put_u16_le(days);
-    buf.put_u16_le(minutes);
+    /// Encode a DATETIMEOFFSET value for TVP.
+    ///
+    /// DATETIMEOFFSET is TIME followed by DATE followed by timezone offset.
+    ///
+    /// # Arguments
+    ///
+    /// * `time_intervals` - Time in 100-nanosecond intervals since midnight
+    /// * `days` - Days since year 1 (0001-01-01)
+    /// * `offset_minutes` - Timezone offset in minutes (e.g., -480 for UTC-8, 330 for UTC+5:30)
+    /// * `scale` - Fractional seconds precision (0-7)
+    pub fn encode_tvp_datetimeoffset(
+        time_intervals: u64,
+        days: u32,
+        offset_minutes: i16,
+        scale: u8,
+        buf: &mut BytesMut,
+    ) {
+        // Length depends on scale (time bytes + 3 date bytes + 2 offset bytes)
+        let time_len = match scale {
+            0..=2 => 3,
+            3..=4 => 4,
+            5..=7 => 5,
+            _ => 5,
+        };
+        buf.put_u8(time_len + 3 + 2); // time + date + offset
+
+        // Time component
+        for i in 0..time_len {
+            buf.put_u8((time_intervals >> (8 * i)) as u8);
+        }
+
+        // Date component
+        buf.put_u8((days & 0xFF) as u8);
+        buf.put_u8(((days >> 8) & 0xFF) as u8);
+        buf.put_u8(((days >> 16) & 0xFF) as u8);
+
+        // Timezone offset in minutes (signed 16-bit little-endian)
+        buf.put_i16_le(offset_minutes);
+    }
+
+    /// Encode a DECIMAL value for TVP.
+    ///
+    /// # Arguments
+    ///
+    /// * `sign` - 0 for negative, 1 for positive
+    /// * `mantissa` - The absolute value as a 128-bit integer
+    pub fn encode_tvp_decimal(sign: u8, mantissa: u128, buf: &mut BytesMut) {
+        buf.put_u8(17); // Length: 1 byte sign + 16 bytes mantissa
+        buf.put_u8(sign);
+        buf.put_u128_le(mantissa);
+    }
+
+    /// Encode a MONEY value for TVP (8 bytes).
+    ///
+    /// The MONEY wire format is a 64-bit signed integer scaled by 10_000, written
+    /// as the high 32 bits little-endian followed by the low 32 bits little-endian
+    /// (MS-TDS §2.2.5.5.1.2). `scaled` is the already-scaled cents value — callers
+    /// that hold a `Decimal` should multiply by 10_000 and truncate to `i64` before
+    /// calling this (see `mssql_types::encode::encode_money`).
+    pub fn encode_tvp_money(scaled: i64, buf: &mut BytesMut) {
+        buf.put_u8(8); // Length
+        let high = (scaled >> 32) as i32;
+        let low = (scaled & 0xFFFF_FFFF) as u32;
+        buf.put_i32_le(high);
+        buf.put_u32_le(low);
+    }
+
+    /// Encode a SMALLMONEY value for TVP (4 bytes).
+    ///
+    /// `scaled` is the 32-bit signed integer scaled by 10_000, written
+    /// little-endian.
+    pub fn encode_tvp_smallmoney(scaled: i32, buf: &mut BytesMut) {
+        buf.put_u8(4); // Length
+        buf.put_i32_le(scaled);
+    }
+
+    /// Encode a legacy DATETIME value for TVP (8 bytes).
+    ///
+    /// DATETIME wire format: days since 1900-01-01 (i32 LE) + time units since
+    /// midnight (u32 LE) where each unit is 1/300 of a second.
+    pub fn encode_tvp_datetime(days: i32, ticks: u32, buf: &mut BytesMut) {
+        buf.put_u8(8); // Length
+        buf.put_i32_le(days);
+        buf.put_u32_le(ticks);
+    }
+
+    /// Encode a SMALLDATETIME value for TVP (4 bytes).
+    ///
+    /// SMALLDATETIME wire format: days since 1900-01-01 (u16 LE) + minutes since
+    /// midnight (u16 LE). Sub-minute precision is discarded by the caller.
+    pub fn encode_tvp_smalldatetime(days: u16, minutes: u16, buf: &mut BytesMut) {
+        buf.put_u8(4); // Length
+        buf.put_u16_le(days);
+        buf.put_u16_le(minutes);
+    }
 }
 
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
+    use super::sealed::*;
     use super::*;
 
     #[test]

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -434,7 +434,7 @@ dependencies = [
 
 [[package]]
 name = "mssql-auth"
-version = "0.11.0"
+version = "0.18.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -444,7 +444,7 @@ dependencies = [
 
 [[package]]
 name = "mssql-client"
-version = "0.11.0"
+version = "0.18.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -452,6 +452,7 @@ dependencies = [
  "lru",
  "mssql-auth",
  "mssql-codec",
+ "mssql-derive",
  "mssql-tls",
  "mssql-types",
  "once_cell",
@@ -466,7 +467,7 @@ dependencies = [
 
 [[package]]
 name = "mssql-codec"
-version = "0.11.0"
+version = "0.18.0"
 dependencies = [
  "bytes",
  "futures-core",
@@ -477,6 +478,15 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "mssql-derive"
+version = "0.18.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -496,7 +506,7 @@ dependencies = [
 
 [[package]]
 name = "mssql-tls"
-version = "0.11.0"
+version = "0.18.0"
 dependencies = [
  "rustls",
  "thiserror",
@@ -508,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "mssql-types"
-version = "0.11.0"
+version = "0.18.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -901,7 +911,7 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tds-protocol"
-version = "0.11.0"
+version = "0.18.0"
 dependencies = [
  "bitflags",
  "bytes",

--- a/fuzz/fuzz_targets/decode_value.rs
+++ b/fuzz/fuzz_targets/decode_value.rs
@@ -32,5 +32,5 @@ fuzz_target!(|input: FuzzInput| {
 
     // Try to decode the value
     let mut bytes = Bytes::from(input.data);
-    let _ = mssql_types::decode::decode_value(&mut bytes, &type_info);
+    let _ = mssql_types::__private::decode_value(&mut bytes, &type_info);
 });

--- a/fuzz/fuzz_targets/type_roundtrip.rs
+++ b/fuzz/fuzz_targets/type_roundtrip.rs
@@ -252,7 +252,7 @@ fuzz_target!(|input: FuzzSqlValue| {
         };
 
         // Attempt decode — should not panic
-        let decode_result = mssql_types::decode::decode_value(&mut decode_bytes, &type_info);
+        let decode_result = mssql_types::__private::decode_value(&mut decode_bytes, &type_info);
 
         // If decode succeeded, verify basic invariants
         if let Ok(decoded) = decode_result {

--- a/public-api/mssql-types.txt
+++ b/public-api/mssql-types.txt
@@ -85,7 +85,6 @@ pub fn mssql_types::decode::TypeInfo::from(T) -> T
 pub trait mssql_types::decode::TdsDecode: core::marker::Sized
 pub fn mssql_types::decode::TdsDecode::decode(&mut bytes::bytes::Bytes, &mssql_types::decode::TypeInfo) -> core::result::Result<Self, mssql_types::error::TypeError>
 pub fn mssql_types::decode::decode_utf16_string(&[u8]) -> core::result::Result<alloc::string::String, mssql_types::error::TypeError>
-pub fn mssql_types::decode::decode_value(&mut bytes::bytes::Bytes, &mssql_types::decode::TypeInfo) -> core::result::Result<mssql_types::value::SqlValue, mssql_types::error::TypeError>
 pub mod mssql_types::encode
 pub trait mssql_types::encode::TdsEncode
 pub fn mssql_types::encode::TdsEncode::encode(&self, &mut bytes::bytes_mut::BytesMut) -> core::result::Result<(), mssql_types::error::TypeError>
@@ -93,21 +92,7 @@ pub fn mssql_types::encode::TdsEncode::type_id(&self) -> u8
 impl mssql_types::encode::TdsEncode for mssql_types::value::SqlValue
 pub fn mssql_types::value::SqlValue::encode(&self, &mut bytes::bytes_mut::BytesMut) -> core::result::Result<(), mssql_types::error::TypeError>
 pub fn mssql_types::value::SqlValue::type_id(&self) -> u8
-pub fn mssql_types::encode::datetime_to_legacy_days_ticks(chrono::naive::datetime::NaiveDateTime) -> (i32, u32)
-pub fn mssql_types::encode::datetime_to_smalldatetime_days_minutes(chrono::naive::datetime::NaiveDateTime) -> core::result::Result<(u16, u16), mssql_types::error::TypeError>
-pub fn mssql_types::encode::decimal_to_money_cents_i64(rust_decimal::decimal::Decimal) -> core::result::Result<i64, mssql_types::error::TypeError>
-pub fn mssql_types::encode::decimal_to_smallmoney_cents_i32(rust_decimal::decimal::Decimal) -> core::result::Result<i32, mssql_types::error::TypeError>
-pub fn mssql_types::encode::encode_date(chrono::naive::date::NaiveDate, &mut bytes::bytes_mut::BytesMut) -> core::result::Result<(), mssql_types::error::TypeError>
-pub fn mssql_types::encode::encode_datetime2(chrono::naive::datetime::NaiveDateTime, &mut bytes::bytes_mut::BytesMut) -> core::result::Result<(), mssql_types::error::TypeError>
-pub fn mssql_types::encode::encode_datetime_legacy(chrono::naive::datetime::NaiveDateTime, &mut bytes::bytes_mut::BytesMut)
-pub fn mssql_types::encode::encode_datetimeoffset(chrono::datetime::DateTime<chrono::offset::fixed::FixedOffset>, &mut bytes::bytes_mut::BytesMut) -> core::result::Result<(), mssql_types::error::TypeError>
-pub fn mssql_types::encode::encode_decimal(rust_decimal::decimal::Decimal, &mut bytes::bytes_mut::BytesMut)
-pub fn mssql_types::encode::encode_money(rust_decimal::decimal::Decimal, &mut bytes::bytes_mut::BytesMut) -> core::result::Result<(), mssql_types::error::TypeError>
-pub fn mssql_types::encode::encode_smalldatetime(chrono::naive::datetime::NaiveDateTime, &mut bytes::bytes_mut::BytesMut) -> core::result::Result<(), mssql_types::error::TypeError>
-pub fn mssql_types::encode::encode_smallmoney(rust_decimal::decimal::Decimal, &mut bytes::bytes_mut::BytesMut) -> core::result::Result<(), mssql_types::error::TypeError>
-pub fn mssql_types::encode::encode_time(chrono::naive::time::NaiveTime, &mut bytes::bytes_mut::BytesMut)
 pub fn mssql_types::encode::encode_utf16_string(&str, &mut bytes::bytes_mut::BytesMut)
-pub fn mssql_types::encode::encode_uuid(uuid::Uuid, &mut bytes::bytes_mut::BytesMut)
 pub mod mssql_types::error
 #[non_exhaustive] pub enum mssql_types::error::TypeError
 pub mssql_types::error::TypeError::BufferTooSmall
@@ -2438,7 +2423,6 @@ pub fn mssql_types::datetime(chrono::naive::datetime::NaiveDateTime) -> mssql_ty
 pub fn mssql_types::datetime2(chrono::naive::datetime::NaiveDateTime, u8) -> mssql_types::to_sql::DateTime2
 pub fn mssql_types::datetimeoffset(chrono::datetime::DateTime<chrono::offset::fixed::FixedOffset>, u8) -> mssql_types::to_sql::DateTimeOffset
 pub fn mssql_types::decode_utf16_string(&[u8]) -> core::result::Result<alloc::string::String, mssql_types::error::TypeError>
-pub fn mssql_types::decode_value(&mut bytes::bytes::Bytes, &mssql_types::decode::TypeInfo) -> core::result::Result<mssql_types::value::SqlValue, mssql_types::error::TypeError>
 pub fn mssql_types::encode_utf16_string(&str, &mut bytes::bytes_mut::BytesMut)
 pub fn mssql_types::nchar(impl core::convert::Into<alloc::string::String>, u16) -> mssql_types::to_sql::NChar
 pub fn mssql_types::null<T: mssql_types::to_sql::SqlTyped>() -> mssql_types::to_sql::TypedNull

--- a/public-api/tds-protocol.txt
+++ b/public-api/tds-protocol.txt
@@ -14,7 +14,6 @@ pub const tds_protocol::collation::LCID_MASK: u32
 pub const tds_protocol::collation::PRIMARY_LANGUAGE_MASK: u32
 pub fn tds_protocol::collation::code_page_for_lcid(u32) -> core::option::Option<u16>
 pub fn tds_protocol::collation::code_page_for_sort_id(u8) -> core::option::Option<u16>
-pub fn tds_protocol::collation::encode_str_for_collation(&str, core::option::Option<&tds_protocol::token::Collation>) -> alloc::vec::Vec<u8>
 pub fn tds_protocol::collation::encoding_for_lcid(u32) -> core::option::Option<&'static encoding_rs::Encoding>
 pub fn tds_protocol::collation::encoding_for_sort_id(u8) -> core::option::Option<&'static encoding_rs::Encoding>
 pub fn tds_protocol::collation::encoding_name_for_lcid(u32) -> &'static str
@@ -1467,8 +1466,6 @@ impl<T> core::clone::CloneToUninit for tds_protocol::sql_batch::SqlBatch where T
 pub unsafe fn tds_protocol::sql_batch::SqlBatch::clone_to_uninit(&self, *mut u8)
 impl<T> core::convert::From<T> for tds_protocol::sql_batch::SqlBatch
 pub fn tds_protocol::sql_batch::SqlBatch::from(T) -> T
-pub fn tds_protocol::sql_batch::encode_sql_batch(&str) -> bytes::bytes::Bytes
-pub fn tds_protocol::sql_batch::encode_sql_batch_with_transaction(&str, u64) -> bytes::bytes::Bytes
 pub mod tds_protocol::token
 #[non_exhaustive] #[repr(u8)] pub enum tds_protocol::token::EnvChangeType
 pub tds_protocol::token::EnvChangeType::BeginTransaction = 8
@@ -2746,24 +2743,6 @@ pub const tds_protocol::tvp::TVP_END_TOKEN: u8
 pub const tds_protocol::tvp::TVP_NULL_TOKEN: u16
 pub const tds_protocol::tvp::TVP_ROW_TOKEN: u8
 pub const tds_protocol::tvp::TVP_TYPE_ID: u8
-pub fn tds_protocol::tvp::encode_tvp_bit(bool, &mut bytes::bytes_mut::BytesMut)
-pub fn tds_protocol::tvp::encode_tvp_date(u32, &mut bytes::bytes_mut::BytesMut)
-pub fn tds_protocol::tvp::encode_tvp_datetime(i32, u32, &mut bytes::bytes_mut::BytesMut)
-pub fn tds_protocol::tvp::encode_tvp_datetime2(u64, u32, u8, &mut bytes::bytes_mut::BytesMut)
-pub fn tds_protocol::tvp::encode_tvp_datetimeoffset(u64, u32, i16, u8, &mut bytes::bytes_mut::BytesMut)
-pub fn tds_protocol::tvp::encode_tvp_decimal(u8, u128, &mut bytes::bytes_mut::BytesMut)
-pub fn tds_protocol::tvp::encode_tvp_float(f64, u8, &mut bytes::bytes_mut::BytesMut)
-pub fn tds_protocol::tvp::encode_tvp_guid(&[u8; 16], &mut bytes::bytes_mut::BytesMut)
-pub fn tds_protocol::tvp::encode_tvp_int(i64, u8, &mut bytes::bytes_mut::BytesMut)
-pub fn tds_protocol::tvp::encode_tvp_money(i64, &mut bytes::bytes_mut::BytesMut)
-pub fn tds_protocol::tvp::encode_tvp_null(&tds_protocol::tvp::TvpWireType, &mut bytes::bytes_mut::BytesMut)
-pub fn tds_protocol::tvp::encode_tvp_nvarchar(&str, u16, &mut bytes::bytes_mut::BytesMut)
-pub fn tds_protocol::tvp::encode_tvp_smalldatetime(u16, u16, &mut bytes::bytes_mut::BytesMut)
-pub fn tds_protocol::tvp::encode_tvp_smallmoney(i32, &mut bytes::bytes_mut::BytesMut)
-pub fn tds_protocol::tvp::encode_tvp_time(u64, u8, &mut bytes::bytes_mut::BytesMut)
-pub fn tds_protocol::tvp::encode_tvp_varbinary(&[u8], u16, &mut bytes::bytes_mut::BytesMut)
-pub fn tds_protocol::tvp::encode_tvp_varchar(&str, u16, &mut bytes::bytes_mut::BytesMut)
-pub fn tds_protocol::tvp::encode_tvp_varchar_with_collation(&str, u16, core::option::Option<&tds_protocol::token::Collation>, &mut bytes::bytes_mut::BytesMut)
 pub mod tds_protocol::types
 #[non_exhaustive] #[repr(u8)] pub enum tds_protocol::types::TypeId
 pub tds_protocol::types::TypeId::BigBinary = 173
@@ -6002,20 +5981,4 @@ pub const tds_protocol::PACKET_HEADER_SIZE: usize
 pub const tds_protocol::TVP_END_TOKEN: u8
 pub const tds_protocol::TVP_ROW_TOKEN: u8
 pub const tds_protocol::TVP_TYPE_ID: u8
-pub fn tds_protocol::encode_sql_batch(&str) -> bytes::bytes::Bytes
-pub fn tds_protocol::encode_sql_batch_with_transaction(&str, u64) -> bytes::bytes::Bytes
-pub fn tds_protocol::encode_tvp_bit(bool, &mut bytes::bytes_mut::BytesMut)
-pub fn tds_protocol::encode_tvp_date(u32, &mut bytes::bytes_mut::BytesMut)
-pub fn tds_protocol::encode_tvp_datetime2(u64, u32, u8, &mut bytes::bytes_mut::BytesMut)
-pub fn tds_protocol::encode_tvp_datetimeoffset(u64, u32, i16, u8, &mut bytes::bytes_mut::BytesMut)
-pub fn tds_protocol::encode_tvp_decimal(u8, u128, &mut bytes::bytes_mut::BytesMut)
-pub fn tds_protocol::encode_tvp_float(f64, u8, &mut bytes::bytes_mut::BytesMut)
-pub fn tds_protocol::encode_tvp_guid(&[u8; 16], &mut bytes::bytes_mut::BytesMut)
-pub fn tds_protocol::encode_tvp_int(i64, u8, &mut bytes::bytes_mut::BytesMut)
-pub fn tds_protocol::encode_tvp_null(&tds_protocol::tvp::TvpWireType, &mut bytes::bytes_mut::BytesMut)
-pub fn tds_protocol::encode_tvp_nvarchar(&str, u16, &mut bytes::bytes_mut::BytesMut)
-pub fn tds_protocol::encode_tvp_time(u64, u8, &mut bytes::bytes_mut::BytesMut)
-pub fn tds_protocol::encode_tvp_varbinary(&[u8], u16, &mut bytes::bytes_mut::BytesMut)
-pub fn tds_protocol::encode_tvp_varchar(&str, u16, &mut bytes::bytes_mut::BytesMut)
-pub fn tds_protocol::encode_tvp_varchar_with_collation(&str, u16, core::option::Option<&tds_protocol::token::Collation>, &mut bytes::bytes_mut::BytesMut)
 pub fn tds_protocol::is_column_encrypted(u16) -> bool


### PR DESCRIPTION
## Summary

Implements #242 (Option A). The low-level TDS wire encoders/decoders that the
driver shares across crate boundaries were part of the **frozen public API**
only because they're consumed cross-crate — they're implementation primitives,
not user-facing API. This moves them off the documented surface (and the
`cargo-public-api` snapshot) via a `#[doc(hidden)] pub mod __private` convention,
so they don't become a 1.0 stability commitment.

## Mechanism

Each sealed function is relocated into a `pub(crate) mod sealed` **inside its
still-public module** and re-exported through `crate::__private`. Cross-crate
consumers import via `__private`; intra-crate callers keep working via a
`pub(crate) use`. Keeping the host module genuinely `pub` (rather than a
`#[path]` facade over a private module) means the **public items' definitions
stay public**, so `cargo-public-api` does not re-resolve their paths — the
snapshot diff is **pure removals, 0 additions, no path flips**.

`__private` uses glob re-exports so the set tracks the `#[cfg(feature = ...)]`
gating on the underlying encoders.

## Sealed inventory (cross-crate-consumed; evidence: crates.io reverse-deps + GitHub code search show first-party only)

- **mssql-types** — `encode::*` (14: `encode_uuid`, `encode_decimal`, `encode_money`, `encode_smallmoney`, `encode_date`, `encode_time`, `encode_datetime2`, `encode_datetimeoffset`, `encode_datetime_legacy`, `encode_smalldatetime`, `decimal_to_money_cents_i64`, `decimal_to_smallmoney_cents_i32`, `datetime_to_legacy_days_ticks`, `datetime_to_smalldatetime_days_minutes`) and `decode::decode_value`
- **tds-protocol** — `collation::encode_str_for_collation`, `sql_batch::{encode_sql_batch, encode_sql_batch_with_transaction}`, `tvp::encode_tvp_*` (18)

## Pinned-public (left public deliberately, reported per the issue)

`mssql_types::decode::{TypeInfo, Collation}` stay public: `TypeInfo` is the
return type of the public `mssql_client::row::Column::to_type_info`, so sealing
it would change the **mssql-client** surface. `Collation` is reachable via
`TypeInfo`'s public field. The `TvpEncoder`/`TvpColumnDef`/`TvpColumnFlags`/`SqlBatch`
types and `TdsEncode`/`encode_utf16_string` are out of scope (not "codec
helpers") and remain at their exact paths.

## Snapshot diff

`public-api/mssql-types.txt` (-16) and `public-api/tds-protocol.txt` (-37) —
pure removals. `mssql-client` surface unchanged (TypeInfo path intact). Windows
baselines reference none of the sealed items (no change needed).

## Verification

Full local gate green: `fmt`, `clippy --all-features --all-targets -D warnings`,
`nextest --all-features` (919 pass), `cargo doc -D warnings`, doc-consistency,
public-api, typos, feature-flags, and the **live ignored suite** (274 pass —
incl. TVP and AE temporal/money/uuid/date parameter round-trips that exercise
the sealed encoders). No behavior change — import-path-only relocation.

Closes #242