### PR TITLE
refactor(types): share the divergence-prone decode primitives (#204 step 3)

### DIFF
--- a/crates/mssql-client/src/column_parser.rs
+++ b/crates/mssql-client/src/column_parser.rs
@@ -669,79 +669,16 @@ pub fn parse_column_value(buf: &mut &[u8], col: &ColumnData) -> Result<SqlValue>
             }
         }
 
-        // DECIMAL/NUMERIC types (1-byte length prefix)
+        // DECIMAL/NUMERIC types (1-byte length prefix). The mantissa decode and
+        // the 96-bit/scale-28 overflow policy are shared with the secondary
+        // decode stack (`mssql_types::decode`) so the two cannot drift — that
+        // drift was issue #188. Only `scale` is consulted by the shared decoder.
         TypeId::Decimal | TypeId::Numeric | TypeId::DecimalN | TypeId::NumericN => {
-            if buf.remaining() < 1 {
-                return Err(Error::Protocol(
-                    "unexpected EOF reading DECIMAL/NUMERIC length".into(),
-                ));
-            }
-            let len = buf.get_u8() as usize;
-            if len == 0 {
-                SqlValue::Null
-            } else {
-                if buf.remaining() < len {
-                    return Err(Error::Protocol(
-                        "unexpected EOF reading DECIMAL/NUMERIC data".into(),
-                    ));
-                }
-
-                // First byte is sign: 0 = negative, 1 = positive
-                let sign = buf.get_u8();
-                let mantissa_len = len - 1;
-
-                // Read mantissa as little-endian integer (up to 16 bytes for max precision 38)
-                let mut mantissa_bytes = [0u8; 16];
-                for i in 0..mantissa_len.min(16) {
-                    mantissa_bytes[i] = buf.get_u8();
-                }
-                // Skip any excess bytes (shouldn't happen with valid data)
-                for _ in 16..mantissa_len {
-                    buf.get_u8();
-                }
-
-                let mantissa = u128::from_le_bytes(mantissa_bytes);
-                let scale = col.type_info.scale.unwrap_or(0) as u32;
-
-                #[cfg(feature = "decimal")]
-                {
-                    use rust_decimal::Decimal;
-                    // rust_decimal holds 96-bit mantissas with scale <= 28;
-                    // SQL Server NUMERIC goes to 38 digits, so legitimate
-                    // wire values can exceed it. That must be an error, not
-                    // a silent fall back to f64 (~15-16 significant digits):
-                    // a lossy value read, written back, or compared
-                    // downstream corrupts data (issue #157).
-                    let decimal = i128::try_from(mantissa)
-                        .ok()
-                        .and_then(|m| Decimal::try_from_i128_with_scale(m, scale).ok());
-                    match decimal {
-                        Some(mut decimal) => {
-                            if sign == 0 {
-                                decimal.set_sign_negative(true);
-                            }
-                            SqlValue::Decimal(decimal)
-                        }
-                        None => {
-                            return Err(mssql_types::TypeError::InvalidDecimal(format!(
-                                "NUMERIC value (mantissa {mantissa}, scale {scale}) exceeds \
-                                 rust_decimal's 96-bit/scale-28 range; CAST the column to a \
-                                 narrower NUMERIC, FLOAT, or VARCHAR in the query"
-                            ))
-                            .into());
-                        }
-                    }
-                }
-
-                #[cfg(not(feature = "decimal"))]
-                {
-                    // Without the decimal feature, convert to f64
-                    let divisor = 10f64.powi(scale as i32);
-                    let value = (mantissa as f64) / divisor;
-                    let value = if sign == 0 { -value } else { value };
-                    SqlValue::Double(value)
-                }
-            }
+            let type_info = mssql_types::TypeInfo::decimal(
+                col.type_info.precision.unwrap_or(18),
+                col.type_info.scale.unwrap_or(0),
+            );
+            mssql_types::__private::decode_decimal(buf, &type_info)?
         }
 
         // DATETIME/SMALLDATETIME nullable (1-byte length prefix)

--- a/crates/mssql-client/src/column_parser.rs
+++ b/crates/mssql-client/src/column_parser.rs
@@ -26,6 +26,13 @@
 
 use bytes::Buf;
 use mssql_types::SqlValue;
+// Scale primitives shared with the secondary decode stack (`mssql_types::decode`)
+// so the scale→width mapping and the 100ns-interval conversion cannot drift
+// between the two stacks (see #204). `time_bytes_for_scale` is pure scale math,
+// used for frame-length validation even without `chrono`.
+#[cfg(feature = "chrono")]
+use mssql_types::__private::intervals_to_time;
+use mssql_types::__private::time_bytes_for_scale;
 use tds_protocol::token::{ColMetaData, Collation, ColumnData, NbcRow, RawRow};
 use tds_protocol::types::TypeId;
 
@@ -1728,50 +1735,6 @@ fn parse_sql_variant(buf: &mut &[u8]) -> Result<SqlValue> {
             Ok(SqlValue::Binary(data))
         }
     }
-}
-
-/// Calculate number of bytes needed for TIME based on scale.
-fn time_bytes_for_scale(scale: u8) -> usize {
-    match scale {
-        0..=2 => 3,
-        3..=4 => 4,
-        5..=7 => 5,
-        _ => 5, // Default to max precision
-    }
-}
-
-/// Convert 100-nanosecond intervals to NaiveTime.
-#[cfg(feature = "chrono")]
-fn intervals_to_time(intervals: u64, scale: u8) -> chrono::NaiveTime {
-    // Scale determines the unit:
-    // scale 0: seconds
-    // scale 1: 100ms
-    // scale 2: 10ms
-    // scale 3: 1ms
-    // scale 4: 100us
-    // scale 5: 10us
-    // scale 6: 1us
-    // scale 7: 100ns
-    // Saturating: `intervals` comes from the wire, and a hostile value must
-    // not overflow-panic in debug builds (saturation lands in the
-    // out-of-range fallback below).
-    let nanos = match scale {
-        0 => intervals.saturating_mul(1_000_000_000),
-        1 => intervals.saturating_mul(100_000_000),
-        2 => intervals.saturating_mul(10_000_000),
-        3 => intervals.saturating_mul(1_000_000),
-        4 => intervals.saturating_mul(100_000),
-        5 => intervals.saturating_mul(10_000),
-        6 => intervals.saturating_mul(1_000),
-        7 => intervals.saturating_mul(100),
-        _ => intervals.saturating_mul(100),
-    };
-
-    let secs = (nanos / 1_000_000_000) as u32;
-    let nano_part = (nanos % 1_000_000_000) as u32;
-
-    chrono::NaiveTime::from_num_seconds_from_midnight_opt(secs, nano_part)
-        .unwrap_or_else(|| chrono::NaiveTime::from_hms_opt(0, 0, 0).expect("midnight is valid"))
 }
 
 /// Decode 16 GUID bytes from SQL Server mixed-endian wire format to RFC 4122 format.

--- a/crates/mssql-client/src/column_parser.rs
+++ b/crates/mssql-client/src/column_parser.rs
@@ -1466,65 +1466,32 @@ fn parse_sql_variant(buf: &mut &[u8]) -> Result<SqlValue> {
             }
         }
         0x6A | 0x6C => {
-            // DECIMALN/NUMERICN - 2 prop bytes (precision, scale)
-            let _precision = if prop_count >= 1 { buf.get_u8() } else { 18 };
+            // DECIMALN/NUMERICN - 2 prop bytes (precision, scale). Share the
+            // mantissa decode and the 96-bit/scale-28 overflow policy with the
+            // top-level path and the secondary stack (#204): reframe the variant
+            // payload (`[sign][mantissa]`, `data_len` bytes) as the
+            // `[len][sign][mantissa]` form `decode_decimal` reads, with
+            // `data_len` standing in for the length byte.
+            let precision = if prop_count >= 1 { buf.get_u8() } else { 18 };
             let scale = if prop_count >= 2 { buf.get_u8() } else { 0 };
             buf.advance(prop_count.saturating_sub(2));
 
-            if data_len < 1 {
+            if data_len > u8::MAX as usize {
+                // Not representable as a single-byte length prefix, and far
+                // larger than any real NUMERIC (max 17 bytes); treat as
+                // malformed and skip without panicking.
+                buf.advance(data_len);
                 return Ok(SqlValue::Null);
             }
 
-            let sign = buf.get_u8();
-            let mantissa_len = data_len - 1;
-
-            if mantissa_len > 16 {
-                // Too large, skip and return null
-                buf.advance(mantissa_len);
-                return Ok(SqlValue::Null);
-            }
-
-            let mut mantissa_bytes = [0u8; 16];
-            for i in 0..mantissa_len.min(16) {
-                mantissa_bytes[i] = buf.get_u8();
-            }
-            let mantissa = u128::from_le_bytes(mantissa_bytes);
-
-            #[cfg(feature = "decimal")]
-            {
-                use rust_decimal::Decimal;
-                // Same overflow class as the top-level DECIMAL branch:
-                // rust_decimal holds 96-bit mantissas with scale <= 28, but a
-                // 16-byte wire mantissa (legitimate 38-digit NUMERIC or
-                // hostile) can exceed that regardless of scale. The old
-                // `scale > 28` guard did not cover an oversized mantissa, so
-                // `from_i128_with_scale` could panic. Fall back to f64 on any
-                // out-of-range value.
-                let decimal = i128::try_from(mantissa)
-                    .ok()
-                    .and_then(|m| Decimal::try_from_i128_with_scale(m, scale as u32).ok());
-                match decimal {
-                    Some(mut decimal) => {
-                        if sign == 0 {
-                            decimal.set_sign_negative(true);
-                        }
-                        Ok(SqlValue::Decimal(decimal))
-                    }
-                    None => Err(mssql_types::TypeError::InvalidDecimal(format!(
-                        "NUMERIC value in sql_variant (mantissa {mantissa}, scale {scale}) \
-                         exceeds rust_decimal's 96-bit/scale-28 range; CAST the column to a \
-                         narrower NUMERIC, FLOAT, or VARCHAR in the query"
-                    ))
-                    .into()),
-                }
-            }
-            #[cfg(not(feature = "decimal"))]
-            {
-                let divisor = 10f64.powi(scale as i32);
-                let value = (mantissa as f64) / divisor;
-                let value = if sign == 0 { -value } else { value };
-                Ok(SqlValue::Double(value))
-            }
+            let type_info = mssql_types::TypeInfo::decimal(precision, scale);
+            let result = {
+                let len_prefix = [data_len as u8];
+                let mut framed = (&len_prefix[..]).chain(&buf[..data_len]);
+                mssql_types::__private::decode_decimal(&mut framed, &type_info)
+            };
+            buf.advance(data_len);
+            result.map_err(Into::into)
         }
         0x24 => {
             // UNIQUEIDENTIFIER (no properties)
@@ -2101,6 +2068,25 @@ mod tests {
             err.to_string().contains("rust_decimal"),
             "error should explain the range limitation: {err}"
         );
+    }
+
+    /// A valid SQL_VARIANT DECIMALN decodes through the shared decoder (#204):
+    /// 123.45 as NUMERIC(5,2). total_len=7: base_type + prop_count + precision
+    /// + scale + sign(1) + mantissa(2).
+    #[cfg(feature = "decimal")]
+    #[test]
+    fn variant_decimal_decodes_via_shared_decoder() {
+        let mut data = Vec::new();
+        data.extend_from_slice(&7u32.to_le_bytes());
+        data.push(0x6A); // DECIMALN
+        data.push(0x02); // prop_count: precision, scale
+        data.push(5); // precision
+        data.push(2); // scale
+        data.push(0x01); // sign (positive)
+        data.extend_from_slice(&12345u16.to_le_bytes()); // mantissa LE
+        let mut buf: &[u8] = &data;
+        let value = parse_sql_variant(&mut buf).expect("valid NUMERIC must decode");
+        assert_eq!(value, SqlValue::Decimal("123.45".parse().unwrap()));
     }
 
     #[cfg(feature = "chrono")]

--- a/crates/mssql-client/src/column_parser.rs
+++ b/crates/mssql-client/src/column_parser.rs
@@ -1476,10 +1476,13 @@ fn parse_sql_variant(buf: &mut &[u8]) -> Result<SqlValue> {
             let scale = if prop_count >= 2 { buf.get_u8() } else { 0 };
             buf.advance(prop_count.saturating_sub(2));
 
-            if data_len > u8::MAX as usize {
-                // Not representable as a single-byte length prefix, and far
-                // larger than any real NUMERIC (max 17 bytes); treat as
-                // malformed and skip without panicking.
+            // A valid NUMERIC/DECIMAL payload is at most 17 bytes (sign + 16
+            // mantissa). Anything larger is malformed; skip it and return Null,
+            // preserving the pre-#204 behavior (the old `mantissa_len > 16`
+            // guard) rather than feeding the shared decoder a payload it would
+            // partially decode. This also keeps `data_len` within `u8`, so the
+            // length-prefix reframing below cannot truncate or panic.
+            if data_len > 17 {
                 buf.advance(data_len);
                 return Ok(SqlValue::Null);
             }
@@ -2087,6 +2090,25 @@ mod tests {
         let mut buf: &[u8] = &data;
         let value = parse_sql_variant(&mut buf).expect("valid NUMERIC must decode");
         assert_eq!(value, SqlValue::Decimal("123.45".parse().unwrap()));
+    }
+
+    /// A SQL_VARIANT DECIMALN whose payload exceeds the 17-byte NUMERIC maximum
+    /// (sign + 16 mantissa) is malformed: it decodes to Null, not through the
+    /// shared decoder. data_len = 18 (sign + 17 mantissa); total_len = 22.
+    #[test]
+    fn variant_decimal_oversized_payload_is_null() {
+        let mut data = Vec::new();
+        data.extend_from_slice(&22u32.to_le_bytes());
+        data.push(0x6A); // DECIMALN
+        data.push(0x02); // prop_count: precision, scale
+        data.push(38); // precision
+        data.push(0); // scale
+        data.push(0x01); // sign
+        data.extend_from_slice(&[0u8; 17]); // 17 mantissa bytes => data_len 18
+        let mut buf: &[u8] = &data;
+        let value = parse_sql_variant(&mut buf).expect("oversized payload must not error");
+        assert_eq!(value, SqlValue::Null);
+        assert!(buf.is_empty(), "the whole payload must be consumed");
     }
 
     #[cfg(feature = "chrono")]

--- a/crates/mssql-client/src/error.rs
+++ b/crates/mssql-client/src/error.rs
@@ -367,6 +367,7 @@ impl Error {
             | Self::InvalidIdentifier(_)
             | Self::Protocol(_)
             | Self::ProtocolError(_)
+            | Self::Type(_)
             | Self::Tls(_)
             | Self::Authentication(_)
             | Self::Cancel(_) => true,

--- a/crates/mssql-types/src/decode.rs
+++ b/crates/mssql-types/src/decode.rs
@@ -219,6 +219,25 @@ pub(crate) mod sealed {
         super::decode_decimal(buf, type_info)
     }
 
+    /// Number of TDS wire bytes a scale-`scale` TIME/DATETIME2/DATETIMEOFFSET
+    /// time component occupies.
+    ///
+    /// Shared with `mssql-client`'s `column_parser` so the two decode stacks
+    /// agree on the scale→width mapping (see #204). Pure scale math, so it is
+    /// available without the `chrono` feature (column_parser validates frame
+    /// lengths against it even when `chrono` is off).
+    pub fn time_bytes_for_scale(scale: u8) -> usize {
+        super::time_bytes_for_scale(scale)
+    }
+
+    /// Convert wire 100ns-interval-derived `intervals` (at scale `scale`) into a
+    /// `NaiveTime`, shared with `column_parser` so the scale conversion cannot
+    /// drift (see #204).
+    #[cfg(feature = "chrono")]
+    pub fn intervals_to_time(intervals: u64, scale: u8) -> chrono::NaiveTime {
+        super::intervals_to_time(intervals, scale)
+    }
+
     /// Decode a SQL value based on type information.
     pub fn decode_value(buf: &mut Bytes, type_info: &TypeInfo) -> Result<SqlValue, TypeError> {
         match type_info.type_id {
@@ -1052,7 +1071,6 @@ pub fn decode_utf16_string(data: &[u8]) -> Result<String, TypeError> {
 }
 
 /// Calculate number of bytes needed for TIME based on scale.
-#[cfg(feature = "chrono")]
 fn time_bytes_for_scale(scale: u8) -> usize {
     match scale {
         0..=2 => 3,

--- a/crates/mssql-types/src/decode.rs
+++ b/crates/mssql-types/src/decode.rs
@@ -206,6 +206,19 @@ impl TypeInfo {
 pub(crate) mod sealed {
     use super::*;
 
+    /// Decode a DECIMAL/NUMERIC value (1-byte length prefix, sign byte,
+    /// little-endian mantissa).
+    ///
+    /// Shared with `mssql-client`'s `column_parser` so the two decode stacks
+    /// cannot drift on the overflow policy (the divergence that caused #188).
+    /// Generic over [`bytes::Buf`] so both `&[u8]` and [`Bytes`] callers reuse it.
+    pub fn decode_decimal<B: Buf>(
+        buf: &mut B,
+        type_info: &TypeInfo,
+    ) -> Result<SqlValue, TypeError> {
+        super::decode_decimal(buf, type_info)
+    }
+
     /// Decode a SQL value based on type information.
     pub fn decode_value(buf: &mut Bytes, type_info: &TypeInfo) -> Result<SqlValue, TypeError> {
         match type_info.type_id {
@@ -539,7 +552,7 @@ fn decode_guid(buf: &mut Bytes) -> Result<SqlValue, TypeError> {
 }
 
 #[cfg(feature = "decimal")]
-fn decode_decimal(buf: &mut Bytes, type_info: &TypeInfo) -> Result<SqlValue, TypeError> {
+fn decode_decimal<B: Buf>(buf: &mut B, type_info: &TypeInfo) -> Result<SqlValue, TypeError> {
     use rust_decimal::Decimal;
 
     if buf.remaining() < 1 {
@@ -604,7 +617,7 @@ fn decode_decimal(buf: &mut Bytes, type_info: &TypeInfo) -> Result<SqlValue, Typ
 }
 
 #[cfg(not(feature = "decimal"))]
-fn decode_decimal(buf: &mut Bytes, _type_info: &TypeInfo) -> Result<SqlValue, TypeError> {
+fn decode_decimal<B: Buf>(buf: &mut B, _type_info: &TypeInfo) -> Result<SqlValue, TypeError> {
     // Skip decimal data and return as string
     if buf.remaining() < 1 {
         return Err(TypeError::BufferTooSmall {


### PR DESCRIPTION
## What

Step 3 of #204: make `column_parser` (mssql-client, the sole live decode path) and `mssql_types::decode::decode_value` (the secondary stack) share **one** implementation of the decode primitives that historically diverged — DECIMAL/NUMERIC and the scale-driven temporal family — instead of carrying hand-synced copies.

Two commits:

1. **DECIMAL/NUMERIC** — `decode_decimal` is made generic over `bytes::Buf`, exposed through the sealed `__private` surface (doc-hidden → off the cargo-public-api snapshot), and column_parser's decimal arm delegates to it. These copies already drifted once (#188); this removes the duplication.
2. **Temporal scale primitives** — `time_bytes_for_scale` (scale→wire-width) and `intervals_to_time` (100ns-interval → `NaiveTime`) were byte-identical in both files. They are now exposed via `__private` and imported into column_parser (main TIME/DATETIME2/DATETIMEOFFSET arms **and** the SQL_VARIANT sub-decoder), with the local copies deleted. Each stack keeps its own length framing — only the inner primitives are shared.

## Scope decisions (some deviate from the original plan — flagged for review)

- **Error bridge already existed.** The plan called for adding `From<TypeError> for Error`; it's already present (`Error::Type(#[from] …)`). The only real error-model change is that malformed decimal/temporal input now surfaces as `Error::Type` instead of `Error::Protocol`. `Error::Type` was **non-terminal** while `Error::Protocol` is terminal, so to preserve retry semantics this PR classifies `Error::Type` as terminal in `is_terminal` (a decode error never succeeds on retry).
- **datetime/smalldatetime intentionally NOT shared.** column_parser's `datetime_from_wire`/`smalldatetime_from_wire` are also consumed by the Always-Encrypted denormalize path (out of scope for #204 step 3). They carry no scale, so they aren't a drift risk. Sharing them would split their source or drag AE in. Left as a documented follow-up candidate.
- **Mechanism: shared primitives, not whole decoders.** For temporal, the genuinely divergence-prone logic is the scale math (`time_bytes_for_scale` + `intervals_to_time`), not the per-stack framing/dispatch. Sharing the primitives (rather than delegating the whole `decode_time`/etc.) keeps each stack's framing, avoids changing the `--no-default-features` placeholder strings and malformed-frame handling, and still eliminates the real drift surface.
- **Money / IntN / DATE** left duplicated (out of scope; not drift-prone).

### Feature-configuration convergence (corrected)
Both decode stacks now call **one** `decode_decimal`, so for any given feature configuration they produce identical results — including, when `decimal` is genuinely off, the same `"DECIMAL (feature disabled)"` placeholder (rather than the old lossy f64).

**Correction (per review):** an earlier revision of this PR claimed `mssql-client --no-default-features` would surface that placeholder. It does not — `mssql-client` depends on `mssql-types` without `default-features = false`, so `mssql-types/decimal` stays enabled via its default feature and the live path still decodes to `SqlValue::Decimal`. The durable guarantee is stack-convergence (above), not a reachable behavior change through mssql-client's own flags. Rewiring the dependency's default features is a broader change, intentionally left out of scope.

## Verification

Full local gate green: `just ci-all` (922 tests) + `just typos` + `just check-feature-flags` + `just public-api` + the full live ignored suite against SQL Server 2022 (**292 passed, 0 failed**, including the Always-Encrypted live round-trips).

Per the repo practice, both shared paths were falsified (seen red before trusting green):
- A deliberate sign bug in shared `decode_decimal` turned `numeric_grid` red.
- A deliberate scale-7 multiplier bug in shared `intervals_to_time` turned `time_scales`, `datetime2_scales`, and `datetimeoffset_offsets` red.

Both confirm column_parser drives the shared implementations.

## Note on CI
The advisory "Semver Check" job fails on every PR right now (main carries breaking changes queued for 0.19.0 vs published 0.18.0) — it's `continue-on-error`. Check `mergeable` (MERGEABLE), not that red advisory check.

Refs #204.
