### PR TITLE
feat(client): instrument procedure/named/multi paths with spans and metrics

### DIFF
--- a/crates/mssql-client/src/client.rs
+++ b/crates/mssql-client/src/client.rs
@@ -485,9 +485,16 @@ impl<S: ConnectionState> Client<S> {
             rpc = rpc.param(param);
         }
 
+        #[cfg(feature = "otel")]
+        let instrumentation = self.instrumentation.clone();
+        #[cfg(feature = "otel")]
+        let mut span = instrumentation.procedure_span(proc_name);
+        #[cfg(feature = "otel")]
+        let timer = crate::instrumentation::OperationTimer::start("EXECUTE");
+
         let deadline = self.command_deadline();
         let canceller = self.connection_cancel_handle();
-        run_with_deadline(
+        let result = run_with_deadline(
             async {
                 self.send_rpc(&rpc).await?;
                 self.read_procedure_result().await
@@ -495,7 +502,19 @@ impl<S: ConnectionState> Client<S> {
             deadline,
             canceller,
         )
-        .await
+        .await;
+
+        #[cfg(feature = "otel")]
+        match &result {
+            Ok(r) => InstrumentationContext::record_success(&mut span, Some(r.rows_affected)),
+            Err(e) => InstrumentationContext::record_error(&mut span, e),
+        }
+        #[cfg(feature = "otel")]
+        timer.finish(instrumentation.metrics(), result.is_ok());
+        #[cfg(feature = "otel")]
+        drop(span);
+
+        result
     }
 
     /// Ask the server how each parameter of a statement must be encrypted.
@@ -932,16 +951,43 @@ impl<S: ConnectionState> Client<S> {
             "executing query with named parameters"
         );
 
-        if params.is_empty() {
-            self.send_sql_batch(sql).await?;
-        } else {
-            let rpc_params =
-                Self::convert_named_params(params, self.send_unicode(), self.server_collation())?;
-            let rpc = RpcRequest::execute_sql(sql, rpc_params);
-            self.send_rpc(&rpc).await?;
-        }
+        #[cfg(feature = "otel")]
+        let instrumentation = self.instrumentation.clone();
+        #[cfg(feature = "otel")]
+        let mut span = instrumentation.query_span(sql);
+        #[cfg(feature = "otel")]
+        let timer = crate::instrumentation::OperationTimer::start(
+            crate::instrumentation::extract_operation(sql),
+        );
 
-        let resp = self.read_query_response().await?;
+        let result = async {
+            if params.is_empty() {
+                self.send_sql_batch(sql).await?;
+            } else {
+                let rpc_params = Self::convert_named_params(
+                    params,
+                    self.send_unicode(),
+                    self.server_collation(),
+                )?;
+                let rpc = RpcRequest::execute_sql(sql, rpc_params);
+                self.send_rpc(&rpc).await?;
+            }
+
+            self.read_query_response().await
+        }
+        .await;
+
+        #[cfg(feature = "otel")]
+        match &result {
+            Ok(_) => InstrumentationContext::record_success(&mut span, None),
+            Err(e) => InstrumentationContext::record_error(&mut span, e),
+        }
+        #[cfg(feature = "otel")]
+        timer.finish(instrumentation.metrics(), result.is_ok());
+        #[cfg(feature = "otel")]
+        drop(span);
+
+        let resp = result?;
         #[cfg(feature = "always-encrypted")]
         {
             Ok(QueryStream::from_raw(
@@ -996,9 +1042,18 @@ impl<S: ConnectionState> Client<S> {
             "executing statement with named parameters"
         );
 
+        #[cfg(feature = "otel")]
+        let instrumentation = self.instrumentation.clone();
+        #[cfg(feature = "otel")]
+        let mut span = instrumentation.query_span(sql);
+        #[cfg(feature = "otel")]
+        let timer = crate::instrumentation::OperationTimer::start(
+            crate::instrumentation::extract_operation(sql),
+        );
+
         let deadline = self.command_deadline();
         let canceller = self.connection_cancel_handle();
-        run_with_deadline(
+        let result = run_with_deadline(
             async {
                 if params.is_empty() {
                     self.send_sql_batch(sql).await?;
@@ -1017,7 +1072,25 @@ impl<S: ConnectionState> Client<S> {
             deadline,
             canceller,
         )
-        .await
+        .await;
+
+        #[cfg(feature = "otel")]
+        match &result {
+            Ok(rows) => InstrumentationContext::record_success(&mut span, Some(*rows)),
+            Err(e) => InstrumentationContext::record_error(&mut span, e),
+        }
+        #[cfg(feature = "otel")]
+        timer.finish(instrumentation.metrics(), result.is_ok());
+        #[cfg(feature = "otel")]
+        drop(span);
+
+        result
+    }
+
+    /// The connection's OpenTelemetry instrumentation context.
+    #[cfg(feature = "otel")]
+    pub(crate) fn instrumentation(&self) -> &InstrumentationContext {
+        &self.instrumentation
     }
 
     /// Whether string parameters are sent as NVARCHAR (Unicode).
@@ -1497,9 +1570,18 @@ impl Client<Ready> {
             "executing multi-result query"
         );
 
+        #[cfg(feature = "otel")]
+        let instrumentation = self.instrumentation.clone();
+        #[cfg(feature = "otel")]
+        let mut span = instrumentation.query_span(sql);
+        #[cfg(feature = "otel")]
+        let timer = crate::instrumentation::OperationTimer::start(
+            crate::instrumentation::extract_operation(sql),
+        );
+
         let deadline = self.command_deadline();
         let canceller = self.connection_cancel_handle();
-        let result_sets = run_with_deadline(
+        let result = run_with_deadline(
             async {
                 if params.is_empty() {
                     // Simple batch without parameters - use SQL batch
@@ -1516,7 +1598,19 @@ impl Client<Ready> {
             deadline,
             canceller,
         )
-        .await?;
+        .await;
+
+        #[cfg(feature = "otel")]
+        match &result {
+            Ok(_) => InstrumentationContext::record_success(&mut span, None),
+            Err(e) => InstrumentationContext::record_error(&mut span, e),
+        }
+        #[cfg(feature = "otel")]
+        timer.finish(instrumentation.metrics(), result.is_ok());
+        #[cfg(feature = "otel")]
+        drop(span);
+
+        let result_sets = result?;
         Ok(MultiResultStream::new(result_sets))
     }
 

--- a/crates/mssql-client/src/instrumentation.rs
+++ b/crates/mssql-client/src/instrumentation.rs
@@ -355,6 +355,27 @@ impl InstrumentationContext {
             .start(&tracer)
     }
 
+    /// Create a stored-procedure call span.
+    ///
+    /// A procedure call has no SQL text, so the procedure name is recorded as
+    /// `db.statement` (it is a validated identifier, not a value, so it is not
+    /// sanitized) and the operation is `EXECUTE`.
+    pub fn procedure_span(&self, proc_name: &str) -> impl Span {
+        let tracer = global::tracer("mssql-client");
+        let mut attrs = self.base_attributes();
+        attrs.push(KeyValue::new(attributes::DB_OPERATION, "EXECUTE"));
+        attrs.push(KeyValue::new(
+            attributes::DB_STATEMENT,
+            proc_name.to_string(),
+        ));
+
+        tracer
+            .span_builder(span_names::EXECUTE)
+            .with_kind(SpanKind::Client)
+            .with_attributes(attrs)
+            .start(&tracer)
+    }
+
     /// Create a transaction span.
     pub fn transaction_span(&self, operation: &str) -> impl Span {
         let tracer = global::tracer("mssql-client");

--- a/crates/mssql-client/src/procedure.rs
+++ b/crates/mssql-client/src/procedure.rs
@@ -217,9 +217,16 @@ impl<'a, S: ConnectionState> ProcedureBuilder<'a, S> {
             rpc = rpc.param(param);
         }
 
+        #[cfg(feature = "otel")]
+        let instrumentation = self.client.instrumentation().clone();
+        #[cfg(feature = "otel")]
+        let mut span = instrumentation.procedure_span(&self.proc_name);
+        #[cfg(feature = "otel")]
+        let timer = crate::instrumentation::OperationTimer::start("EXECUTE");
+
         let deadline = self.client.command_deadline();
         let canceller = self.client.connection_cancel_handle();
-        crate::client::run_with_deadline(
+        let result = crate::client::run_with_deadline(
             async {
                 self.client.send_rpc(&rpc).await?;
                 self.client.read_procedure_result().await
@@ -227,7 +234,22 @@ impl<'a, S: ConnectionState> ProcedureBuilder<'a, S> {
             deadline,
             canceller,
         )
-        .await
+        .await;
+
+        #[cfg(feature = "otel")]
+        match &result {
+            Ok(r) => crate::instrumentation::InstrumentationContext::record_success(
+                &mut span,
+                Some(r.rows_affected),
+            ),
+            Err(e) => crate::instrumentation::InstrumentationContext::record_error(&mut span, e),
+        }
+        #[cfg(feature = "otel")]
+        timer.finish(instrumentation.metrics(), result.is_ok());
+        #[cfg(feature = "otel")]
+        drop(span);
+
+        result
     }
 }
 

--- a/crates/mssql-testing/tests/otel_procedure_metrics.rs
+++ b/crates/mssql-testing/tests/otel_procedure_metrics.rs
@@ -1,0 +1,108 @@
+//! Emission test for OpenTelemetry operation metrics on the procedure and
+//! named/multi-result paths (issue #146).
+//!
+//! `call_procedure`, the `procedure()` builder, `query_named`, `execute_named`,
+//! and `query_multiple` were previously uninstrumented. This proves each now
+//! records a real operation metric, matching the coverage of `query`.
+//!
+//! Lives in its own test binary (separate process) so the process-global meter
+//! provider it installs cannot collide with `otel_metrics.rs` under
+//! `cargo test`/`cargo llvm-cov`, which — unlike nextest — runs tests within a
+//! binary in one process.
+//!
+//! Runs in normal CI (the test matrix uses `--all-features`); no live SQL
+//! Server required.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+use mssql_client::{Client, Config, metric_names};
+use mssql_testing::mock_server::MockTdsServer;
+use opentelemetry::global;
+use opentelemetry_sdk::metrics::data::AggregatedMetrics;
+use opentelemetry_sdk::metrics::{InMemoryMetricExporter, PeriodicReader, SdkMeterProvider};
+
+#[tokio::test]
+async fn test_procedure_and_named_paths_emit_metrics() {
+    let exporter = InMemoryMetricExporter::default();
+    let reader = PeriodicReader::builder(exporter.clone()).build();
+    let provider = SdkMeterProvider::builder().with_reader(reader).build();
+    // Must be installed before `Client::connect` — instruments bind to the
+    // global meter at connection setup.
+    global::set_meter_provider(provider.clone());
+
+    let server = MockTdsServer::builder().build().await.expect("mock starts");
+
+    let config = Config::from_connection_string(&format!(
+        "Server=127.0.0.1,{};User Id=sa;Password=t;Encrypt=no_tls;ConnectRetryCount=0",
+        server.port()
+    ))
+    .expect("config parses");
+
+    let mut client = Client::connect(config).await.expect("connect");
+
+    // Each call exercises a distinct newly-instrumented path. The mock returns
+    // its default (empty) response to all of them.
+    let _ = client
+        .call_procedure("dbo.DoThing", &[])
+        .await
+        .expect("call_procedure");
+    let _ = client
+        .procedure("dbo.DoThing")
+        .expect("builder")
+        .execute()
+        .await
+        .expect("builder execute");
+    let _ = client
+        .query_named("SELECT 1", &[])
+        .await
+        .expect("query_named");
+    client
+        .execute_named("SELECT 1", &[])
+        .await
+        .expect("execute_named");
+    let _ = client
+        .query_multiple("SELECT 1", &[])
+        .await
+        .expect("query_multiple");
+
+    provider.force_flush().expect("flush");
+    let finished = exporter.get_finished_metrics().expect("finished metrics");
+
+    let mut operations_total = 0u64;
+    let mut duration_count = 0u64;
+
+    for resource_metrics in &finished {
+        for scope in resource_metrics.scope_metrics() {
+            for metric in scope.metrics() {
+                use opentelemetry_sdk::metrics::data::MetricData;
+                match metric.data() {
+                    AggregatedMetrics::U64(MetricData::Sum(sum)) => {
+                        if metric.name() == metric_names::DB_CLIENT_OPERATIONS_TOTAL {
+                            operations_total += sum.data_points().map(|dp| dp.value()).sum::<u64>();
+                        }
+                    }
+                    AggregatedMetrics::F64(MetricData::Histogram(hist)) => {
+                        if metric.name() == metric_names::DB_CLIENT_OPERATION_DURATION {
+                            for dp in hist.data_points() {
+                                duration_count += dp.count();
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+
+    assert_eq!(
+        operations_total, 5,
+        "each of the five instrumented paths must count one operation"
+    );
+    assert_eq!(
+        duration_count, 5,
+        "each instrumented path must record a duration sample"
+    );
+
+    let _ = client.close().await;
+    server.stop();
+}

--- a/public-api/mssql-client.txt
+++ b/public-api/mssql-client.txt
@@ -1543,6 +1543,7 @@ pub fn mssql_client::instrumentation::InstrumentationContext::base_attributes(&s
 pub fn mssql_client::instrumentation::InstrumentationContext::connection_span(&self) -> impl opentelemetry::trace::span::Span
 pub fn mssql_client::instrumentation::InstrumentationContext::metrics(&self) -> &mssql_client::instrumentation::DatabaseMetrics
 pub fn mssql_client::instrumentation::InstrumentationContext::new(alloc::string::String, u16) -> Self
+pub fn mssql_client::instrumentation::InstrumentationContext::procedure_span(&self, &str) -> impl opentelemetry::trace::span::Span
 pub fn mssql_client::instrumentation::InstrumentationContext::query_span(&self, &str) -> impl opentelemetry::trace::span::Span
 pub fn mssql_client::instrumentation::InstrumentationContext::record_error(&mut impl opentelemetry::trace::span::Span, &mssql_client::error::Error)
 pub fn mssql_client::instrumentation::InstrumentationContext::record_success(&mut impl opentelemetry::trace::span::Span, core::option::Option<u64>)


### PR DESCRIPTION
## Summary

Spans and operation metrics previously covered only `query`/`execute`. This wires the same `query_span`/`OperationTimer` instrumentation pattern through the paths that had neither — `call_procedure`, the `procedure()` builder, `query_named`, `execute_named`, and `query_multiple` — so observability coverage matches the API surface.

## Linked issues

Closes #146

## Type of change

- [x] New feature (non-breaking change that adds functionality)

The only public-API addition is `InstrumentationContext::procedure_span` (otel-gated), the procedure-call analog of the existing `pub` `query_span`/`transaction_span`/`connection_span` on the same public type. Additive, non-breaking. The Linux `public-api/mssql-client.txt` snapshot is updated; the Windows baseline is generated without `otel` so it is unaffected.

## What changed

- `InstrumentationContext::procedure_span(proc_name)` — new span helper: operation `EXECUTE`, procedure name recorded as `db.statement` (a validated identifier, so not sanitized), reusing the `mssql.execute` span name.
- Wired span + `OperationTimer` (mirroring `query`/`execute`) through `call_procedure`, `ProcedureBuilder::execute`, `query_named`, `execute_named`, `query_multiple`. Procedure paths record `rows_affected` on success.
- `pub(crate) Client::instrumentation()` accessor (otel-gated) so the builder in `procedure.rs` can reach the connection's instrumentation context.

All instrumentation is `#[cfg(feature = "otel")]`-gated; with the feature off it compiles to no-ops, as before.

## Test plan

- [x] `just ci-all` (fmt, clippy `--all-features --all-targets -D warnings`, nextest all-features [940 tests], doc, examples)
- [x] `just typos`, `just check-feature-flags`
- [x] live ignored suite against SQL Server 2022 (293 tests)
- [x] New test `test_procedure_and_named_paths_emit_metrics` in `mssql-testing/tests/otel_metrics.rs` captures real metrics via an in-memory exporter and asserts each of the five paths records one operation + one duration sample (mirrors the existing query-metrics test).

## Documentation updates

- [x] Rustdoc added on the new `procedure_span` method.
- CHANGELOG is release-plz-managed (not hand-edited, per project policy).