### PR TITLE
fix(client): validate sp_executesql parameter and TVP type identifiers (#277)

### DIFF
--- a/crates/mssql-client/src/client/params.rs
+++ b/crates/mssql-client/src/client/params.rs
@@ -19,6 +19,7 @@ use tds_protocol::tvp::{TvpColumnDef as TvpWireColumnDef, TvpEncoder, TvpWireTyp
 
 use crate::error::{Error, Result};
 use crate::state::ConnectionState;
+use crate::validation::{validate_identifier, validate_qualified_identifier};
 
 use super::Client;
 
@@ -231,6 +232,10 @@ impl<S: ConnectionState> Client<S> {
                 } else {
                     format!("@{}", p.name)
                 };
+                // The name is interpolated verbatim into the `sp_executesql`
+                // `@params` declaration (`build_param_declarations`); validate it
+                // to prevent SQL injection via a crafted parameter name (#277).
+                validate_identifier(&name)?;
                 Self::sql_value_to_rpc_param(&name, &p.value, send_unicode, collation)
             })
             .collect()
@@ -247,6 +252,19 @@ impl<S: ConnectionState> Client<S> {
         tvp_data: &mssql_types::TvpData,
         collation: Option<&tds_protocol::token::Collation>,
     ) -> Result<RpcParam> {
+        // The TVP type name is interpolated verbatim into the `sp_executesql`
+        // `@params` declaration as `{name} READONLY` (`build_param_declarations`);
+        // validate it (schema-qualified `schema.Type` allowed) to prevent SQL
+        // injection via a crafted type name (#277). Delimited/bracketed names
+        // (`[My Type]`) are rejected, consistent with the rest of the driver's
+        // identifier handling.
+        let full_type_name = if tvp_data.schema.is_empty() {
+            tvp_data.type_name.clone()
+        } else {
+            format!("{}.{}", tvp_data.schema, tvp_data.type_name)
+        };
+        validate_qualified_identifier(&full_type_name)?;
+
         // Convert mssql-types column definitions to wire format
         let wire_columns: Vec<TvpWireColumnDef> = tvp_data
             .columns
@@ -294,15 +312,8 @@ impl<S: ConnectionState> Client<S> {
         // Encode end marker
         encoder.encode_end(&mut buf);
 
-        // Build the full TVP type name (schema.TypeName)
-        let full_type_name = if tvp_data.schema.is_empty() {
-            tvp_data.type_name.clone()
-        } else {
-            format!("{}.{}", tvp_data.schema, tvp_data.type_name)
-        };
-
-        // Create RPC param with TVP type info
-        // The type info includes the TVP type name for parameter declarations
+        // Create RPC param with TVP type info. The type info carries the
+        // (already-validated) TVP type name for the parameter declaration.
         let type_info = RpcTypeInfo::tvp(&full_type_name);
 
         Ok(RpcParam {
@@ -616,5 +627,36 @@ mod tests {
             &mut buf,
         )
         .expect_err("nested TVP cell must error");
+    }
+
+    /// #277: a crafted named-parameter name must be rejected before it is
+    /// interpolated into the `sp_executesql` `@params` declaration. A normal
+    /// name still converts.
+    #[test]
+    fn named_param_name_injection_is_rejected() {
+        let malicious = [crate::to_params::NamedParam::new(
+            "p1 int); DROP TABLE users; --",
+            SqlValue::Int(1),
+        )];
+        Client::<Ready>::convert_named_params(&malicious, true, None)
+            .expect_err("a parameter name carrying injection must be rejected");
+
+        let ok = [crate::to_params::NamedParam::new("p1", SqlValue::Int(1))];
+        Client::<Ready>::convert_named_params(&ok, true, None)
+            .expect("a normal parameter name must convert");
+    }
+
+    /// #277: a crafted TVP type name must be rejected before it is interpolated
+    /// as `{name} READONLY`. A schema-qualified name still converts (validation
+    /// runs before encoding, so the empty column set is irrelevant here).
+    #[test]
+    fn tvp_type_name_injection_is_rejected() {
+        let bad = mssql_types::TvpData::new("dbo", "T READONLY); DROP TABLE users; --");
+        Client::<Ready>::encode_tvp_param("@tvp", &bad, None)
+            .expect_err("a TVP type name carrying injection must be rejected");
+
+        let good = mssql_types::TvpData::new("dbo", "IntList");
+        Client::<Ready>::encode_tvp_param("@tvp", &good, None)
+            .expect("a schema-qualified TVP type name must convert");
     }
 }


### PR DESCRIPTION
Closes #277.

## What

`validate_identifier` was already wired into the bulk/savepoint/procedure paths, but **not** into the two user-controlled names that `tds_protocol::build_param_declarations` interpolates **verbatim** into the `sp_executesql` `@params` declaration:

1. **Named-parameter identifier** (`NamedParam.name`) — `@`-prefixed, user-supplied.
2. **TVP type name** — interpolated as `{name} READONLY`, including any schema qualifier.

Both are now validated at the **mssql-client conversion boundary** (`crates/mssql-client/src/client/params.rs`):
- `convert_named_params` → `validate_identifier(&name)` on the `@`-prefixed name.
- `encode_tvp_param` → `validate_qualified_identifier(&full_type_name)` (allows `schema.Type`) before any encoding (fail-fast).

## Why validate here, not in `build_param_declarations`

`build_param_declarations` lives in the lower-level `tds-protocol` crate, which can't call up into `mssql-client` where the validators live; it also returns `String` (infallible), so adding validation there would mean duplicating the validator into `tds-protocol` and/or breaking a public signature. Validating at the mssql-client boundary — where user input actually enters and where the existing validators already guard bulk/proc/savepoint names — is consistent and keeps the wire layer a raw building block.

## Scope (per the issue's corrected scope comment)

- ✅ Named parameter identifiers.
- ✅ TVP type names (schema-qualified allowed).
- ❌ TVP **column** names — written zero-length per MS-TDS (`tvp.rs`: `// ColName - MUST be zero-length`); nothing to inject.

Exposure was low (names are usually driver-generated `@p1` / derive field names, which pass validation), but this closes the gap for any caller-supplied name and makes identifier handling consistent across the codebase. **Behavior note:** delimited/bracketed type names (`[My Type]`) are now rejected, matching the rest of the driver's identifier handling.

## Verification

- New unit tests for both rejection paths (`named_param_name_injection_is_rejected`, `tvp_type_name_injection_is_rejected`), each with a valid-name pass-through. **Falsified red** by neutering each validation before trusting green.
- Full local gate: `ci-all` (922 tests), `check-feature-flags`, `typos`, `public-api`, plus the full live ignored suite against SQL Server 2022 (**292 passed**) — including all 7 live TVP tests and the live named-query path.
- No public-API change (validators and the changed fns are `pub(crate)`/private).

## Release context
Part of the v0.19.0 release-train work — this is one of the two security fixes (#277, #278) that gate the held Release PR #282. The advisory Semver Check will fail (continue-on-error, main carries queued breaking changes); check `mergeable`.