### PR TITLE
Release & dependency hygiene: #305, #206, #184

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -648,3 +648,19 @@ jobs:
             exit 1
           fi
           echo "No ignored BREAKING body lines in PR commit range."
+
+  changelog-completeness:
+    name: Changelog Completeness
+    # Release-PR-only: release-plz can silently drop non-merge commits from a
+    # generated CHANGELOG section while bumping the version correctly (issue
+    # #184: PR #170 in v0.13.0; recurred in v0.19.0). This guard diffs the
+    # pending `## [X.Y.Z]` section against the commits the release covers and
+    # fails if a published-crate commit is missing.
+    if: github.event_name == 'pull_request' && startsWith(github.head_ref, 'release-plz-')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Check the pending CHANGELOG section is complete
+        run: bash scripts/check-changelog-completeness.sh "${{ github.event.pull_request.base.sha }}"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -262,8 +262,14 @@ Rules for agents: **never run `cargo publish`, never create version tags, never 
   empty commit has no effect — the marker must touch the affected crate
   (PR #201 used a genuine doc improvement).
 - **Changelog completeness**: release-plz has dropped commits from generated
-  CHANGELOG entries before (#184, v0.13.0). Diff the entries against
-  `git log` since the last tag.
+  CHANGELOG entries before (#184, v0.13.0; recurred in v0.19.0). The
+  **Changelog Completeness** CI job (`scripts/check-changelog-completeness.sh`)
+  now guards this automatically on the Release PR — it diffs the pending
+  `## [X.Y.Z]` section against the published-crate commits in
+  `<last-tag>..main` and fails on any missing entry. Run it locally on a
+  Release PR branch with `bash scripts/check-changelog-completeness.sh`. It is
+  a no-op off a Release PR (self-gates on the top section being ahead of the
+  latest tag), so a red result is a real gap: restore the entries by hand.
 
 `just doc-consistency` (also a CI gate) verifies MSRV references agree across files, CHANGELOG matches the workspace version, deny.toml/audit.toml ignore lists stay in sync, and first-party dependency snippets in README/docs match the workspace version.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,13 @@ categories = ["database"]
 #   Primary (user-facing): mssql-client (main API), mssql-driver-pool (connection pooling)
 #   Internal (implementation): tds-protocol, mssql-types, mssql-tls, mssql-codec, mssql-auth, mssql-derive
 #   Dev-only (publish = false): mssql-testing
-tds-protocol = { version = "0.19.1", path = "crates/tds-protocol" }
+# default-features = false on the two crates with non-empty defaults (#305) so a
+# downstream `--no-default-features` build can shed their type/encoding features;
+# inheriting members forward what they need via `features = [...]`.
+tds-protocol = { version = "0.19.1", path = "crates/tds-protocol", default-features = false }
 mssql-tls = { version = "0.19.1", path = "crates/mssql-tls" }
 mssql-codec = { version = "0.19.1", path = "crates/mssql-codec" }
-mssql-types = { version = "0.19.1", path = "crates/mssql-types" }
+mssql-types = { version = "0.19.1", path = "crates/mssql-types", default-features = false }
 mssql-auth = { version = "0.19.1", path = "crates/mssql-auth" }
 mssql-driver-pool = { version = "0.19.1", path = "crates/mssql-pool" }
 mssql-client = { version = "0.19.1", path = "crates/mssql-client" }

--- a/crates/mssql-client/Cargo.toml
+++ b/crates/mssql-client/Cargo.toml
@@ -63,7 +63,12 @@ tls = ["dep:mssql-tls"]
 filestream = ["tokio/fs"]
 
 [dependencies]
-tds-protocol = { workspace = true }
+# tds-protocol and mssql-types disable default features at the workspace root
+# (#305) so a downstream `--no-default-features` build of mssql-client can shed
+# the upstream type/codec features. The needed features are forwarded
+# explicitly: `std` unconditionally here (mssql-client is a std crate), and
+# `encoding`/`chrono`/`uuid`/`decimal`/`json` via mssql-client's own features.
+tds-protocol = { workspace = true, features = ["std"] }
 mssql-tls = { workspace = true, optional = true }
 mssql-codec = { workspace = true }
 mssql-types = { workspace = true }

--- a/crates/mssql-client/tests/bulk_insert.rs
+++ b/crates/mssql-client/tests/bulk_insert.rs
@@ -2965,3 +2965,108 @@ async fn test_bulk_insert_rejects_image_column_from_server_metadata() {
 
     client.close().await.expect("Failed to close");
 }
+
+// =============================================================================
+// Command-Timeout on the Data-Transfer Path (Issue #206)
+// =============================================================================
+
+/// Issue #206: the bulk-transfer `finish()` data phase runs under
+/// `command_timeout` as a *hard abandon* — an ATTENTION cancel cannot be
+/// interleaved into a partially-sent BulkLoad message, so on expiry the
+/// connection is left mid-request and discarded. The setup round-trips have
+/// live timeout coverage at the shared-plumbing level; this exercises the
+/// distinct `finish()` path.
+///
+/// Choreography: a second connection holds an exclusive lock on the target
+/// table inside an open transaction, so the BulkLoad data phase blocks until
+/// the 1s timeout fires and returns `Error::CommandTimeout`.
+#[tokio::test]
+#[ignore = "Requires SQL Server"]
+async fn test_bulk_finish_command_timeout() {
+    use std::time::{Duration, Instant};
+
+    // A permanent table: the exclusive lock must be visible across connections,
+    // and temp (#) tables are session-local.
+    let table = format!("dbo.BulkFinishTimeout_{}", std::process::id());
+
+    // Locker connection: create the table, then hold TABLOCKX for the test's
+    // duration inside an open transaction (HOLDLOCK keeps it past the SELECT).
+    let mut locker = Client::connect(get_test_config().expect("SQL Server config required"))
+        .await
+        .expect("locker connect");
+    locker
+        .execute(
+            &format!(
+                // Nullable column: the without-schema-discovery path emits the
+                // nullable INTN type id, which the server rejects for a NOT NULL
+                // column ("Invalid column type from bcp client"). A NULL column
+                // accepts it, so the data phase proceeds to the insert and
+                // blocks on the held lock — which is the path under test.
+                "IF OBJECT_ID('{table}','U') IS NOT NULL DROP TABLE {table}; \
+                 CREATE TABLE {table} (id INT NULL)"
+            ),
+            &[],
+        )
+        .await
+        .expect("create table");
+    locker
+        .execute("BEGIN TRANSACTION", &[])
+        .await
+        .expect("begin tran");
+    locker
+        .execute(
+            &format!("SELECT * FROM {table} WITH (TABLOCKX, HOLDLOCK)"),
+            &[],
+        )
+        .await
+        .expect("acquire exclusive lock");
+
+    // Victim connection: 1s command timeout. The bulk data phase blocks on the
+    // lock until the timeout abandons the connection.
+    let mut victim_cfg = get_test_config().expect("SQL Server config required");
+    victim_cfg.command_timeout = Duration::from_secs(1);
+    let mut victim = Client::connect(victim_cfg).await.expect("victim connect");
+
+    let builder = BulkInsertBuilder::new(&table)
+        .with_typed_columns(vec![BulkColumn::new("id", "INT", 0).unwrap()]);
+
+    // Skip schema discovery: `bulk_insert()`'s `SELECT TOP 0 *` would itself
+    // block on the exclusive lock and time out during setup. The INSERT BULK
+    // prelude only puts the connection in bulk-load mode (no data lock), so it
+    // succeeds — leaving the BulkLoad data transfer in finish() as the only
+    // thing that blocks.
+    let mut writer = victim
+        .bulk_insert_without_schema_discovery(&builder)
+        .await
+        .expect("INSERT BULK prelude should succeed before the blocking data phase");
+    writer
+        .send_row_values(&[SqlValue::Int(1)])
+        .expect("buffer row");
+
+    let start = Instant::now();
+    let result = writer.finish().await;
+    let elapsed = start.elapsed();
+
+    // The victim was abandoned mid-request; dropping it tears down the session
+    // so its queued bulk load cannot race the cleanup below.
+    drop(victim);
+
+    // Release the lock and drop the table (best-effort; the idempotent guard at
+    // the top of the test reclaims a leftover on the next run).
+    locker.execute("ROLLBACK", &[]).await.ok();
+    locker
+        .execute(&format!("DROP TABLE {table}"), &[])
+        .await
+        .ok();
+    locker.close().await.ok();
+
+    match result {
+        Err(mssql_client::Error::CommandTimeout) => {}
+        Err(other) => panic!("finish() must hit the command timeout, got {other:?}"),
+        Ok(v) => panic!("finish() must time out under the lock, got Ok({v:?})"),
+    }
+    assert!(
+        elapsed < Duration::from_secs(5),
+        "timeout must fire near 1s, not block indefinitely; took {elapsed:?}"
+    );
+}

--- a/crates/mssql-codec/Cargo.toml
+++ b/crates/mssql-codec/Cargo.toml
@@ -13,7 +13,12 @@ categories = ["network-programming", "asynchronous"]
 default = []
 
 [dependencies]
-tds-protocol = { workspace = true }
+# tds-protocol's default features are disabled at the workspace root (#305);
+# forward only `std` here. mssql-codec does not use tds-protocol's
+# `encoding`-gated APIs, so a `--no-default-features` build can drop encoding_rs.
+# `encoding` is still enabled in the default workspace build via mssql-client's
+# `encoding` feature (feature unification).
+tds-protocol = { workspace = true, features = ["std"] }
 bytes = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true }

--- a/crates/mssql-testing/Cargo.toml
+++ b/crates/mssql-testing/Cargo.toml
@@ -17,7 +17,9 @@ otel = ["mssql-client/otel"]
 
 [dependencies]
 mssql-client = { workspace = true }
-tds-protocol = { workspace = true }
+# tds-protocol's default features are disabled at the workspace root (#305);
+# this dev-only crate only needs `std`.
+tds-protocol = { workspace = true, features = ["std"] }
 bytes = { workspace = true }
 tokio = { workspace = true, features = ["fs"] }
 tokio-rustls = { workspace = true }

--- a/scripts/check-changelog-completeness.sh
+++ b/scripts/check-changelog-completeness.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# Changelog-completeness guard (issue #184).
+#
+# release-plz has silently dropped non-merge commits from a generated CHANGELOG
+# section while bumping the version correctly (v0.13.0 / PR #170: two `fix`
+# commits omitted). git-cliff rendered them fine; the drop happened in
+# release-plz's own layer and recurs unpredictably. This guard fails when a
+# non-merge commit in the release range is missing from the pending CHANGELOG
+# section, so the gap is caught on the Release PR instead of after publish.
+#
+# Mechanism: release-plz's commit_parsers (release-plz.toml) skip only `^Merge`;
+# every other non-merge commit lands in some group. AND release-plz attributes
+# commits to packages by changed file paths, so a commit that touches only root
+# files (release-plz.toml, RELEASING.md, .github/, the release commit itself,
+# xtask, the publish=false crates) is legitimately absent from the changelog.
+# So: every non-merge commit in <latest-tag>..<compare-ref> that touches a
+# PUBLISHED crate directory must appear in the pending `## [X.Y.Z]` section.
+#
+# Usage: check-changelog-completeness.sh [<compare-ref>]
+#   <compare-ref> defaults to origin/main — the commits the release will cover.
+#   On the Release PR, pass the PR base sha (the main tip the CHANGELOG was
+#   generated against).
+#
+# Self-gating: if the top versioned CHANGELOG section equals the latest release
+# tag (no pending release), the check is a no-op — safe to run on any branch.
+set -euo pipefail
+
+CHANGELOG="CHANGELOG.md"
+compare_ref="${1:-origin/main}"
+
+# Resolve the compare ref, falling back for local runs without an origin remote.
+if ! git rev-parse --verify --quiet "$compare_ref^{commit}" >/dev/null; then
+  for alt in main HEAD; do
+    if git rev-parse --verify --quiet "$alt^{commit}" >/dev/null; then
+      compare_ref="$alt"
+      break
+    fi
+  done
+fi
+
+# Latest release tag and its bare version.
+last_tag="$(git tag --list 'v*' --sort=-v:refname | head -1)"
+if [ -z "$last_tag" ]; then
+  echo "No v* tags found; cannot determine the release range. Skipping."
+  exit 0
+fi
+last_version="${last_tag#v}"
+
+# The topmost versioned section header, e.g. "## [0.19.2](...) - 2026-06-18".
+# This deliberately skips a leading "## [Unreleased]" (no version digits).
+top_header="$(grep -m1 -E '^## \[[0-9]+\.[0-9]+\.[0-9]+\]' "$CHANGELOG" || true)"
+if [ -z "$top_header" ]; then
+  echo "No versioned section in $CHANGELOG; nothing to check."
+  exit 0
+fi
+top_version="$(sed -E 's/^## \[([0-9]+\.[0-9]+\.[0-9]+)\].*/\1/' <<<"$top_header")"
+
+if [ "$top_version" = "$last_version" ]; then
+  echo "Top CHANGELOG section [$top_version] is the released version; no pending"
+  echo "release to check."
+  exit 0
+fi
+
+# Body of the pending section: from its header line to the next "## [".
+section="$(awk -v hdr="$top_header" '
+  index($0, hdr) == 1 { grab = 1; next }
+  grab && /^## \[/ { exit }
+  grab { print }
+' "$CHANGELOG")"
+
+# Normalize text for tolerant substring matching: drop markdown link targets,
+# issue/PR numbers (release-plz rewrites "(#42)" into a link), and markdown
+# punctuation; lowercase; collapse whitespace.
+normalize() {
+  sed -E '
+    s/\]\([^)]*\)//g
+    s/#[0-9]+//g
+    s/[][()*`_]//g
+    s/[[:space:]]+/ /g
+  ' | tr '[:upper:]' '[:lower:]'
+}
+
+norm_section="$(printf '%s\n' "$section" | normalize)"
+
+missing=0
+checked=0
+while IFS=$'\t' read -r sha subject; do
+  [ -z "$sha" ] && continue
+  # release-plz skips only merge-like subjects.
+  case "$subject" in
+  Merge\ *) continue ;;
+  esac
+  checked=$((checked + 1))
+  # Description = subject minus the conventional "type(scope)!: " prefix; if
+  # there is no such prefix, release-plz renders the whole subject, so use it.
+  desc="$(sed -E 's/^[a-zA-Z]+(\([^)]*\))?!?:[[:space:]]*//' <<<"$subject")"
+  norm_desc="$(printf '%s' "$desc" | normalize | sed -E 's/^ //; s/ $//')"
+  [ -z "$norm_desc" ] && continue
+  if ! printf '%s' "$norm_section" | grep -qF -- "$norm_desc"; then
+    echo "::error::CHANGELOG [$top_version] is missing commit $sha: '$subject'"
+    missing=1
+  fi
+# Only commits touching a published crate dir are attributed to the changelog
+# by release-plz. Include crates/ and exclude the publish=false crates, so a
+# newly added published crate is covered automatically (a false positive is a
+# loud, easy fix; silently skipping a real crate would defeat the guard).
+done < <(git log --no-merges --pretty=$'%h\t%s' "$last_tag..$compare_ref" -- \
+  'crates/' \
+  ':(exclude)crates/api-smoke/' \
+  ':(exclude)crates/doc-tests/' \
+  ':(exclude)crates/mssql-testing/')
+
+if [ "$missing" -ne 0 ]; then
+  echo
+  echo "The pending CHANGELOG [$top_version] section is incomplete (issue #184:"
+  echo "release-plz can silently drop commits). Restore the missing entries on"
+  echo "the Release PR branch — matching git-cliff's rendering — before merging."
+  exit 1
+fi
+
+echo "CHANGELOG [$top_version] covers all $checked non-merge commits in" \
+  "$last_tag..$compare_ref."


### PR DESCRIPTION
v0.20.0 hygiene batch (3 issues, 3 commits).

## Closes
- Closes #305 — internal deps now disable default features
- Closes #206 — live test for the bulk `finish()` timeout path
- Closes #184 — CI guard for Release PR changelog completeness

## #305 — `default-features = false` on internal deps
Internal deps were declared without `default-features = false`, so a downstream `--no-default-features` build of `mssql-client` could not shed the upstream type/encoding features (`mssql-types` default = chrono/uuid/decimal; `tds-protocol` default = std/encoding always leaked in).

Fix: `default-features = false` at the workspace root on the two deps with non-empty defaults; members forward what they need via `features` (`std` unconditionally, the type/encoding features via mssql-client's own flags). `mssql-codec`/`mssql-auth`/`mssql-tls` have `default = []` so nothing leaks from them.

- **Default builds are unchanged** (verified) — the default feature sets re-enable everything.
- Only `--no-default-features`/single-feature builds change: they now actually minimize the tree (`cargo tree --no-default-features` no longer pulls `rust_decimal`/`chrono`/`uuid`/`encoding_rs`).
- **Breaking-change call:** classified non-breaking. Default builds (the supported surface) are identical; per STABILITY.md, relying on default features leaking through `--no-default-features` is not a guaranteed behavior. The only theoretical break is a consumer who builds `--no-default-features` *and* uses a type feature without enabling it — previously compiled by accident. Flagging for reviewer judgment; happy to add a `!` marker if you'd rather mark it.
- Validated against the full `cargo hack --each-feature` matrix.

**Out of scope (deliberate):** `mssql-pool` → `mssql-client` is left as-is. Disabling client defaults there would need mirroring the whole type-feature surface onto the pool (a larger API change) for marginal minimal-build benefit.

## #206 — bulk `finish()` timeout live test
Adds an ignored live test. A locker connection holds `TABLOCKX/HOLDLOCK` on the target table in an open transaction so the BulkLoad data phase blocks; the victim's 1s `command_timeout` fires and returns `CommandTimeout`. Uses `bulk_insert_without_schema_discovery` so the `SELECT TOP 0 *` metadata query doesn't itself block (which would test setup, not `finish()`). Verified live (passes in ~1.0s — confirms it actually blocks on the lock, not an instant rejection).

## #184 — changelog-completeness guard
`scripts/check-changelog-completeness.sh` + a Release-PR-only CI job. Diffs the pending `## [X.Y.Z]` section against the published-crate commits in `<last-tag>..main` and fails on any missing entry.

- Mirrors release-plz attribution: only commits touching a published crate dir are checked (root/infra/`RELEASING.md`/`release-plz.toml` commits are legitimately absent); only `^Merge` subjects are skipped.
- Self-gates to a no-op when the top section is the already-released version (safe to run on any branch).
- Tolerant normalized match (strips PR links / `#NNN` / markdown punctuation) since release-plz rewrites `(#NNN)` into links.
- **Validated** against three historical releases: v0.19.1 ✓ clean, v0.18.0 ✓ clean, and it caught a **real recurrence** — two `test(client):` commits (`#287`) were dropped from the published **v0.19.0** changelog. (Historical/already-shipped; noted, not rewritten.)

## Gate
Full local pre-push gate green: `just ci-all` (932 tests), `just typos`, `just check-feature-flags`, and the live ignored suite (293 passed).