### PR TITLE
fix(types): harden date construction against overflow panic (#309)

### DIFF
--- a/crates/mssql-client/src/column_parser.rs
+++ b/crates/mssql-client/src/column_parser.rs
@@ -806,7 +806,11 @@ pub fn parse_column_value(buf: &mut &[u8], col: &ColumnData) -> Result<SqlValue>
                 {
                     let base = chrono::NaiveDate::from_ymd_opt(1, 1, 1)
                         .expect("epoch 0001-01-01 is valid");
-                    let date = base + chrono::Duration::days(days as i64);
+                    let date = base
+                        .checked_add_signed(chrono::Duration::days(days as i64))
+                        .ok_or_else(|| {
+                            Error::Protocol(format!("date field days out of range: {days}"))
+                        })?;
                     SqlValue::Date(date)
                 }
                 #[cfg(not(feature = "chrono"))]
@@ -884,7 +888,11 @@ pub fn parse_column_value(buf: &mut &[u8], col: &ColumnData) -> Result<SqlValue>
                 {
                     let base = chrono::NaiveDate::from_ymd_opt(1, 1, 1)
                         .expect("epoch 0001-01-01 is valid");
-                    let date = base + chrono::Duration::days(days as i64);
+                    let date = base
+                        .checked_add_signed(chrono::Duration::days(days as i64))
+                        .ok_or_else(|| {
+                            Error::Protocol(format!("date field days out of range: {days}"))
+                        })?;
                     let time = intervals_to_time(intervals, scale);
                     SqlValue::DateTime(date.and_time(time))
                 }
@@ -940,7 +948,11 @@ pub fn parse_column_value(buf: &mut &[u8], col: &ColumnData) -> Result<SqlValue>
                     use chrono::TimeZone;
                     let base = chrono::NaiveDate::from_ymd_opt(1, 1, 1)
                         .expect("epoch 0001-01-01 is valid");
-                    let date = base + chrono::Duration::days(days as i64);
+                    let date = base
+                        .checked_add_signed(chrono::Duration::days(days as i64))
+                        .ok_or_else(|| {
+                            Error::Protocol(format!("date field days out of range: {days}"))
+                        })?;
                     let time = intervals_to_time(intervals, scale);
                     let offset = chrono::FixedOffset::east_opt((offset_minutes as i32) * 60)
                         .unwrap_or_else(|| {
@@ -1534,7 +1546,11 @@ fn parse_sql_variant(buf: &mut &[u8]) -> Result<SqlValue> {
                 let days = u32::from_le_bytes(date_bytes);
                 let base =
                     chrono::NaiveDate::from_ymd_opt(1, 1, 1).expect("epoch 0001-01-01 is valid");
-                let date = base + chrono::Duration::days(days as i64);
+                let date = base
+                    .checked_add_signed(chrono::Duration::days(days as i64))
+                    .ok_or_else(|| {
+                        Error::Protocol(format!("date field days out of range: {days}"))
+                    })?;
                 Ok(SqlValue::Date(date))
             }
             #[cfg(not(feature = "chrono"))]
@@ -1606,7 +1622,11 @@ fn parse_sql_variant(buf: &mut &[u8]) -> Result<SqlValue> {
 
                 let base =
                     chrono::NaiveDate::from_ymd_opt(1, 1, 1).expect("epoch 0001-01-01 is valid");
-                let date = base + chrono::Duration::days(days as i64);
+                let date = base
+                    .checked_add_signed(chrono::Duration::days(days as i64))
+                    .ok_or_else(|| {
+                        Error::Protocol(format!("date field days out of range: {days}"))
+                    })?;
                 let time = intervals_to_time(intervals, scale);
                 Ok(SqlValue::DateTime(date.and_time(time)))
             }
@@ -1650,7 +1670,11 @@ fn parse_sql_variant(buf: &mut &[u8]) -> Result<SqlValue> {
                 use chrono::TimeZone;
                 let base =
                     chrono::NaiveDate::from_ymd_opt(1, 1, 1).expect("epoch 0001-01-01 is valid");
-                let date = base + chrono::Duration::days(days as i64);
+                let date = base
+                    .checked_add_signed(chrono::Duration::days(days as i64))
+                    .ok_or_else(|| {
+                        Error::Protocol(format!("date field days out of range: {days}"))
+                    })?;
                 let time = intervals_to_time(intervals, scale);
                 let offset = chrono::FixedOffset::east_opt((offset_minutes as i32) * 60)
                     .unwrap_or_else(|| {


### PR DESCRIPTION
## What

Part 1 of #309: guard the six date-component constructions against an overflow
panic. `Refs #309` — the parser-decompose part (item 2) is intentionally left
for a separate, dedicated change.

## The hazard

`parse_column_value` and `parse_sql_variant` built the DATE / DATETIME2 /
DATETIMEOFFSET date component with an unchecked add:

```rust
let date = base + chrono::Duration::days(days as i64);
```

`days` comes from a 3-byte wire field, so it cannot currently overflow
`NaiveDate` (unreachable today), but the unchecked `+` is a latent panic hazard
if the framing ever changes.

## The fix

All six sites now use:

```rust
let date = base
    .checked_add_signed(chrono::Duration::days(days as i64))
    .ok_or_else(|| Error::Protocol(format!("date field days out of range: {days}")))?;
```

returning a protocol error instead of panicking — matching the already-hardened
`datetime_from_wire` / `smalldatetime_from_wire` helpers. **No behavior change
for any reachable input** (`checked_add_signed` returns `Some` for every value
the 3-byte field can produce, identical to `+`).

## Verification

No new test: the happy path is unchanged and covered by the existing date tests
and the #203 differential type matrix; the error path is unreachable by
construction (can't be exercised through the 3-byte field). Full local gate green:
`just ci-all` + `just typos` + `just check-feature-flags` + the live SQL Server
2022 ignored suite (incl. the #203 date matrix).

## Deferred (item 2 of #309)

Decomposing `parse_column_value` (~779 lines) and `parse_sql_variant` (~395
lines) into per-type helpers is a large, behavior-preserving refactor of a hot,
correctness-critical path with no functional benefit. It warrants its own
focused change rather than riding along with this correctness fix, so #309 stays
open for it.
