### PR TITLE
fix(types): gate test_encode_date behind the chrono feature (#302)

### DIFF
--- a/crates/mssql-types/src/encode.rs
+++ b/crates/mssql-types/src/encode.rs
@@ -612,6 +612,7 @@ mod tests {
         assert!(encode_datetime2(dt, &mut buf).is_err());
     }
 
+    #[cfg(feature = "chrono")]
     #[test]
     fn test_encode_date() {
         let mut buf = BytesMut::new();


### PR DESCRIPTION
Closes #302.

## What
`test_encode_date` (`crates/mssql-types/src/encode.rs`) uses `chrono::NaiveDate` / `encode_date` but lacked the `#[cfg(feature = "chrono")]` its sibling `test_encode_date_range_enforced` carries. So:

```
$ cargo test -p mssql-types --no-default-features --lib --no-run
error[E0433]: failed to resolve: use of unresolved module or unlinked crate `chrono`  encode.rs:618
error[E0425]: cannot find function `encode_date` in this scope                         encode.rs:619
```

## Why it was latent
CI's feature-flag job runs cargo-hack `--each-feature` (default + each single feature) — it never builds the bare `--no-default-features` **test** config, so this didn't surface in CI. Pure compile/test-config issue, no runtime impact.

## Fix
One line: add `#[cfg(feature = "chrono")]` to `test_encode_date`, matching the sibling.

## Verification
- **Falsified red→green:** the `--no-default-features --lib --no-run` build failed with the two errors above before the change, compiles after.
- `test_encode_date` still runs and passes under default/all-features (chrono on).
- `just ci-all`, `just check-feature-flags`, `just typos` all pass. (Live suite N/A — test-only `cfg` gate, no live path touched.)

First item of the v0.20.0 Batch-1 bug sweep; warm-up before the #300 perf anchor.