### PR TITLE
docs(tls): correct false 'system root' certificate claims

### DIFF
--- a/crates/mssql-tls/src/config.rs
+++ b/crates/mssql-tls/src/config.rs
@@ -44,7 +44,8 @@ pub struct TlsConfig {
 
     /// Custom root certificates to trust.
     ///
-    /// If empty, the system root certificates are used.
+    /// If empty, the bundled webpki (Mozilla) root certificates are used. The
+    /// driver does not read the operating system trust store.
     pub root_certificates: Vec<CertificateDer<'static>>,
 
     /// Client authentication credentials for mutual TLS (TDS 8.0 client cert auth).

--- a/crates/mssql-tls/src/connector.rs
+++ b/crates/mssql-tls/src/connector.rs
@@ -231,10 +231,10 @@ impl TlsConnector {
         if config.trust_server_certificate {
             // When trusting all certificates, we still need a root store
             // but we'll use a custom verifier later
-            // For now, add system roots as a fallback
+            // For now, add the bundled webpki (Mozilla) roots as a fallback
             root_store.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
         } else if config.root_certificates.is_empty() {
-            // Use system root certificates
+            // Use the bundled webpki (Mozilla) root certificates
             root_store.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
         } else {
             // Use custom root certificates


### PR DESCRIPTION
## What

Corrects three doc/comment sites in `mssql-tls` that falsely claimed the
operating-system root certificate store is used. Closes #279.

## Why

The connector always loads `webpki_roots::TLS_SERVER_ROOTS` — the bundled
Mozilla CA set compiled into the binary — never the OS trust store. Three sites
said otherwise:

- `config.rs` — `TlsConfig::root_certificates` doc ("If empty, the system root
  certificates are used").
- `connector.rs` `build_root_store` — two comments ("add system roots as a
  fallback", "Use system root certificates").

(`default_tls_config`'s doc already correctly says "Mozilla root certificate
store", so it was left unchanged — the plan's "~4 sites" was actually 3.)

## Scope

**Docs-only**, no behavior change. Adding real OS/system trust-store support
(via `rustls-native-certs` / `rustls-platform-verifier`) is a separate,
mildly security-sensitive feature tracked in **#314**.

## Verification

Full local gate green: `just ci-all` (incl. `cargo doc -D warnings`) + `just typos`
+ `just check-feature-flags` + the live SQL Server 2022 ignored suite.
