### PR TITLE
perf(client): share column metadata across rows in buffered decode (#300)

### DIFF
--- a/crates/mssql-client/src/blob_stream.rs
+++ b/crates/mssql-client/src/blob_stream.rs
@@ -72,7 +72,7 @@ pub struct BlobStream<'a, S: ConnectionState = Ready> {
     /// Metadata for just the leading scalar columns (for row decoding).
     prefix_meta: ColMetaData,
     /// `Column`s for the leading scalar columns.
-    scalar_columns: Vec<Column>,
+    scalar_row_meta: std::sync::Arc<crate::row::ColMetaData>,
     /// Index of the trailing MAX column.
     blob_index: usize,
     /// PLP decoder for the current row's blob; `Some` between `next` and drain.
@@ -103,7 +103,7 @@ impl<'a, S: ConnectionState> BlobStream<'a, S> {
             encryption_enabled,
             meta,
             prefix_meta,
-            scalar_columns,
+            scalar_row_meta: std::sync::Arc::new(crate::row::ColMetaData::new(scalar_columns)),
             blob_index,
             plp: None,
             blob_null: false,
@@ -121,7 +121,7 @@ impl<'a, S: ConnectionState> BlobStream<'a, S> {
     /// trailing MAX column.
     #[must_use]
     pub fn columns(&self) -> &[Column] {
-        &self.scalar_columns
+        &self.scalar_row_meta.columns
     }
 
     /// Advance to the next row, returning its scalar columns.
@@ -230,7 +230,7 @@ impl<'a, S: ConnectionState> BlobStream<'a, S> {
                     let row = crate::column_parser::convert_raw_row(
                         &raw,
                         &self.prefix_meta,
-                        &self.scalar_columns,
+                        &self.scalar_row_meta,
                     )?;
                     self.plp = Some(PlpDecoder::new());
                     self.blob_null = false;
@@ -257,7 +257,7 @@ impl<'a, S: ConnectionState> BlobStream<'a, S> {
                     let row = crate::column_parser::convert_nbc_row(
                         &nbc,
                         &self.prefix_meta,
-                        &self.scalar_columns,
+                        &self.scalar_row_meta,
                     )?;
                     self.blob_null = blob_null;
                     self.plp = if blob_null {

--- a/crates/mssql-client/src/column_parser.rs
+++ b/crates/mssql-client/src/column_parser.rs
@@ -24,6 +24,8 @@
 // `smalldatetime_from_wire` / `datetime_from_wire`).
 #![allow(clippy::unwrap_used, clippy::expect_used, clippy::needless_range_loop)]
 
+use std::sync::Arc;
+
 use bytes::Buf;
 use mssql_types::SqlValue;
 // Scale primitives shared with the secondary decode stack (`mssql_types::decode`)
@@ -83,7 +85,7 @@ fn datetime_from_wire(days: i64, time_300ths: u64) -> Result<chrono::NaiveDateTi
 pub(crate) fn convert_raw_row(
     raw: &RawRow,
     meta: &ColMetaData,
-    columns: &[crate::row::Column],
+    row_meta: &Arc<crate::row::ColMetaData>,
 ) -> Result<crate::row::Row> {
     let mut values = Vec::with_capacity(meta.columns.len());
     let mut buf = raw.data.as_ref();
@@ -93,7 +95,10 @@ pub(crate) fn convert_raw_row(
         values.push(value);
     }
 
-    Ok(crate::row::Row::from_values(columns.to_vec(), values))
+    Ok(crate::row::Row::from_values_shared(
+        Arc::clone(row_meta),
+        values,
+    ))
 }
 
 /// Convert an NbcRow to a client Row.
@@ -102,7 +107,7 @@ pub(crate) fn convert_raw_row(
 pub(crate) fn convert_nbc_row(
     nbc: &NbcRow,
     meta: &ColMetaData,
-    columns: &[crate::row::Column],
+    row_meta: &Arc<crate::row::ColMetaData>,
 ) -> Result<crate::row::Row> {
     let mut values = Vec::with_capacity(meta.columns.len());
     let mut buf = nbc.data.as_ref();
@@ -116,7 +121,10 @@ pub(crate) fn convert_nbc_row(
         }
     }
 
-    Ok(crate::row::Row::from_values(columns.to_vec(), values))
+    Ok(crate::row::Row::from_values_shared(
+        Arc::clone(row_meta),
+        values,
+    ))
 }
 
 /// Convert a RawRow to a client Row with Always Encrypted decryption.
@@ -131,7 +139,7 @@ pub(crate) fn convert_nbc_row(
 pub(crate) fn convert_raw_row_decrypted(
     raw: &RawRow,
     meta: &ColMetaData,
-    columns: &[crate::row::Column],
+    row_meta: &Arc<crate::row::ColMetaData>,
     decryptor: &crate::column_decryptor::ColumnDecryptor,
 ) -> Result<crate::row::Row> {
     let mut values = Vec::with_capacity(meta.columns.len());
@@ -146,7 +154,10 @@ pub(crate) fn convert_raw_row_decrypted(
         values.push(value);
     }
 
-    Ok(crate::row::Row::from_values(columns.to_vec(), values))
+    Ok(crate::row::Row::from_values_shared(
+        Arc::clone(row_meta),
+        values,
+    ))
 }
 
 /// Convert an NbcRow to a client Row with Always Encrypted decryption.
@@ -156,7 +167,7 @@ pub(crate) fn convert_raw_row_decrypted(
 pub(crate) fn convert_nbc_row_decrypted(
     nbc: &NbcRow,
     meta: &ColMetaData,
-    columns: &[crate::row::Column],
+    row_meta: &Arc<crate::row::ColMetaData>,
     decryptor: &crate::column_decryptor::ColumnDecryptor,
 ) -> Result<crate::row::Row> {
     let mut values = Vec::with_capacity(meta.columns.len());
@@ -175,7 +186,10 @@ pub(crate) fn convert_nbc_row_decrypted(
         }
     }
 
-    Ok(crate::row::Row::from_values(columns.to_vec(), values))
+    Ok(crate::row::Row::from_values_shared(
+        Arc::clone(row_meta),
+        values,
+    ))
 }
 
 /// Decrypt an encrypted column value and re-parse it as the plaintext type.

--- a/crates/mssql-client/src/lib.rs
+++ b/crates/mssql-client/src/lib.rs
@@ -168,7 +168,7 @@ pub mod __bench {
     #[must_use]
     pub fn decode_buffered_response(bytes: Bytes) -> Vec<Row> {
         let mut parser = TokenParser::new(bytes);
-        let mut columns = Vec::new();
+        let mut row_meta = std::sync::Arc::new(crate::row::ColMetaData::new(Vec::new()));
         let mut meta = None;
         let mut rows = Vec::new();
         while let Some(token) = parser
@@ -177,13 +177,15 @@ pub mod __bench {
         {
             match token {
                 Token::ColMetaData(m) => {
-                    columns = Client::<Ready>::build_columns(&m);
+                    row_meta = std::sync::Arc::new(crate::row::ColMetaData::new(
+                        Client::<Ready>::build_columns(&m),
+                    ));
                     meta = Some(m);
                 }
                 Token::Row(raw) => {
                     let m = meta.as_ref().expect("ColMetaData precedes ROW tokens");
                     rows.push(
-                        crate::column_parser::convert_raw_row(&raw, m, &columns)
+                        crate::column_parser::convert_raw_row(&raw, m, &row_meta)
                             .expect("benchmark row must convert"),
                     );
                 }

--- a/crates/mssql-client/src/row.rs
+++ b/crates/mssql-client/src/row.rs
@@ -333,7 +333,15 @@ impl Row {
     /// This constructor supports existing code that works with `SqlValue` directly.
     /// It's less efficient than the buffer-based approach but maintains compatibility.
     pub fn from_values(columns: Vec<Column>, values: Vec<SqlValue>) -> Self {
-        let metadata = Arc::new(ColMetaData::new(columns));
+        Self::from_values_shared(Arc::new(ColMetaData::new(columns)), values)
+    }
+
+    /// Like [`Row::from_values`], but shares an already-built
+    /// `Arc<ColMetaData>` rather than cloning a `Vec<Column>` and rebuilding
+    /// the metadata for every row. Every row in a result set has identical
+    /// columns, so the decode path builds the metadata once per result set and
+    /// hands each row a cheap `Arc` clone of it (#300).
+    pub(crate) fn from_values_shared(metadata: Arc<ColMetaData>, values: Vec<SqlValue>) -> Self {
         let slices: Arc<[ColumnSlice]> = values
             .iter()
             .enumerate()

--- a/crates/mssql-client/src/row_stream.rs
+++ b/crates/mssql-client/src/row_stream.rs
@@ -23,6 +23,8 @@
 //! # }
 //! ```
 
+use std::sync::Arc;
+
 use tds_protocol::token::{ColMetaData, Token};
 
 use crate::Client;
@@ -51,7 +53,7 @@ pub struct RowStream<'a, S: ConnectionState = Ready> {
     /// The incremental token decoder over the rolling packet buffer.
     source: RowSource,
     /// Columns for the current result set (rebuilt on each ColMetaData).
-    columns: Vec<Column>,
+    row_meta: Arc<crate::row::ColMetaData>,
     /// Protocol metadata for decoding raw rows of the current result set.
     meta: ColMetaData,
     /// Pre-resolved column decryptor for the current Always Encrypted result set.
@@ -76,7 +78,7 @@ impl<'a, S: ConnectionState> RowStream<'a, S> {
         Self {
             client,
             source,
-            columns,
+            row_meta: Arc::new(crate::row::ColMetaData::new(columns)),
             meta,
             #[cfg(feature = "always-encrypted")]
             decryptor,
@@ -90,7 +92,7 @@ impl<'a, S: ConnectionState> RowStream<'a, S> {
         Self {
             client,
             source: RowSource::new(false),
-            columns: Vec::new(),
+            row_meta: Arc::new(crate::row::ColMetaData::new(Vec::new())),
             meta: ColMetaData::default(),
             #[cfg(feature = "always-encrypted")]
             decryptor: None,
@@ -101,7 +103,7 @@ impl<'a, S: ConnectionState> RowStream<'a, S> {
     /// The columns of the current result set.
     #[must_use]
     pub fn columns(&self) -> &[Column] {
-        &self.columns
+        &self.row_meta.columns
     }
 
     /// Whether the stream has been fully consumed.
@@ -207,7 +209,9 @@ impl<'a, S: ConnectionState> RowStream<'a, S> {
 
     /// Adopt a new result set's metadata mid-stream (multi-statement batch).
     async fn switch_result_set(&mut self, meta: ColMetaData) -> Result<()> {
-        self.columns = Client::<S>::build_columns(&meta);
+        self.row_meta = Arc::new(crate::row::ColMetaData::new(Client::<S>::build_columns(
+            &meta,
+        )));
         #[cfg(feature = "always-encrypted")]
         {
             self.decryptor = self
@@ -227,11 +231,11 @@ impl<'a, S: ConnectionState> RowStream<'a, S> {
             return crate::column_parser::convert_raw_row_decrypted(
                 raw,
                 &self.meta,
-                &self.columns,
+                &self.row_meta,
                 dec,
             );
         }
-        crate::column_parser::convert_raw_row(raw, &self.meta, &self.columns)
+        crate::column_parser::convert_raw_row(raw, &self.meta, &self.row_meta)
     }
 
     /// Decode a null-bitmap-compressed row against the current metadata.
@@ -241,10 +245,10 @@ impl<'a, S: ConnectionState> RowStream<'a, S> {
             return crate::column_parser::convert_nbc_row_decrypted(
                 nbc,
                 &self.meta,
-                &self.columns,
+                &self.row_meta,
                 dec,
             );
         }
-        crate::column_parser::convert_nbc_row(nbc, &self.meta, &self.columns)
+        crate::column_parser::convert_nbc_row(nbc, &self.meta, &self.row_meta)
     }
 }

--- a/crates/mssql-client/src/stream.rs
+++ b/crates/mssql-client/src/stream.rs
@@ -34,6 +34,7 @@
 
 use std::collections::VecDeque;
 use std::pin::Pin;
+use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures_core::Stream;
@@ -86,7 +87,7 @@ pub(crate) enum PendingRow {
 #[must_use = "streams must be consumed; dropping a stream discards remaining rows"]
 pub struct QueryStream<'a> {
     /// Column metadata for the result set.
-    columns: Vec<Column>,
+    row_meta: Arc<crate::row::ColMetaData>,
     /// Buffered rows (typed or raw) from the response.
     rows: VecDeque<PendingRow>,
     /// Protocol metadata needed to decode raw rows. `None` if every pending
@@ -114,7 +115,7 @@ impl QueryStream<'_> {
     #[cfg(test)]
     pub(crate) fn new(columns: Vec<Column>, rows: Vec<Row>) -> Self {
         Self {
-            columns,
+            row_meta: Arc::new(crate::row::ColMetaData::new(columns)),
             rows: rows.into_iter().map(PendingRow::Parsed).collect(),
             meta: None,
             #[cfg(feature = "always-encrypted")]
@@ -138,7 +139,7 @@ impl QueryStream<'_> {
         >,
     ) -> Self {
         Self {
-            columns,
+            row_meta: Arc::new(crate::row::ColMetaData::new(columns)),
             rows: pending.into(),
             meta: Some(meta),
             #[cfg(feature = "always-encrypted")]
@@ -152,7 +153,7 @@ impl QueryStream<'_> {
     #[allow(dead_code)]
     pub(crate) fn empty() -> Self {
         Self {
-            columns: Vec::new(),
+            row_meta: Arc::new(crate::row::ColMetaData::new(Vec::new())),
             rows: VecDeque::new(),
             meta: None,
             #[cfg(feature = "always-encrypted")]
@@ -165,7 +166,7 @@ impl QueryStream<'_> {
     /// Get the column metadata for this result set.
     #[must_use]
     pub fn columns(&self) -> &[Column] {
-        &self.columns
+        &self.row_meta.columns
     }
 
     /// Check if the stream has finished.
@@ -221,11 +222,11 @@ impl QueryStream<'_> {
                     return crate::column_parser::convert_raw_row_decrypted(
                         &raw,
                         meta,
-                        &self.columns,
+                        &self.row_meta,
                         dec,
                     );
                 }
-                crate::column_parser::convert_raw_row(&raw, meta, &self.columns)
+                crate::column_parser::convert_raw_row(&raw, meta, &self.row_meta)
             }
             PendingRow::Nbc(nbc) => {
                 let meta = self
@@ -237,11 +238,11 @@ impl QueryStream<'_> {
                     return crate::column_parser::convert_nbc_row_decrypted(
                         &nbc,
                         meta,
-                        &self.columns,
+                        &self.row_meta,
                         dec,
                     );
                 }
-                crate::column_parser::convert_nbc_row(&nbc, meta, &self.columns)
+                crate::column_parser::convert_nbc_row(&nbc, meta, &self.row_meta)
             }
         }
     }
@@ -460,7 +461,7 @@ impl ProcedureResult {
 #[must_use]
 pub struct ResultSet {
     /// Column metadata for this result set.
-    columns: Vec<Column>,
+    row_meta: Arc<crate::row::ColMetaData>,
     /// Pending rows — either pre-parsed or raw TDS bytes awaiting decode.
     pending_rows: VecDeque<PendingRow>,
     /// Protocol metadata required to decode raw rows. `None` when every
@@ -482,7 +483,7 @@ impl ResultSet {
     /// (private) to defer row decoding.
     pub fn new(columns: Vec<Column>, rows: Vec<Row>) -> Self {
         Self {
-            columns,
+            row_meta: Arc::new(crate::row::ColMetaData::new(columns)),
             pending_rows: rows.into_iter().map(PendingRow::Parsed).collect(),
             meta: None,
             #[cfg(feature = "always-encrypted")]
@@ -505,7 +506,7 @@ impl ResultSet {
         >,
     ) -> Self {
         Self {
-            columns,
+            row_meta: Arc::new(crate::row::ColMetaData::new(columns)),
             pending_rows: pending.into(),
             meta: Some(meta),
             #[cfg(feature = "always-encrypted")]
@@ -516,7 +517,7 @@ impl ResultSet {
     /// Get the column metadata.
     #[must_use]
     pub fn columns(&self) -> &[Column] {
-        &self.columns
+        &self.row_meta.columns
     }
 
     /// Get the number of rows remaining.
@@ -565,11 +566,11 @@ impl ResultSet {
                     return crate::column_parser::convert_raw_row_decrypted(
                         &raw,
                         meta,
-                        &self.columns,
+                        &self.row_meta,
                         dec,
                     );
                 }
-                crate::column_parser::convert_raw_row(&raw, meta, &self.columns)
+                crate::column_parser::convert_raw_row(&raw, meta, &self.row_meta)
             }
             PendingRow::Nbc(nbc) => {
                 let meta = self
@@ -581,11 +582,11 @@ impl ResultSet {
                     return crate::column_parser::convert_nbc_row_decrypted(
                         &nbc,
                         meta,
-                        &self.columns,
+                        &self.row_meta,
                         dec,
                     );
                 }
-                crate::column_parser::convert_nbc_row(&nbc, meta, &self.columns)
+                crate::column_parser::convert_nbc_row(&nbc, meta, &self.row_meta)
             }
         }
     }
@@ -597,7 +598,7 @@ impl ResultSet {
     /// materializing rows when the caller wants stream-level ergonomics.
     fn into_query_stream<'a>(self) -> QueryStream<'a> {
         QueryStream {
-            columns: self.columns,
+            row_meta: self.row_meta,
             rows: self.pending_rows,
             meta: self.meta,
             #[cfg(feature = "always-encrypted")]


### PR DESCRIPTION
## What

Step 1 of #300: eliminate the dominant per-row allocation on the buffered
read path by sharing column metadata across rows. **64.5% fewer allocations.**
`Refs #300` (more steps to come).

## The cost

`convert_raw_row` built each `Row` via `Row::from_values(columns.to_vec(), ..)`.
That cloned the entire `Vec<Column>` — and each `Column`'s two owned `String`s
(`name`, `type_name`) — **for every row**, then `from_values` rebuilt an
`Arc<ColMetaData>` per row. Every row in a result set has identical columns, so
this was pure waste and the single largest allocation source the bench flagged.

## The fix

Build the `Arc<ColMetaData>` **once per result set** and hand each row a cheap
`Arc` clone:

- Add `pub(crate) Row::from_values_shared(Arc<ColMetaData>, values)`;
  `from_values` now delegates to it (no duplication).
- The four `convert_*` functions take `&Arc<ColMetaData>` instead of `&[Column]`.
- `QueryStream` / `ResultSet` / `RowStream` / `BlobStream` store
  `row_meta: Arc<ColMetaData>` instead of `columns: Vec<Column>`; the public
  `columns()` accessors derive `&[Column]` from it.

**No public API change** (all internal / `pub(crate)`; the public `columns()`
signatures are unchanged), so no public-api snapshot churn.

## Measurement (the #300 step-0 bench)

```
                   allocations    bytes/row
before (main)        203,017       21,619
after  (this PR)      72,021        9,623
                     -64.5%         -55.5%
```

`cargo bench -p mssql-client --bench buffered_decode --features bench`.

## Verification

Full local gate green: `just ci-all` + `just typos` + `just check-feature-flags`
+ the live SQL Server 2022 ignored suite (932 unit + 292 ignored tests). The
differential type matrix (#203) and `streaming_memory` peak-memory bounds are the
correctness net for a decode-path change; both pass. Behavior is unchanged — rows
decode identically; only the metadata ownership is shared.

## Next

Remaining #300 steps (later PRs): the per-row `RawRow` `BytesMut` + the
byte-at-a-time cell copy in `RawRow::decode`; the per-row `Vec<SqlValue>` /
slices / values `Arc`s and the empty-buffer `Arc<Bytes>`; and cell zero-copy
slices into the row `Bytes`. The ~72 remaining allocs/row are mostly per-cell
`String`/`Vec` and the row-level `Arc`s.
