### PR TITLE
fix(release): exclude stray merge commits from the generated changelog

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -55,3 +55,25 @@ changelog_include = [
 ]
 
 # xtask and mssql-testing are `publish = false` and are skipped automatically.
+
+[changelog]
+# Skip merge commits from the generated CHANGELOG. release-plz folds GitHub's
+# own "Merge pull request #N" commits, but a stray local merge (e.g. "Merge
+# remote-tracking branch 'origin/main' into <branch>") slips through into the
+# "Other" section — that happened in v0.19.0. A "^Merge " skip covers both.
+#
+# NOTE: setting commit_parsers REPLACES release-plz's default set entirely (it
+# is not merged), so the Keep-a-Changelog defaults are reproduced in full below
+# with the skip prepended. Every other changelog field (body template, the
+# #NNN→PR-link preprocessor, release-commit folding) is left unset and keeps its
+# release-plz default.
+commit_parsers = [
+  { message = "^Merge ", skip = true },
+  { message = "^feat", group = "added" },
+  { message = "^changed", group = "changed" },
+  { message = "^deprecated", group = "deprecated" },
+  { message = "^removed", group = "removed" },
+  { message = "^fix", group = "fixed" },
+  { message = "^security", group = "security" },
+  { message = ".*", group = "other" },
+]


### PR DESCRIPTION
## What

Adds a `[changelog]` section to `release-plz.toml` that skips merge commits
(`^Merge `) from the generated CHANGELOG, while reproducing release-plz's full
Keep-a-Changelog default `commit_parsers` set.

Addresses the **merge-leak** direction of #184: the v0.19.0 entry leaked a raw
`- Merge remote-tracking branch 'origin/main' into …` line into the *Other*
section.

## Why this happens

release-plz folds GitHub's own `Merge pull request #N` commits, but a stray
local merge (e.g. updating a feature branch with `git merge origin/main`) is
**not** folded and falls through the default `.*` → *Other* parser. An explicit
`^Merge ` skip catches both forms and is version-independent.

Because `commit_parsers` **fully replaces** release-plz's default set (confirmed
in `release_plz_core` source — the field is used only when the user's is empty,
never merged), the full default parser set is reproduced here with the skip
prepended. All other changelog fields (body template, the `#NNN`→PR-link
preprocessor, release-commit folding) are left unset and keep their release-plz
defaults. This is a **no-squash** workflow, so merge commits never contribute a
changelog entry (the individual conventional commits do) — skipping them drops
nothing real.

## Verification

- **Engine-level (falsification):** ran `git-cliff 2.13.1` (the engine release-plz
  embeds) over `v0.18.0..v0.19.0` with a faithfully reconstructed release-plz
  config. Baseline reproduces the leak; with the `^Merge ` skip prepended, the
  diff shows **only** merge lines disappear — every real entry is byte-identical.
- **release-plz read-path:** ran `release-plz update` (CLI 0.3.159 — the exact
  version `release-plz/action@v0.5.130` installs) against synthetic nested-merge
  topologies; confirmed the config is honored and all real `fix(...)` entries
  survive.
- **Version timing:** the action was bumped to v0.5.130 (CLI 0.3.159) on
  2026-06-15, *before* v0.19.0 (06-17) — so the leak was produced by the same
  CLI version CI still runs, i.e. the bug is **live**, not already-fixed.

### Known verification limitation

The actual CI path is `release-plz release-pr` **with GitHub remote integration**;
the leak surfaces on that remote path (PR-folding), which I could not run locally
without a token / opening a real PR. The `^Merge ` skip is applied at git-cliff's
commit-classification layer (proven via the engine test) **independent** of the
remote PR-folding path, so it removes the merge commit regardless — but the
end-to-end remote run itself was not executed locally.

## Scope / non-goals

- Does **not** fix the *silent-drop* direction of #184 (v0.13.0 / PR #170's
  commits vanishing) — that is an upstream release-plz bug with no config fix,
  still covered by the pre-merge changelog-diff action item. **#184 stays open**
  for it; this PR uses `Refs`, not `Closes`.
- Deliberately omitted a speculative `^chore(release)` skip — release-plz already
  folds its own release commits, so it would be dead config.

## Tradeoff to flag

Overriding `commit_parsers` couples us to release-plz's current default parser
set: if release-plz ever changes its KAC defaults, our frozen copy silently
diverges. This is inherent to git-cliff's only merge-skip mechanism and is
documented inline in `release-plz.toml`.
