### PR TITLE
fix(protocol): correct three inert wire-layer bugs (#281)

### DIFF
--- a/crates/tds-protocol/src/rpc.rs
+++ b/crates/tds-protocol/src/rpc.rs
@@ -967,15 +967,15 @@ impl RpcRequest {
     pub fn build_param_declarations(params: &[RpcParam]) -> String {
         params
             .iter()
-            .map(|p| {
+            .enumerate()
+            .map(|(idx, p)| {
                 let name = if p.name.starts_with('@') {
                     p.name.clone()
                 } else if p.name.is_empty() {
-                    // Generate positional name
-                    format!(
-                        "@p{}",
-                        params.iter().position(|x| x.name == p.name).unwrap_or(0) + 1
-                    )
+                    // Generate positional name. Use the parameter's own index;
+                    // `position()` on the empty name always returned the first
+                    // unnamed param, so multiple unnamed params all became @p1.
+                    format!("@p{}", idx + 1)
                 } else {
                     format!("@{}", p.name)
                 };
@@ -1347,6 +1347,21 @@ mod tests {
         let decls = RpcRequest::build_param_declarations(&params);
         assert!(decls.contains("@p1 int"));
         assert!(decls.contains("@name nvarchar"));
+    }
+
+    #[test]
+    fn test_param_declarations_unnamed_are_positional() {
+        // Multiple unnamed params must get distinct positional names. Previously
+        // `position()` on the empty name returned the first index for every
+        // unnamed param, collapsing them all to @p1.
+        let params = vec![
+            RpcParam::int("", 1),
+            RpcParam::int("", 2),
+            RpcParam::int("", 3),
+        ];
+
+        let decls = RpcRequest::build_param_declarations(&params);
+        assert_eq!(decls, "@p1 int, @p2 int, @p3 int");
     }
 
     #[test]

--- a/crates/tds-protocol/src/token.rs
+++ b/crates/tds-protocol/src/token.rs
@@ -2686,8 +2686,7 @@ impl TokenParser {
             | Some(TokenType::Sspi)
             | Some(TokenType::ColInfo)
             | Some(TokenType::TabName)
-            | Some(TokenType::Offset)
-            | Some(TokenType::ReturnValue) => {
+            | Some(TokenType::Offset) => {
                 if self.remaining() < 3 {
                     return Err(ProtocolError::UnexpectedEof);
                 }
@@ -2696,6 +2695,15 @@ impl TokenParser {
                     self.data[self.position + 2],
                 ]) as usize;
                 1 + 2 + length // token type + length prefix + data
+            }
+            // RETURNVALUE has no length prefix (MS-TDS §2.2.7.18): the bytes
+            // after the token type are the 2-byte ParamOrdinal, not a length.
+            // Parse to find its end, mirroring ReturnValue::decode in the main
+            // loop (the length-prefix treatment skipped `1 + 2 + ParamOrdinal`).
+            Some(TokenType::ReturnValue) => {
+                let mut buf = &self.data[self.position + 1..];
+                let _ = ReturnValue::decode(&mut buf)?;
+                self.data.len() - self.position - buf.remaining()
             }
             // Tokens with 4-byte length prefix
             Some(TokenType::SessionState) | Some(TokenType::FedAuthInfo) => {
@@ -4461,6 +4469,44 @@ mod tests {
         // Every skipped token was traversed: proof the input was non-trivial.
         assert_eq!(parser.position(), total_len);
         assert!(parser.next_token().unwrap().is_none());
+    }
+
+    /// `skip_token` must parse a RETURNVALUE to find its end, not treat the
+    /// leading ParamOrdinal as a 2-byte length prefix (issue #281). With the
+    /// old length-prefix treatment it skipped `1 + 2 + ParamOrdinal` bytes,
+    /// landing mid-token and corrupting the rest of the stream.
+    #[test]
+    fn skip_token_returnvalue_advances_to_token_end() {
+        let rv = build_return_value_intn(1, "@result", 0x01, Some(42));
+        let rv_token_len = 1 + rv.len(); // 0xAC type byte + inner fields
+
+        let mut buf = BytesMut::new();
+        buf.put_u8(TokenType::ReturnValue as u8);
+        buf.extend_from_slice(&rv);
+        // A trailing DONE proves the parser realigns exactly after the skip.
+        let done = Done {
+            status: DoneStatus {
+                more: false,
+                error: false,
+                in_xact: false,
+                count: true,
+                attn: false,
+                srverror: false,
+            },
+            cur_cmd: 0x1234,
+            row_count: 7,
+        };
+        done.encode(&mut buf);
+
+        let mut parser = TokenParser::new(buf.freeze());
+        parser.skip_token().unwrap();
+        assert_eq!(parser.position(), rv_token_len);
+
+        let Some(Token::Done(decoded)) = parser.next_token().unwrap() else {
+            panic!("expected the DONE token after skipping the RETURNVALUE");
+        };
+        assert_eq!(decoded.cur_cmd, 0x1234);
+        assert_eq!(decoded.row_count, 7);
     }
 
     /// Build an ALTMETADATA token describing one `SUM` aggregate over an `int`

--- a/crates/tds-protocol/src/types.rs
+++ b/crates/tds-protocol/src/types.rs
@@ -309,8 +309,10 @@ impl ColumnFlags {
             identity: (flags & 0x0010) != 0,
             computed: (flags & 0x0020) != 0,
             fixed_len_clr_type: (flags & 0x0100) != 0,
-            sparse_column_set: (flags & 0x0200) != 0,
-            encrypted: (flags & 0x0400) != 0,
+            // MS-TDS §2.2.7.4 Flags (LSB order): bit 9 (0x0200) is reserved,
+            // fSparseColumnSet is bit 10 (0x0400), fEncrypted is bit 11 (0x0800).
+            sparse_column_set: (flags & 0x0400) != 0,
+            encrypted: (flags & 0x0800) != 0,
             hidden: (flags & 0x2000) != 0,
             key: (flags & 0x4000) != 0,
             nullable_unknown: (flags & 0x8000) != 0,
@@ -342,10 +344,10 @@ impl ColumnFlags {
             flags |= 0x0100;
         }
         if self.sparse_column_set {
-            flags |= 0x0200;
+            flags |= 0x0400;
         }
         if self.encrypted {
-            flags |= 0x0400;
+            flags |= 0x0800;
         }
         if self.hidden {
             flags |= 0x2000;
@@ -392,5 +394,44 @@ mod tests {
         assert_eq!(flags.nullable, restored.nullable);
         assert_eq!(flags.identity, restored.identity);
         assert_eq!(flags.key, restored.key);
+    }
+
+    #[test]
+    fn test_column_flags_spec_bit_positions() {
+        // MS-TDS §2.2.7.4 Flags, least-significant-bit order. fSparseColumnSet
+        // is bit 10 (0x0400) and fEncrypted is bit 11 (0x0800); bit 9 (0x0200)
+        // is reserved. The encrypted bit MUST match crypto::COLUMN_FLAG_ENCRYPTED.
+        assert_eq!(crate::crypto::COLUMN_FLAG_ENCRYPTED, 0x0800);
+
+        let sparse = ColumnFlags::from_bits(0x0400);
+        assert!(sparse.sparse_column_set);
+        assert!(!sparse.encrypted);
+
+        let encrypted = ColumnFlags::from_bits(0x0800);
+        assert!(encrypted.encrypted);
+        assert!(!encrypted.sparse_column_set);
+
+        // Reserved bit 9 must decode to neither flag.
+        let reserved = ColumnFlags::from_bits(0x0200);
+        assert!(!reserved.sparse_column_set);
+        assert!(!reserved.encrypted);
+
+        // Each flag round-trips to exactly its spec bit.
+        assert_eq!(
+            ColumnFlags {
+                sparse_column_set: true,
+                ..Default::default()
+            }
+            .to_bits(),
+            0x0400
+        );
+        assert_eq!(
+            ColumnFlags {
+                encrypted: true,
+                ..Default::default()
+            }
+            .to_bits(),
+            0x0800
+        );
     }
 }


### PR DESCRIPTION
## Summary

Fixes three individually-inert wire-layer bugs from #281 — each genuinely wrong but on a path not exercised today. Each fix carries a unit test that fails against the prior behavior.

## Linked issues

Refs #281 (items 1–3 of 4; the dead public-API item 4 is a breaking removal, deferred to its own PR).

## Type of change

- [x] Bug fix (non-breaking — behavioral only, no public signatures change)

## What changed

1. **`ColumnFlags::from_bits`/`to_bits` wrong bits.** Used `0x0200`/`0x0400` for sparse/encrypted. Per MS-TDS §2.2.7.4 (Flags, least-significant-bit order, with reserved bit 9), `fSparseColumnSet` is bit 10 (`0x0400`) and `fEncrypted` is bit 11 (`0x0800`). This aligns the public `ColumnFlags` API with `crypto::COLUMN_FLAG_ENCRYPTED` (the working AE path) and the spec. `from_bits` has no live caller and the decode path reads raw `flags: u16` / `crypto::is_column_encrypted`, so decoding behavior is unchanged.
2. **RPC positional declaration collapsed unnamed params to `@p1`.** `build_param_declarations` called `position()` on the empty name, which always returns the first unnamed param. Now uses each parameter's own index → `@p1, @p2, …`, matching the `@p{i+1}` convention already used by `convert_params`.
3. **`skip_token` mis-skipped RETURNVALUE.** It treated the token as 2-byte-length-prefixed, but the bytes after the type are the `ParamOrdinal` (USHORT), not a length — so it skipped `1 + 2 + ParamOrdinal` bytes and corrupted the stream. Now parses via `ReturnValue::decode` to find the end, mirroring the main decode loop (which had this same bug fixed earlier).

No public-API signature changes; the `public-api` snapshot is unchanged.

## Test plan

- [x] `just ci-all` (fmt, clippy `-D warnings`, nextest all-features, doc, examples)
- [x] `just typos`, `just check-feature-flags`
- [x] live ignored suite vs SQL Server 2022 (293 tests) — protocol-interop coverage
- [x] Three new unit tests: `test_column_flags_spec_bit_positions`, `test_param_declarations_unnamed_are_positional`, `skip_token_returnvalue_advances_to_token_end`. Each is constructed to go red against the pre-fix behavior.

## Notes

The MS-TDS spec bit layout was verified against the primary source (learn.microsoft.com MS-TDS §2.2.7.4). Note the tiberius reference implementation's own `ColumnFlag` constants disagree with the spec here; the spec and this driver's own `crypto.rs` are the authorities.