### PR TITLE
feat(tls): OS/platform trust store via opt-in native-certs feature (#314)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2226,6 +2226,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys 0.4.1",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "jni-sys"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2590,6 +2620,7 @@ name = "mssql-tls"
 version = "0.19.1"
 dependencies = [
  "rustls",
+ "rustls-platform-verifier 0.7.0",
  "thiserror 2.0.18",
  "tokio",
  "tokio-rustls",
@@ -3720,7 +3751,7 @@ dependencies = [
  "quinn",
  "rustls",
  "rustls-pki-types",
- "rustls-platform-verifier",
+ "rustls-platform-verifier 0.6.2",
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
@@ -3938,7 +3969,28 @@ checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
 dependencies = [
  "core-foundation",
  "core-foundation-sys",
- "jni",
+ "jni 0.21.1",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni 0.22.4",
  "log",
  "once_cell",
  "rustls",
@@ -4319,6 +4371,16 @@ name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
 
 [[package]]
 name = "simdutf8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,10 @@ encoding_rs = "0.8"
 rustls = { version = "0.23", default-features = false, features = ["std", "tls12", "ring"] }
 rustls-pemfile = "2.2"
 webpki-roots = "1.0"
+# OS/platform trust store (behind the `native-certs` feature). Delegates server
+# certificate verification to the operating system's verifier (Windows CryptoAPI,
+# macOS SecTrust, Linux native-certs) so enterprise internal CAs are honored.
+rustls-platform-verifier = "0.7"
 
 # Certificate handling
 p12 = "0.6"

--- a/crates/mssql-client/Cargo.toml
+++ b/crates/mssql-client/Cargo.toml
@@ -57,6 +57,10 @@ sspi-auth = ["mssql-auth/sspi-auth"]
 # legacy SQL Server instances, or development environments) to reduce binary size and compile time.
 # When disabled, only `Encrypt=no_tls` connections are supported.
 tls = ["dep:mssql-tls"]
+# Verify server certificates against the OS/platform trust store (enterprise
+# internal CAs). Implies `tls`. Off by default — see the mssql-tls `native-certs`
+# feature. Honored only when no explicit root certificates are configured.
+native-certs = ["tls", "mssql-tls/native-certs"]
 # FILESTREAM BLOB access (Windows only)
 # Enables async read/write of SQL Server FILESTREAM data via the Win32 OpenSqlFilestream API.
 # Requires the Microsoft OLE DB Driver for SQL Server (msoledbsql.dll) at runtime.

--- a/crates/mssql-tls/Cargo.toml
+++ b/crates/mssql-tls/Cargo.toml
@@ -11,10 +11,17 @@ categories = ["network-programming", "cryptography"]
 
 [features]
 default = []
+# Verify server certificates against the OS/platform trust store, so servers
+# chaining to an enterprise internal CA installed in the OS store are accepted.
+# Delegates to the platform verifier (revocation + OS policy). Off by default:
+# enabling it changes the trust-anchor set. Active only when no explicit
+# `root_certificates` are configured (explicit roots still take precedence).
+native-certs = ["dep:rustls-platform-verifier"]
 
 [dependencies]
 rustls = { workspace = true }
 webpki-roots = { workspace = true }
+rustls-platform-verifier = { workspace = true, optional = true }
 tokio = { workspace = true }
 tokio-rustls = { workspace = true }
 thiserror = { workspace = true, features = ["std"] }

--- a/crates/mssql-tls/src/config.rs
+++ b/crates/mssql-tls/src/config.rs
@@ -44,8 +44,11 @@ pub struct TlsConfig {
 
     /// Custom root certificates to trust.
     ///
-    /// If empty, the bundled webpki (Mozilla) root certificates are used. The
-    /// driver does not read the operating system trust store.
+    /// If empty, the bundled webpki (Mozilla) root certificates are used —
+    /// unless the `native-certs` feature is enabled, in which case verification
+    /// is delegated to the OS/platform trust store (so enterprise internal CAs
+    /// installed in the OS store are honored). Setting explicit roots here
+    /// always takes precedence over the OS store.
     pub root_certificates: Vec<CertificateDer<'static>>,
 
     /// Client authentication credentials for mutual TLS (TDS 8.0 client cert auth).

--- a/crates/mssql-tls/src/connector.rs
+++ b/crates/mssql-tls/src/connector.rs
@@ -93,8 +93,12 @@ impl ServerCertVerifier for DangerousServerCertVerifier {
 
 /// Create a secure default TLS client configuration.
 ///
-/// This uses the Mozilla root certificate store for server validation
-/// and requires no client authentication.
+/// Server certificates are validated against the bundled Mozilla root
+/// certificate store, and no client authentication is configured.
+///
+/// With the `native-certs` feature enabled, validation is delegated to the
+/// OS/platform trust store instead, so servers chaining to an enterprise
+/// internal CA installed in the OS store are accepted.
 ///
 /// # Example
 ///
@@ -110,15 +114,27 @@ pub fn default_tls_config() -> Result<ClientConfig, TlsError> {
     // Ensure the crypto provider is installed before using rustls
     ensure_crypto_provider();
 
-    let root_store = RootCertStore {
-        roots: webpki_roots::TLS_SERVER_ROOTS.to_vec(),
-    };
+    #[cfg(feature = "native-certs")]
+    {
+        use rustls_platform_verifier::BuilderVerifierExt;
+        ClientConfig::builder()
+            .with_platform_verifier()
+            .map(|builder| builder.with_no_client_auth())
+            .map_err(|e| {
+                TlsError::Configuration(format!("platform certificate verifier init failed: {e}"))
+            })
+    }
 
-    let config = ClientConfig::builder()
-        .with_root_certificates(root_store)
-        .with_no_client_auth();
+    #[cfg(not(feature = "native-certs"))]
+    {
+        let root_store = RootCertStore {
+            roots: webpki_roots::TLS_SERVER_ROOTS.to_vec(),
+        };
 
-    Ok(config)
+        Ok(ClientConfig::builder()
+            .with_root_certificates(root_store)
+            .with_no_client_auth())
+    }
 }
 
 // =============================================================================
@@ -183,12 +199,10 @@ impl TlsConnector {
             return Ok(client_config);
         }
 
-        // Build root certificate store for normal validation
-        let root_store = Self::build_root_store(config)?;
-
-        // Build the client config with proper certificate validation
-        let builder = ClientConfig::builder_with_protocol_versions(&versions)
-            .with_root_certificates(root_store);
+        // Select the server-certificate verifier. With the `native-certs`
+        // feature and no explicit roots, this delegates to the OS/platform
+        // trust store; otherwise it uses the configured (or bundled) roots.
+        let builder = Self::builder_with_verifier(&versions, config)?;
 
         let mut client_config = if let Some(client_auth) = &config.client_auth {
             // Clone the key by matching on the Arc contents
@@ -222,6 +236,34 @@ impl TlsConnector {
         }
 
         Ok(client_config)
+    }
+
+    /// Build a rustls client-config builder with the server-certificate
+    /// verifier installed, positioned for client-auth selection.
+    ///
+    /// With the `native-certs` feature enabled and no explicit
+    /// `root_certificates` configured, server verification is delegated to the
+    /// OS/platform trust store (so enterprise internal CAs are honored).
+    /// Otherwise the configured roots — or the bundled Mozilla roots when none
+    /// are given — are used. Explicit `root_certificates` always take
+    /// precedence over the OS store.
+    fn builder_with_verifier(
+        versions: &[&'static rustls::SupportedProtocolVersion],
+        config: &TlsConfig,
+    ) -> Result<rustls::ConfigBuilder<ClientConfig, rustls::client::WantsClientCert>, TlsError>
+    {
+        let builder = ClientConfig::builder_with_protocol_versions(versions);
+
+        #[cfg(feature = "native-certs")]
+        if config.root_certificates.is_empty() {
+            use rustls_platform_verifier::BuilderVerifierExt;
+            return builder.with_platform_verifier().map_err(|e| {
+                TlsError::Configuration(format!("platform certificate verifier init failed: {e}"))
+            });
+        }
+
+        let root_store = Self::build_root_store(config)?;
+        Ok(builder.with_root_certificates(root_store))
     }
 
     /// Build the root certificate store.
@@ -408,5 +450,39 @@ mod tests {
         let config = TlsConfig::new().strict_mode(true);
         let connector = TlsConnector::new(config).unwrap();
         assert!(connector.is_strict_mode());
+    }
+
+    /// #314: with the `native-certs` feature, the OS/platform trust verifier
+    /// must initialize successfully on the host. These prove the wiring builds
+    /// a usable config; they do NOT exercise end-to-end OS-trust validation
+    /// (that needs a server chaining to an OS-installed internal CA, validated
+    /// manually).
+    #[cfg(feature = "native-certs")]
+    mod native_certs {
+        use super::*;
+
+        #[test]
+        fn default_tls_config_uses_platform_verifier() {
+            setup_crypto_provider();
+            // Construction succeeds → the platform verifier initialized against
+            // the host OS trust store.
+            assert!(default_tls_config().is_ok());
+        }
+
+        #[test]
+        fn connector_with_empty_roots_uses_platform_verifier() {
+            setup_crypto_provider();
+            // Default config has no explicit roots → platform-verifier path.
+            assert!(TlsConnector::new(TlsConfig::default()).is_ok());
+        }
+
+        #[test]
+        fn strict_mode_builds_with_platform_verifier() {
+            setup_crypto_provider();
+            // Strict mode mandates real validation; the platform verifier path
+            // must compose with it.
+            let connector = TlsConnector::new(TlsConfig::new().strict_mode(true)).unwrap();
+            assert!(connector.is_strict_mode());
+        }
     }
 }

--- a/crates/mssql-tls/src/lib.rs
+++ b/crates/mssql-tls/src/lib.rs
@@ -24,12 +24,21 @@
 //! - Hostname verification
 //! - Custom certificate authority support
 //! - Client certificate authentication (TDS 8.0)
+//! - Optional OS/platform trust store (`native-certs` feature)
 //!
 //! ## Security
 //!
 //! By default, this crate validates server certificates using the Mozilla
 //! root certificate store. The `TrustServerCertificate` option disables
 //! validation but logs a warning - this should only be used for development.
+//!
+//! Enterprise deployments often issue server certificates from an internal CA
+//! that lives in the operating system trust store rather than Mozilla's list.
+//! Enable the `native-certs` feature to delegate validation to the OS/platform
+//! verifier (Windows CryptoAPI, macOS SecTrust, Linux native certs), which
+//! honors those internal CAs along with OS revocation and policy. Explicit
+//! [`TlsConfig::add_root_certificate`] roots always take precedence over the
+//! OS store.
 //!
 //! ```rust,ignore
 //! use mssql_tls::{TlsConfig, TlsConnector, default_tls_config};


### PR DESCRIPTION
## Summary

PR 3 of the v0.20.0 protocol-robustness batch. Adds OS/platform trust-store support so SQL Server instances chaining to an **enterprise internal CA** (installed in the OS store but absent from Mozilla's bundle) are accepted — previously rejected unless the caller supplied roots manually. Closes #314.

## Design decisions (the policy choices #314 called out)
- **Mechanism: `rustls-platform-verifier`** (not `rustls-native-certs`). As of 2026 the rustls team recommends platform-verifier for client libraries — it delegates to the OS verifier (Windows CryptoAPI / macOS SecTrust / Linux native-certs), gaining revocation (OCSP/CRL) and OS CA policy, and is deployed by 1Password, Bitwarden, Signal, rustup. `rustls-native-certs` is now "mostly for use inside the platform verifier."
- **Opt-in feature flag** (`native-certs`), off by default. Enabling it changes the trust-anchor set, so existing users' behavior and dependency tree are unchanged until they opt in.
- **Explicit roots win**: the OS verifier is used only when no `root_certificates` are configured. Setting roots takes precedence (predictable, no surprise augmentation).
- Composes with TDS 8.0 strict mode and client-certificate auth; the `TrustServerCertificate` dangerous path is unaffected.

## Changes
- `mssql-tls`: `native-certs` feature + optional `rustls-platform-verifier` dep. `default_tls_config()` and the connector's verifier selection use the platform verifier when the feature is on and no explicit roots are set; otherwise the existing webpki/custom-roots path is unchanged.
- `mssql-client`: `native-certs` feature forwards to `mssql-tls/native-certs` (implies `tls`).
- Docs: updated the `mssql-tls` crate docs and `TlsConfig::root_certificates` (the #279-corrected text) to describe the option.

## Testing
- Feature-gated unit tests (`native_certs` module): platform verifier initializes on the host, builds a usable config, and composes with strict mode.
- **Honest scope:** end-to-end validation against a server chaining to an OS-installed *internal* CA is a manual check (needs a purpose-built server + root install); the automated tests prove wiring + initialization, not the full OS-trust handshake.
- Full local gate green with the feature in `--all-features`: `just ci-all` + `just typos` + `just check-feature-flags` (compiles `native-certs` alone) + `just public-api` (unchanged — no new public items) + live ignored suite vs SQL Server 2017/2019/2022 (293 passed). Clippy clean with the feature both on and off.

Closes #314
