### PR TITLE
fix(protocol)!: reject unknown PRELOGIN encryption bytes instead of defaulting to Off (#278)

### DIFF
--- a/crates/tds-protocol/src/error.rs
+++ b/crates/tds-protocol/src/error.rs
@@ -31,6 +31,10 @@ pub enum ProtocolError {
     #[error("invalid prelogin option: {0:#x}")]
     InvalidPreloginOption(u8),
 
+    /// Invalid PRELOGIN encryption level byte.
+    #[error("invalid encryption level: {0:#x}")]
+    InvalidEncryptionLevel(u8),
+
     /// Invalid TDS version.
     #[error("invalid TDS version: {0:#x}")]
     InvalidTdsVersion(u32),

--- a/crates/tds-protocol/src/prelogin.rs
+++ b/crates/tds-protocol/src/prelogin.rs
@@ -75,15 +75,21 @@ pub enum EncryptionLevel {
 }
 
 impl EncryptionLevel {
-    /// Create from raw byte value.
-    pub fn from_u8(value: u8) -> Self {
+    /// Create from a raw byte value.
+    ///
+    /// Returns an error for an unrecognized byte rather than defaulting to
+    /// [`Self::Off`]: a garbage or unexpected encryption byte from the server
+    /// must not be silently read as "encryption off", which would mask a
+    /// downgrade or a malformed PRELOGIN response (#278). Mirrors the fallible
+    /// [`PreLoginOption::from_u8`].
+    pub fn from_u8(value: u8) -> Result<Self, ProtocolError> {
         match value {
-            0x00 => Self::Off,
-            0x01 => Self::On,
-            0x02 => Self::NotSupported,
-            0x03 => Self::Required,
-            0x80 => Self::ClientCertAuth,
-            _ => Self::Off,
+            0x00 => Ok(Self::Off),
+            0x01 => Ok(Self::On),
+            0x02 => Ok(Self::NotSupported),
+            0x03 => Ok(Self::Required),
+            0x80 => Ok(Self::ClientCertAuth),
+            _ => Err(ProtocolError::InvalidEncryptionLevel(value)),
         }
     }
 
@@ -407,7 +413,7 @@ impl PreLogin {
                     prelogin.version = TdsVersion::new(version_raw);
                 }
                 PreLoginOption::Encryption if length >= 1 => {
-                    prelogin.encryption = EncryptionLevel::from_u8(data[data_offset]);
+                    prelogin.encryption = EncryptionLevel::from_u8(data[data_offset])?;
                 }
                 PreLoginOption::Mars if length >= 1 => {
                     prelogin.mars = data[data_offset] != 0;
@@ -493,6 +499,33 @@ mod tests {
         );
         let decoded = PreLogin::decode(with.as_ref()).unwrap();
         assert!(decoded.fed_auth_required);
+    }
+
+    /// #278: an unrecognized PRELOGIN encryption byte must make decode fail,
+    /// not be silently read as ENCRYPT_OFF (which would mask a downgrade or a
+    /// malformed PRELOGIN response).
+    #[test]
+    fn test_prelogin_decode_rejects_unknown_encryption_byte() {
+        use bytes::BufMut;
+
+        let mut buf = bytes::BytesMut::new();
+        let header_size: u16 = 6; // one option header (5 bytes) + terminator (1)
+
+        // ENCRYPTION option header (type:1 + offset:2 + length:2)
+        buf.put_u8(PreLoginOption::Encryption as u8);
+        buf.put_u16(header_size); // offset to encryption data
+        buf.put_u16(1); // length
+        // Terminator
+        buf.put_u8(PreLoginOption::Terminator as u8);
+        // Data: an invalid encryption level byte
+        buf.put_u8(0x42);
+
+        let result = PreLogin::decode(buf.freeze().as_ref());
+        assert!(
+            matches!(result, Err(ProtocolError::InvalidEncryptionLevel(0x42))),
+            "an unknown encryption byte must be rejected as \
+             InvalidEncryptionLevel(0x42), not read as Off; got {result:?}"
+        );
     }
 
     #[test]

--- a/public-api/tds-protocol.txt
+++ b/public-api/tds-protocol.txt
@@ -285,6 +285,7 @@ pub tds_protocol::error::ProtocolError::IncompletePacket
 pub tds_protocol::error::ProtocolError::IncompletePacket::actual: usize
 pub tds_protocol::error::ProtocolError::IncompletePacket::expected: usize
 pub tds_protocol::error::ProtocolError::InvalidDataType(u8)
+pub tds_protocol::error::ProtocolError::InvalidEncryptionLevel(u8)
 pub tds_protocol::error::ProtocolError::InvalidField
 pub tds_protocol::error::ProtocolError::InvalidField::field: &'static str
 pub tds_protocol::error::ProtocolError::InvalidField::value: u32
@@ -900,7 +901,7 @@ pub tds_protocol::prelogin::EncryptionLevel::Off = 0
 pub tds_protocol::prelogin::EncryptionLevel::On = 1
 pub tds_protocol::prelogin::EncryptionLevel::Required = 3
 impl tds_protocol::prelogin::EncryptionLevel
-pub fn tds_protocol::prelogin::EncryptionLevel::from_u8(u8) -> Self
+pub fn tds_protocol::prelogin::EncryptionLevel::from_u8(u8) -> core::result::Result<Self, tds_protocol::error::ProtocolError>
 pub const fn tds_protocol::prelogin::EncryptionLevel::is_required(&self) -> bool
 impl core::clone::Clone for tds_protocol::prelogin::EncryptionLevel
 pub fn tds_protocol::prelogin::EncryptionLevel::clone(&self) -> tds_protocol::prelogin::EncryptionLevel
@@ -3071,7 +3072,7 @@ pub tds_protocol::EncryptionLevel::Off = 0
 pub tds_protocol::EncryptionLevel::On = 1
 pub tds_protocol::EncryptionLevel::Required = 3
 impl tds_protocol::prelogin::EncryptionLevel
-pub fn tds_protocol::prelogin::EncryptionLevel::from_u8(u8) -> Self
+pub fn tds_protocol::prelogin::EncryptionLevel::from_u8(u8) -> core::result::Result<Self, tds_protocol::error::ProtocolError>
 pub const fn tds_protocol::prelogin::EncryptionLevel::is_required(&self) -> bool
 impl core::clone::Clone for tds_protocol::prelogin::EncryptionLevel
 pub fn tds_protocol::prelogin::EncryptionLevel::clone(&self) -> tds_protocol::prelogin::EncryptionLevel
@@ -3462,6 +3463,7 @@ pub tds_protocol::ProtocolError::IncompletePacket
 pub tds_protocol::ProtocolError::IncompletePacket::actual: usize
 pub tds_protocol::ProtocolError::IncompletePacket::expected: usize
 pub tds_protocol::ProtocolError::InvalidDataType(u8)
+pub tds_protocol::ProtocolError::InvalidEncryptionLevel(u8)
 pub tds_protocol::ProtocolError::InvalidField
 pub tds_protocol::ProtocolError::InvalidField::field: &'static str
 pub tds_protocol::ProtocolError::InvalidField::value: u32


### PR DESCRIPTION
Closes #278.

## What

`EncryptionLevel::from_u8` mapped **any** unrecognized byte to `Self::Off` (`_ => Self::Off`), so a garbage or unexpected encryption byte from the server was silently read as "encryption off" — masking a potential downgrade or a malformed PRELOGIN response.

It now returns `Result<Self, ProtocolError>` and errors on an unknown byte via a new `ProtocolError::InvalidEncryptionLevel(u8)`, mirroring the sibling `PreLoginOption::from_u8`. `PreLogin::decode` propagates the error with `?`.

## Approach (chosen with maintainer)

The issue offered two paths; you chose the **direct fix** (make `from_u8` fallible) over adding a parallel `try_from_u8`. Rationale:
- It removes the footgun rather than leaving `from_u8 -> Self (unknown -> Off)` on the public API.
- It adds no parallel API and keeps `from_u8` consistent with `PreLoginOption::from_u8` (both `from_u8 -> Result`).
- `from_u8` has exactly one caller (the internal decode), so blast radius is minimal.

**This is a breaking change** to a public signature — acceptable this cycle since 0.19.0 already carries breaking markers. Commit carries `fix(protocol)!:` + a `BREAKING CHANGE:` footer, and the public-API snapshot is regenerated.

## Verification

- New regression test (`test_prelogin_decode_rejects_unknown_encryption_byte`): an invalid encryption byte makes `PreLogin::decode` fail with `InvalidEncryptionLevel`, not silently `Off`. **Falsified red** against the old `_ => Off` behavior before trusting green.
- Full local gate: `ci-all` (922 tests), `check-feature-flags`, `typos`, `public-api` (snapshot regenerated, diff is exactly the new variant + the `from_u8` return type), plus the full live ignored suite against SQL Server 2022 (**292 passed** — every connection exercises PRELOGIN decode with a valid encryption byte).

## Migration

`EncryptionLevel::from_u8` now returns `Result<Self, ProtocolError>`. Callers handle the error, or `.unwrap_or(EncryptionLevel::Off)` to keep the old lenient behavior.

## Release context

The second of the two security fixes (#277 merged, #278 here) that gate the held Release PR #282. Once this merges, #282 can be verified and merged to cut v0.19.0. The advisory Semver Check will fail (continue-on-error); check `mergeable`.