### PR TITLE
fix(protocol): decode malformed UCS-2 lossily instead of as a false EOF

### DIFF
--- a/crates/tds-protocol/src/codec.rs
+++ b/crates/tds-protocol/src/codec.rs
@@ -30,6 +30,11 @@ pub fn read_us_varchar(src: &mut impl Buf) -> Option<String> {
 }
 
 /// Read a UTF-16LE string of specified character length.
+///
+/// Malformed UCS-2 (e.g. an unpaired surrogate) is decoded lossily, with each
+/// invalid unit replaced by U+FFFD, rather than failing. This keeps `None`
+/// meaning unambiguously "not enough bytes in the buffer" so callers do not
+/// conflate a decode failure with end-of-input.
 pub fn read_utf16_string(src: &mut impl Buf, char_count: usize) -> Option<String> {
     let byte_count = char_count * 2;
     if src.remaining() < byte_count {
@@ -41,7 +46,7 @@ pub fn read_utf16_string(src: &mut impl Buf, char_count: usize) -> Option<String
         chars.push(src.get_u16_le());
     }
 
-    String::from_utf16(&chars).ok()
+    Some(String::from_utf16_lossy(&chars))
 }
 
 /// Write a length-prefixed UTF-16LE string (1-byte length).
@@ -91,7 +96,7 @@ pub fn utf16_byte_len(s: &str) -> usize {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use bytes::BytesMut;
@@ -122,5 +127,30 @@ mod tests {
     fn test_utf16_byte_len() {
         assert_eq!(utf16_byte_len("Hello"), 10);
         assert_eq!(utf16_byte_len("世界"), 4);
+    }
+
+    /// An unpaired surrogate is malformed UCS-2. It must decode lossily (to
+    /// U+FFFD) rather than returning `None`, so the result is distinguishable
+    /// from a short buffer (#276).
+    #[test]
+    fn test_utf16_unpaired_surrogate_is_lossy_not_none() {
+        let mut buf = BytesMut::new();
+        buf.put_u16_le(0x0041); // 'A'
+        buf.put_u16_le(0xD800); // lone high surrogate (no following low surrogate)
+        buf.put_u16_le(0x0042); // 'B'
+        let mut cursor = buf.freeze();
+
+        let decoded = read_utf16_string(&mut cursor, 3)
+            .expect("malformed UCS-2 must decode lossily, not return None");
+        assert_eq!(decoded, "A\u{FFFD}B");
+    }
+
+    /// A short buffer is the only remaining `None` case.
+    #[test]
+    fn test_utf16_short_buffer_is_none() {
+        let mut buf = BytesMut::new();
+        buf.put_u16_le(0x0041); // only 1 char of bytes
+        let mut cursor = buf.freeze();
+        assert!(read_utf16_string(&mut cursor, 2).is_none());
     }
 }


### PR DESCRIPTION
## What

Makes UCS-2 string decoding tolerate malformed input instead of failing with a
misleading end-of-input error. Closes #276.

## The bug

`read_utf16_string` (`crates/tds-protocol/src/codec.rs`) ended with
`String::from_utf16(&chars).ok()`. An unpaired surrogate made `from_utf16`
return `Err` → `None`, which is **indistinguishable** from the short-buffer
`None` returned earlier in the function. Callers (`read_b_varchar` /
`read_us_varchar`) map `None` to `ProtocolError::UnexpectedEof`, so a
valid-but-malformed string was reported as truncation.

## The fix (policy: LOSSY)

Switch to `String::from_utf16_lossy`: malformed units become U+FFFD and decoding
never fails. `None` now means **only** "not enough bytes in the buffer", so the
EOF conflation is gone. The `Option<String>` signature is unchanged
(**non-breaking**); all callers improve without modification.

## Verification

- New tests (confirmed **red→green** by temporarily restoring the old decode):
  - `test_utf16_unpaired_surrogate_is_lossy_not_none` — `A` + lone `0xD800` + `B`
    decodes to `"A\u{FFFD}B"` rather than `None`.
  - `test_utf16_short_buffer_is_none` — the remaining `None` case still holds.
- Full local gate green: `just ci-all` + `just typos` + `just check-feature-flags`
  + the live SQL Server 2022 ignored suite (292 ignored tests passed).
