### PR TITLE
fix(protocol): robustness for ALTMETADATA/ALTROW (#275) and PRELOGIN cert-auth combos (#308)

### DIFF
--- a/crates/tds-protocol/src/prelogin.rs
+++ b/crates/tds-protocol/src/prelogin.rs
@@ -70,8 +70,19 @@ pub enum EncryptionLevel {
     /// Encryption is required.
     #[default]
     Required = 0x03,
-    /// Client certificate authentication (TDS 8.0+).
+    /// Client certificate authentication, base level off
+    /// (`ENCRYPT_CLIENT_CERT | ENCRYPT_OFF`, TDS 8.0+).
+    ///
+    /// `ENCRYPT_CLIENT_CERT` (0x80) is a flag OR'd onto the base encryption
+    /// level, so it appears combined with on/required as well (see
+    /// [`Self::ClientCertOn`] / [`Self::ClientCertReq`]).
     ClientCertAuth = 0x80,
+    /// Client certificate authentication with encryption on
+    /// (`ENCRYPT_CLIENT_CERT | ENCRYPT_ON`, TDS 8.0+).
+    ClientCertOn = 0x81,
+    /// Client certificate authentication with encryption required
+    /// (`ENCRYPT_CLIENT_CERT | ENCRYPT_REQ`, TDS 8.0+).
+    ClientCertReq = 0x83,
 }
 
 impl EncryptionLevel {
@@ -89,6 +100,8 @@ impl EncryptionLevel {
             0x02 => Ok(Self::NotSupported),
             0x03 => Ok(Self::Required),
             0x80 => Ok(Self::ClientCertAuth),
+            0x81 => Ok(Self::ClientCertOn),
+            0x83 => Ok(Self::ClientCertReq),
             _ => Err(ProtocolError::InvalidEncryptionLevel(value)),
         }
     }
@@ -96,7 +109,17 @@ impl EncryptionLevel {
     /// Check if encryption is required.
     #[must_use]
     pub const fn is_required(&self) -> bool {
-        matches!(self, Self::On | Self::Required | Self::ClientCertAuth)
+        // ClientCertOn/ClientCertReq carry ENCRYPT_ON/ENCRYPT_REQ in the base
+        // bits, so they imply encryption; 0x80 (ClientCertAuth) is the base-off
+        // combo retained for backwards compatibility.
+        matches!(
+            self,
+            Self::On
+                | Self::Required
+                | Self::ClientCertAuth
+                | Self::ClientCertOn
+                | Self::ClientCertReq
+        )
     }
 }
 
@@ -473,6 +496,35 @@ mod tests {
         assert!(EncryptionLevel::On.is_required());
         assert!(!EncryptionLevel::Off.is_required());
         assert!(!EncryptionLevel::NotSupported.is_required());
+    }
+
+    /// #308: `ENCRYPT_CLIENT_CERT` (0x80) is a flag OR'd onto the base level,
+    /// so 0x81 (cert|on) and 0x83 (cert|req) are valid per MS-TDS and must
+    /// decode rather than erroring as `InvalidEncryptionLevel`. The combos that
+    /// carry encryption (0x81/0x83) are `is_required`.
+    #[test]
+    fn test_encryption_level_client_cert_combos_308() {
+        assert_eq!(
+            EncryptionLevel::from_u8(0x80).unwrap(),
+            EncryptionLevel::ClientCertAuth
+        );
+        assert_eq!(
+            EncryptionLevel::from_u8(0x81).unwrap(),
+            EncryptionLevel::ClientCertOn
+        );
+        assert_eq!(
+            EncryptionLevel::from_u8(0x83).unwrap(),
+            EncryptionLevel::ClientCertReq
+        );
+        assert!(EncryptionLevel::ClientCertOn.is_required());
+        assert!(EncryptionLevel::ClientCertReq.is_required());
+
+        // 0x82 has no defined meaning (ENCRYPT_CLIENT_CERT | 0x02 NotSupported)
+        // and must still fail closed.
+        assert!(matches!(
+            EncryptionLevel::from_u8(0x82),
+            Err(ProtocolError::InvalidEncryptionLevel(0x82))
+        ));
     }
 
     /// FEDAUTHREQUIRED (option 0x06) must be emitted with payload 0x01 when

--- a/crates/tds-protocol/src/token.rs
+++ b/crates/tds-protocol/src/token.rs
@@ -81,6 +81,10 @@ pub enum TokenType {
     TabName = 0xA4,
     /// Offset (OFFSET).
     Offset = 0x78,
+    /// Compute (COMPUTE BY) column metadata (ALTMETADATA). Deprecated in TDS 7.4.
+    AltMetaData = 0x88,
+    /// Compute (COMPUTE BY) row data (ALTROW). Deprecated in TDS 7.4.
+    AltRow = 0xD3,
 }
 
 impl TokenType {
@@ -107,6 +111,8 @@ impl TokenType {
             0xA5 => Some(Self::ColInfo),
             0xA4 => Some(Self::TabName),
             0x78 => Some(Self::Offset),
+            0x88 => Some(Self::AltMetaData),
+            0xD3 => Some(Self::AltRow),
             _ => None,
         }
     }
@@ -868,6 +874,57 @@ impl ColMetaData {
             columns,
             cek_table: None,
         })
+    }
+
+    /// Decode an ALTMETADATA (COMPUTE BY) token body, returning the compute Id
+    /// and the column metadata describing the matching ALTROW values.
+    ///
+    /// The token type byte (0x88) must already be consumed. ALTMETADATA was
+    /// deprecated in TDS 7.4, but legacy `COMPUTE BY` queries still emit it. The
+    /// driver parses it only to learn the ALTROW value layout so those rows can
+    /// be consumed and dropped, keeping the token stream byte-aligned.
+    ///
+    /// Wire format (MS-TDS 2.2.7.1):
+    /// `Count(USHORT) Id(USHORT) ByCols(UCHAR) ByCols*ColNum(USHORT) Count*ComputeData`,
+    /// where each `ComputeData` is `Op(BYTE) Operand(USHORT)` followed by a
+    /// column definition identical to COLMETADATA (TableName is never sent for
+    /// COMPUTE, which excludes text/ntext/image columns).
+    fn decode_alt(src: &mut impl Buf) -> Result<(u16, Self), ProtocolError> {
+        // Count (USHORT) + Id (USHORT) + ByCols (UCHAR)
+        if src.remaining() < 5 {
+            return Err(ProtocolError::UnexpectedEof);
+        }
+        let count = src.get_u16_le();
+        let id = src.get_u16_le();
+        let by_cols = src.get_u8() as usize;
+
+        // ColNum: USHORT repeated ByCols times (the grouping columns). Not needed
+        // to parse ALTROW values, but must be consumed to stay byte-aligned.
+        if src.remaining() < by_cols * 2 {
+            return Err(ProtocolError::UnexpectedEof);
+        }
+        for _ in 0..by_cols {
+            let _ = src.get_u16_le();
+        }
+
+        let mut columns = Vec::with_capacity(count as usize);
+        for _ in 0..count {
+            // ComputeData prefix: Op (BYTE) + Operand (USHORT).
+            if src.remaining() < 3 {
+                return Err(ProtocolError::UnexpectedEof);
+            }
+            let _op = src.get_u8();
+            let _operand = src.get_u16_le();
+            columns.push(Self::decode_column(src)?);
+        }
+
+        Ok((
+            id,
+            Self {
+                columns,
+                cek_table: None,
+            },
+        ))
     }
 
     /// Decode a single column from the metadata.
@@ -2353,6 +2410,10 @@ pub struct TokenParser {
     /// Whether Always Encrypted was negotiated for this connection.
     /// When true, ColMetaData tokens are parsed with CekTable and per-column CryptoMetadata.
     encryption_enabled: bool,
+    /// COMPUTE BY (ALTMETADATA) column layouts keyed by compute Id, used to
+    /// parse and drop the matching ALTROW tokens. Cleared on each new
+    /// ColMetaData (result-set boundary), where compute Ids become unique again.
+    alt_metadata: Vec<(u16, ColMetaData)>,
 }
 
 impl TokenParser {
@@ -2363,6 +2424,7 @@ impl TokenParser {
             data,
             position: 0,
             encryption_enabled: false,
+            alt_metadata: Vec::new(),
         }
     }
 
@@ -2488,6 +2550,9 @@ impl TokenParser {
                     } else {
                         ColMetaData::decode(&mut buf)?
                     };
+                    // New result set: prior COMPUTE BY layouts no longer apply
+                    // and their Ids may be reused.
+                    self.alt_metadata.clear();
                     Token::ColMetaData(col_meta)
                 }
                 Some(TokenType::Row) => {
@@ -2541,6 +2606,41 @@ impl TokenParser {
                     // path must NOT recurse — a server-controlled flat run of these
                     // tokens would otherwise add one stack frame per token and
                     // overflow the stack (remote DoS).
+                    self.position = start_pos + (self.data.len() - start_pos - buf.remaining());
+                    continue;
+                }
+                Some(TokenType::AltMetaData) => {
+                    // COMPUTE BY metadata (#275). Parse to learn the ALTROW value
+                    // layout, store it keyed by Id, then drop the token — compute
+                    // rows are not surfaced, but their bytes must be consumed so
+                    // the base result set stays parseable.
+                    let (id, alt_meta) = ColMetaData::decode_alt(&mut buf)?;
+                    self.position = start_pos + (self.data.len() - start_pos - buf.remaining());
+                    self.alt_metadata.push((id, alt_meta));
+                    continue;
+                }
+                Some(TokenType::AltRow) => {
+                    // COMPUTE BY row (#275). Parse using the matching ALTMETADATA
+                    // to consume its bytes, then drop it. Like the ColInfo skip
+                    // path, this MUST NOT recurse (remote DoS via a flat token run).
+                    if buf.remaining() < 2 {
+                        return Err(ProtocolError::UnexpectedEof);
+                    }
+                    let id = buf.get_u16_le();
+                    let alt_meta = self
+                        .alt_metadata
+                        .iter()
+                        .find(|(stored_id, _)| *stored_id == id)
+                        .map(|(_, meta)| meta)
+                        .ok_or_else(|| {
+                            ProtocolError::StringEncoding(
+                                #[cfg(feature = "std")]
+                                "ALTROW token without matching ALTMETADATA".to_string(),
+                                #[cfg(not(feature = "std"))]
+                                "ALTROW token without matching ALTMETADATA",
+                            )
+                        })?;
+                    let _ = RawRow::decode(&mut buf, alt_meta)?;
                     self.position = start_pos + (self.data.len() - start_pos - buf.remaining());
                     continue;
                 }
@@ -2615,6 +2715,31 @@ impl TokenParser {
                 // Parse to find end
                 let mut buf = &self.data[self.position + 1..];
                 let _ = FeatureExtAck::decode(&mut buf)?;
+                self.data.len() - self.position - buf.remaining()
+            }
+            // COMPUTE BY metadata (#275) has no length prefix; parse to find its
+            // end, recording the layout so a following ALTROW can be skipped.
+            Some(TokenType::AltMetaData) => {
+                let mut buf = &self.data[self.position + 1..];
+                let (id, alt_meta) = ColMetaData::decode_alt(&mut buf)?;
+                let consumed = self.data.len() - self.position - buf.remaining();
+                self.alt_metadata.push((id, alt_meta));
+                consumed
+            }
+            // COMPUTE BY row (#275); length depends on the matching ALTMETADATA.
+            Some(TokenType::AltRow) => {
+                let mut buf = &self.data[self.position + 1..];
+                if buf.remaining() < 2 {
+                    return Err(ProtocolError::UnexpectedEof);
+                }
+                let id = buf.get_u16_le();
+                let alt_meta = self
+                    .alt_metadata
+                    .iter()
+                    .find(|(stored_id, _)| *stored_id == id)
+                    .map(|(_, meta)| meta)
+                    .ok_or(ProtocolError::InvalidTokenType(token_type_byte))?;
+                let _ = RawRow::decode(&mut buf, alt_meta)?;
                 self.data.len() - self.position - buf.remaining()
             }
             // ColMetaData, Row, NbcRow require context and can't be easily skipped
@@ -4336,5 +4461,109 @@ mod tests {
         // Every skipped token was traversed: proof the input was non-trivial.
         assert_eq!(parser.position(), total_len);
         assert!(parser.next_token().unwrap().is_none());
+    }
+
+    /// Build an ALTMETADATA token describing one `SUM` aggregate over an `int`
+    /// column (empty name), followed by `rows` ALTROW tokens each carrying that
+    /// int value. Mirrors the wire shape of a `COMPUTE BY` result set.
+    fn compute_by_tokens(id: u16, rows: &[i32]) -> BytesMut {
+        let mut buf = BytesMut::new();
+        // ALTMETADATA
+        buf.put_u8(TokenType::AltMetaData as u8);
+        buf.put_u16_le(1); // Count = 1 ComputeData
+        buf.put_u16_le(id); // Id
+        buf.put_u8(1); // ByCols = 1
+        buf.put_u16_le(1); // ColNum[0]
+        buf.put_u8(0x4D); // Op = AOPSUM
+        buf.put_u16_le(1); // Operand (column 1)
+        buf.put_u32_le(0); // UserType (ULONG)
+        buf.put_u16_le(0); // Flags
+        buf.put_u8(TypeId::Int4 as u8); // TYPE_INFO (fixed-length int4)
+        buf.put_u8(0); // ColName: B_VARCHAR length 0
+        // ALTROW(s)
+        for &v in rows {
+            buf.put_u8(TokenType::AltRow as u8);
+            buf.put_u16_le(id); // Id matching the ALTMETADATA
+            buf.put_i32_le(v); // int4 value
+        }
+        buf
+    }
+
+    fn trailing_done(buf: &mut BytesMut) {
+        let done = Done {
+            status: DoneStatus {
+                more: false,
+                error: false,
+                in_xact: false,
+                count: true,
+                attn: false,
+                srverror: false,
+            },
+            cur_cmd: 0xBEEF,
+            row_count: 3,
+        };
+        done.encode(buf);
+    }
+
+    /// #275: a COMPUTE BY result set (ALTMETADATA 0x88 + ALTROW 0xD3) must be
+    /// silently consumed, not hard-error. The DONE following the compute tokens
+    /// must still be delivered, and every byte traversed.
+    #[test]
+    fn compute_by_alt_tokens_skipped_275() {
+        let mut buf = compute_by_tokens(7, &[42, -1]);
+        trailing_done(&mut buf);
+        let total_len = buf.len();
+
+        let mut parser = TokenParser::new(buf.freeze());
+
+        // The first token surfaced is the DONE — both ALTROWs and the
+        // ALTMETADATA were dropped, not returned.
+        let Some(Token::Done(done)) = parser.next_token().unwrap() else {
+            panic!("expected DONE after the COMPUTE BY tokens were skipped");
+        };
+        assert_eq!(done.cur_cmd, 0xBEEF);
+
+        // All alt-token bytes were consumed to reach the DONE.
+        assert_eq!(parser.position(), total_len);
+        assert!(parser.next_token().unwrap().is_none());
+    }
+
+    /// #275: ALTMETADATA must be remembered across calls so a following
+    /// ColMetaData (new result set) clears stale compute Ids.
+    #[test]
+    fn compute_by_alt_metadata_cleared_on_new_colmetadata_275() {
+        let mut buf = compute_by_tokens(7, &[42]);
+        // New result set: a COLMETADATA token clears alt_metadata. Encode an
+        // empty (NO_METADATA) ColMetaData, then reuse Id 7 for a fresh compute.
+        buf.put_u8(TokenType::ColMetaData as u8);
+        buf.put_u16_le(ColMetaData::NO_METADATA);
+        buf.extend_from_slice(&compute_by_tokens(7, &[99]));
+        trailing_done(&mut buf);
+        let total_len = buf.len();
+
+        let mut parser = TokenParser::new(buf.freeze());
+
+        // First surfaced token: the empty ColMetaData (compute tokens dropped).
+        let Some(Token::ColMetaData(_)) = parser.next_token().unwrap() else {
+            panic!("expected ColMetaData between the two compute groups");
+        };
+        // Then the DONE, after the second compute group is also dropped.
+        let Some(Token::Done(_)) = parser.next_token().unwrap() else {
+            panic!("expected DONE after the second COMPUTE BY group");
+        };
+        assert_eq!(parser.position(), total_len);
+    }
+
+    /// #275: an ALTROW with no matching ALTMETADATA cannot be length-decoded;
+    /// it must error cleanly rather than panic or desync.
+    #[test]
+    fn altrow_without_altmetadata_errors_275() {
+        let mut buf = BytesMut::new();
+        buf.put_u8(TokenType::AltRow as u8);
+        buf.put_u16_le(7); // Id with no preceding ALTMETADATA
+        buf.put_i32_le(42);
+
+        let mut parser = TokenParser::new(buf.freeze());
+        assert!(parser.next_token().is_err());
     }
 }

--- a/public-api/tds-protocol.txt
+++ b/public-api/tds-protocol.txt
@@ -896,6 +896,8 @@ pub const tds_protocol::packet::PACKET_HEADER_SIZE: usize
 pub mod tds_protocol::prelogin
 #[non_exhaustive] #[repr(u8)] pub enum tds_protocol::prelogin::EncryptionLevel
 pub tds_protocol::prelogin::EncryptionLevel::ClientCertAuth = 128
+pub tds_protocol::prelogin::EncryptionLevel::ClientCertOn = 129
+pub tds_protocol::prelogin::EncryptionLevel::ClientCertReq = 131
 pub tds_protocol::prelogin::EncryptionLevel::NotSupported = 2
 pub tds_protocol::prelogin::EncryptionLevel::Off = 0
 pub tds_protocol::prelogin::EncryptionLevel::On = 1
@@ -3069,6 +3071,8 @@ impl<T> core::convert::From<T> for tds_protocol::version::TdsVersion
 pub fn tds_protocol::version::TdsVersion::from(T) -> T
 #[non_exhaustive] #[repr(u8)] pub enum tds_protocol::EncryptionLevel
 pub tds_protocol::EncryptionLevel::ClientCertAuth = 128
+pub tds_protocol::EncryptionLevel::ClientCertOn = 129
+pub tds_protocol::EncryptionLevel::ClientCertReq = 131
 pub tds_protocol::EncryptionLevel::NotSupported = 2
 pub tds_protocol::EncryptionLevel::Off = 0
 pub tds_protocol::EncryptionLevel::On = 1

--- a/public-api/tds-protocol.txt
+++ b/public-api/tds-protocol.txt
@@ -1616,6 +1616,8 @@ pub unsafe fn tds_protocol::token::Token::clone_to_uninit(&self, *mut u8)
 impl<T> core::convert::From<T> for tds_protocol::token::Token
 pub fn tds_protocol::token::Token::from(T) -> T
 #[non_exhaustive] #[repr(u8)] pub enum tds_protocol::token::TokenType
+pub tds_protocol::token::TokenType::AltMetaData = 136
+pub tds_protocol::token::TokenType::AltRow = 211
 pub tds_protocol::token::TokenType::ColInfo = 165
 pub tds_protocol::token::TokenType::ColMetaData = 129
 pub tds_protocol::token::TokenType::Done = 253
@@ -3561,6 +3563,8 @@ pub unsafe fn tds_protocol::token::Token::clone_to_uninit(&self, *mut u8)
 impl<T> core::convert::From<T> for tds_protocol::token::Token
 pub fn tds_protocol::token::Token::from(T) -> T
 #[non_exhaustive] #[repr(u8)] pub enum tds_protocol::TokenType
+pub tds_protocol::TokenType::AltMetaData = 136
+pub tds_protocol::TokenType::AltRow = 211
 pub tds_protocol::TokenType::ColInfo = 165
 pub tds_protocol::TokenType::ColMetaData = 129
 pub tds_protocol::TokenType::Done = 253


### PR DESCRIPTION
## Summary

PR 1 of the v0.20.0 protocol-robustness batch. Two independent `tds-protocol` decode-path fixes, each currently causing a hard error on a valid (if legacy/rare) wire input.

### #275 — ALTMETADATA (0x88) / ALTROW (0xD3) hard-error → COMPUTE BY kills the connection
The token parser had no arms for these tokens; they fell through to `InvalidTokenType`. Now both are recognized and consumed:
- **ALTMETADATA** is parsed into the compute column layout, keyed by `Id`. The `ComputeData` body is byte-identical to a `COLMETADATA` column after an `Op`/`Operand` prefix, so `ColMetaData::decode_column` is reused.
- **ALTROW** values are decoded against the matching layout (via `RawRow::decode`) and dropped. Base result-set rows are unaffected.
- The layout map is cleared at each new `COLMETADATA` (result-set boundary), where compute `Id`s become unique again.
- The skip path **iterates, does not recurse** — consistent with the #273 stack-overflow fix.

Deprecated in TDS 7.4; COMPUTE BY was removed from T-SQL in SQL Server 2012, so this is robustness against legacy servers (no available container emits these tokens). Validated with wire-byte unit tests.

### #308 — PRELOGIN cert-auth encryption combos 0x81/0x83 unmodeled (errored after #278)
`ENCRYPT_CLIENT_CERT` (0x80) is a flag OR'd onto the base encryption level per MS-TDS, so `0x81` (cert|on) and `0x83` (cert|req) are valid. `from_u8` modeled only `0x80`, so after the #278 fail-closed change those combos errored as `InvalidEncryptionLevel`. Added `ClientCertOn`/`ClientCertReq` variants, accepted in `from_u8`; both are `is_required`. `0x82` (cert|NotSupported) remains undefined and fails closed.

## API impact
Adds 2 variants each to `TokenType` and `EncryptionLevel`. Both enums are `#[non_exhaustive]`, so this is a **non-breaking** addition. Public-API snapshot regenerated.

## Testing
- New wire-byte unit tests for both fixes (`compute_by_*`, `altrow_without_altmetadata_errors_275`, `test_encryption_level_client_cert_combos_308`).
- Full local gate green: `just ci-all` (936 tests) + `just typos` + `just check-feature-flags` + `just public-api` + the live ignored suite against SQL Server 2017/2019/2022 (293 passed).

Closes #275
Closes #308
