### PR TITLE
build(client): gate feature-dependent test/example targets with required-features (#329)

### DIFF
--- a/crates/mssql-client/Cargo.toml
+++ b/crates/mssql-client/Cargo.toml
@@ -141,6 +141,7 @@ path = "examples/bulk_insert.rs"
 [[example]]
 name = "derive_macros"
 path = "examples/derive_macros.rs"
+required-features = ["derive"]
 
 [[example]]
 name = "streaming"
@@ -161,6 +162,39 @@ harness = false
 name = "buffered_decode"
 harness = false
 required-features = ["bench"]
+
+# Integration tests that reference feature-gated APIs (type mapping, derive
+# macros, or the TLS error type) unconditionally. Declaring `required-features`
+# lets `cargo test --no-default-features` skip them instead of failing to
+# compile (#329). Each set is the minimal one whose absence breaks compilation;
+# tests not listed here compile feature-free and stay auto-discovered.
+[[test]]
+name = "azure_sql"
+required-features = ["chrono"]
+
+[[test]]
+name = "error_handling"
+required-features = ["tls"]
+
+[[test]]
+name = "bulk_insert"
+required-features = ["chrono", "decimal", "uuid"]
+
+[[test]]
+name = "derive_runtime"
+required-features = ["derive"]
+
+[[test]]
+name = "integration"
+required-features = ["chrono", "decimal", "uuid"]
+
+[[test]]
+name = "protocol_conformance"
+required-features = ["chrono", "uuid"]
+
+[[test]]
+name = "version_compatibility"
+required-features = ["chrono", "decimal"]
 
 [package.metadata.cargo-machete]
 # tokio-test is a dev-dependency for tests


### PR DESCRIPTION
## Summary

Closes #329. `cargo test -p mssql-client --no-default-features` failed to **compile** because several integration-test and example targets reference feature-gated APIs (chrono/uuid/decimal type mapping, derive macros, the TLS error type) unconditionally. This adds `required-features` to those targets in `crates/mssql-client/Cargo.toml`, following the existing `buffered_decode` bench precedent, so cargo **skips** them when the feature is off instead of failing to build.

## Per-target feature sets

Each set is the **minimal** one whose absence breaks compilation — determined empirically (compiled each target under `--no-default-features` and read the missing symbols) and verified sufficient (each builds with *exactly* these features and no others):

| Target | required-features |
|--------|-------------------|
| `tests/azure_sql` | `chrono` |
| `tests/error_handling` | `tls` (uses `mssql_tls::TlsError`) |
| `tests/derive_runtime` | `derive` |
| `examples/derive_macros` | `derive` |
| `tests/protocol_conformance` | `chrono`, `uuid` |
| `tests/version_compatibility` | `chrono`, `decimal` |
| `tests/bulk_insert` | `chrono`, `decimal`, `uuid` |
| `tests/integration` | `chrono`, `decimal`, `uuid` |

Tests that compile feature-free (e.g. `type_matrix`, `streaming_memory`, `stress`) are untouched and stay auto-discovered.

## Behavior

- `cargo test --no-default-features` now **compiles** (gated targets skipped) — was a hard build failure.
- `--all-features` and default builds are **unchanged**: every target is still built and run. Verified the full local gate + the live ignored suite (293 passed) still exercise these tests under `--all-features`.

Manifest-only change; no library or test code modified.

Closes #329
