### PR TITLE
test(protocol): golden wire-byte tripwire for sealed encoders (#297)

### DIFF
--- a/crates/mssql-types/src/encode.rs
+++ b/crates/mssql-types/src/encode.rs
@@ -621,4 +621,118 @@ mod tests {
         // Should be 3 bytes representing days since 0001-01-01
         assert_eq!(buf.len(), 3);
     }
+
+    // ========================================================================
+    // Golden wire-byte tripwire (#297)
+    //
+    // These sealed encoders emit TDS wire bytes but live off the public surface
+    // (re-exported only via `__private`), so cargo-public-api and semver-checks
+    // cannot see a signature or behavior change. Locking exact output bytes here
+    // turns any such change into a fast unit-test failure (a signature change
+    // fails to compile; a behavior change fails an assertion) instead of
+    // surfacing only in the live round-trip suite. `encode_datetimeoffset` is
+    // already byte-pinned by `test_datetimeoffset_encodes_utc_instant` above.
+    // ========================================================================
+
+    #[cfg(any(feature = "uuid", feature = "decimal", feature = "chrono"))]
+    fn golden(f: impl FnOnce(&mut BytesMut)) -> Vec<u8> {
+        let mut buf = BytesMut::new();
+        f(&mut buf);
+        buf.to_vec()
+    }
+
+    #[cfg(feature = "uuid")]
+    #[test]
+    fn golden_uuid_wire_bytes() {
+        // Mixed-endian: first 3 groups little-endian, last 8 bytes as-is. No
+        // length prefix (the RPC/TVP framing adds that).
+        let uuid = uuid::Uuid::from_bytes(core::array::from_fn(|i| i as u8));
+        assert_eq!(
+            golden(|b| encode_uuid(uuid, b)),
+            [3, 2, 1, 0, 5, 4, 7, 6, 8, 9, 10, 11, 12, 13, 14, 15]
+        );
+    }
+
+    #[cfg(feature = "decimal")]
+    #[test]
+    fn golden_decimal_and_money_wire_bytes() {
+        use rust_decimal::Decimal;
+
+        // DECIMAL: sign byte (1 = positive, 0 = negative) + 16-byte LE mantissa.
+        assert_eq!(
+            golden(|b| encode_decimal(Decimal::from(12345), b)),
+            [1, 0x39, 0x30, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+        );
+        assert_eq!(
+            golden(|b| encode_decimal(Decimal::from(-12345), b)),
+            [0, 0x39, 0x30, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+        );
+
+        // MONEY: value * 10_000 as i64, high 32 bits LE then low 32 bits LE.
+        // 1 → 10_000 = 0x2710.
+        assert_eq!(
+            golden(|b| encode_money(Decimal::from(1), b).unwrap()),
+            [0x00, 0x00, 0x00, 0x00, 0x10, 0x27, 0x00, 0x00]
+        );
+
+        // SMALLMONEY: value * 10_000 as i32 LE.
+        assert_eq!(
+            golden(|b| encode_smallmoney(Decimal::from(1), b).unwrap()),
+            [0x10, 0x27, 0x00, 0x00]
+        );
+    }
+
+    #[cfg(feature = "chrono")]
+    #[test]
+    fn golden_chrono_wire_bytes() {
+        let date_epoch = chrono::NaiveDate::from_ymd_opt(1, 1, 1).unwrap();
+        let dt_epoch_1900 = chrono::NaiveDate::from_ymd_opt(1900, 1, 1).unwrap();
+
+        // DATE: 3-byte LE day count since 0001-01-01. epoch+0x123456 days.
+        let date = date_epoch
+            .checked_add_days(chrono::Days::new(0x0012_3456))
+            .unwrap();
+        assert_eq!(
+            golden(|b| encode_date(date, b).unwrap()),
+            [0x56, 0x34, 0x12]
+        );
+
+        // TIME (scale 7 → 5 bytes): 100ns intervals since midnight. 01:00:00 =
+        // 36_000_000_000 intervals = 0x0000_0008_61C4_6800.
+        let one_am = chrono::NaiveTime::from_hms_opt(1, 0, 0).unwrap();
+        assert_eq!(
+            golden(|b| encode_time(one_am, b)),
+            [0x00, 0x68, 0xC4, 0x61, 0x08]
+        );
+
+        // DATETIME (legacy, 8 bytes): days since 1900 (i32 LE) + 1/300s ticks
+        // (u32 LE). epoch1900 + 0x010203 days at midnight → ticks 0.
+        let legacy = dt_epoch_1900
+            .checked_add_days(chrono::Days::new(0x0001_0203))
+            .unwrap()
+            .and_hms_opt(0, 0, 0)
+            .unwrap();
+        assert_eq!(
+            golden(|b| encode_datetime_legacy(legacy, b)),
+            [0x03, 0x02, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00]
+        );
+
+        // SMALLDATETIME (4 bytes): days since 1900 (u16 LE) + minutes (u16 LE).
+        let small = dt_epoch_1900
+            .checked_add_days(chrono::Days::new(0x0102))
+            .unwrap()
+            .and_hms_opt(0, 0, 0)
+            .unwrap();
+        assert_eq!(
+            golden(|b| encode_smalldatetime(small, b).unwrap()),
+            [0x02, 0x01, 0x00, 0x00]
+        );
+
+        // DATETIME2 (scale 7): 5 time bytes (midnight → 0) + 3 date bytes.
+        let dt2 = date.and_hms_opt(0, 0, 0).unwrap();
+        assert_eq!(
+            golden(|b| encode_datetime2(dt2, b).unwrap()),
+            [0x00, 0x00, 0x00, 0x00, 0x00, 0x56, 0x34, 0x12]
+        );
+    }
 }

--- a/crates/tds-protocol/src/sql_batch.rs
+++ b/crates/tds-protocol/src/sql_batch.rs
@@ -174,4 +174,25 @@ mod tests {
         // Even empty SQL has ALL_HEADERS (22 bytes)
         assert_eq!(payload.len(), 22);
     }
+
+    /// Golden wire-byte tripwire (#297) for the transaction-descriptor path.
+    /// These sealed encoders emit TDS wire bytes off the public surface
+    /// (`__private`), invisible to cargo-public-api/semver-checks; locking the
+    /// exact ALL_HEADERS + descriptor + UTF-16LE layout catches silent drift.
+    /// `encode_sql_batch` (zero descriptor) is pinned by `test_encode_sql_batch`.
+    #[test]
+    fn golden_sql_batch_with_transaction_bytes() {
+        let payload = sealed::encode_sql_batch_with_transaction("Hi", 0x1234_5678_90AB_CDEF);
+        assert_eq!(
+            payload.as_ref(),
+            &[
+                22, 0, 0, 0, // ALL_HEADERS TotalLength = 22
+                18, 0, 0, 0, // HeaderLength = 18
+                0x02, 0x00, // HeaderType = transaction descriptor
+                0xEF, 0xCD, 0xAB, 0x90, 0x78, 0x56, 0x34, 0x12, // descriptor (u64 LE)
+                0x01, 0, 0, 0, // OutstandingRequestCount = 1
+                0x48, 0x00, 0x69, 0x00, // "Hi" UTF-16LE
+            ]
+        );
+    }
 }

--- a/crates/tds-protocol/src/tvp.rs
+++ b/crates/tds-protocol/src/tvp.rs
@@ -1003,4 +1003,78 @@ mod tests {
         assert_eq!(&buf[..2], &(expected.len() as u16).to_le_bytes());
         assert_eq!(&buf[2..], &expected[..]);
     }
+
+    /// Golden wire-byte tripwire (#297). These sealed `encode_tvp_*` encoders
+    /// emit TDS wire bytes but live off the public surface (`__private`), so
+    /// `cargo-public-api` and semver-checks cannot see a signature or behavior
+    /// change. Locking exact output bytes here turns any such change into a
+    /// fast unit-test failure (a signature change fails to compile; a behavior
+    /// change fails an assertion) instead of surfacing only in the live suite.
+    #[test]
+    fn golden_tvp_wire_bytes() {
+        fn bytes(f: impl FnOnce(&mut BytesMut)) -> Vec<u8> {
+            let mut buf = BytesMut::new();
+            f(&mut buf);
+            buf.to_vec()
+        }
+
+        // BIT: 1-byte length + value.
+        assert_eq!(bytes(|b| encode_tvp_bit(true, b)), [0x01, 0x01]);
+        assert_eq!(bytes(|b| encode_tvp_bit(false, b)), [0x01, 0x00]);
+
+        // FLOAT: length + IEEE-754 little-endian. 1.0_f64 / 1.0_f32.
+        assert_eq!(
+            bytes(|b| encode_tvp_float(1.0, 8, b)),
+            [0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xF0, 0x3F]
+        );
+        assert_eq!(
+            bytes(|b| encode_tvp_float(1.0, 4, b)),
+            [0x04, 0x00, 0x00, 0x80, 0x3F]
+        );
+
+        // VARBINARY (non-MAX): 2-byte length + raw bytes.
+        assert_eq!(
+            bytes(|b| encode_tvp_varbinary(&[0xDE, 0xAD, 0xBE, 0xEF], 8000, b)),
+            [0x04, 0x00, 0xDE, 0xAD, 0xBE, 0xEF]
+        );
+
+        // GUID: 1-byte length + mixed-endian (first 3 groups LE, last 8 as-is).
+        let guid: [u8; 16] = core::array::from_fn(|i| i as u8);
+        assert_eq!(
+            bytes(|b| encode_tvp_guid(&guid, b)),
+            [16, 3, 2, 1, 0, 5, 4, 7, 6, 8, 9, 10, 11, 12, 13, 14, 15]
+        );
+
+        // DATE: 3-byte little-endian day count (no length prefix for TVP date).
+        assert_eq!(
+            bytes(|b| encode_tvp_date(0x0001_0203, b)),
+            [0x03, 0x02, 0x01]
+        );
+
+        // TIME (scale 7 → 5 bytes): little-endian interval count.
+        assert_eq!(
+            bytes(|b| encode_tvp_time(0x01_0203_0405, 7, b)),
+            [0x05, 0x05, 0x04, 0x03, 0x02, 0x01]
+        );
+
+        // DATETIME2 (scale 7): length(8) + 5 time bytes + 3 date bytes.
+        assert_eq!(
+            bytes(|b| encode_tvp_datetime2(0x01_0203_0405, 0x0001_0203, 7, b)),
+            [0x08, 0x05, 0x04, 0x03, 0x02, 0x01, 0x03, 0x02, 0x01]
+        );
+
+        // DATETIMEOFFSET (scale 7): length(10) + 5 time + 3 date + 2 offset (LE).
+        assert_eq!(
+            bytes(|b| encode_tvp_datetimeoffset(0x01_0203_0405, 0x0001_0203, 120, 7, b)),
+            [
+                0x0A, 0x05, 0x04, 0x03, 0x02, 0x01, 0x03, 0x02, 0x01, 0x78, 0x00
+            ]
+        );
+
+        // DECIMAL: length(17) + sign + 16-byte little-endian mantissa.
+        assert_eq!(
+            bytes(|b| encode_tvp_decimal(1, 12345, b)),
+            [17, 1, 0x39, 0x30, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+        );
+    }
 }


### PR DESCRIPTION
## Summary

#296 moved the cross-crate TDS wire encoders off the public surface into `pub(crate) mod sealed` (re-exported via `#[doc(hidden)] __private`). A side effect: cargo-public-api and semver-checks no longer see signature or behavior changes to these encoders, so a silent change — wire corruption or a `Microsoft.Data.SqlClient` interop break — would surface only at live-test time, not at diff-read time.

This locks representative output bytes for each sealed encoder in fast unit tests (no live server). A **signature** change now fails to compile; a **behavior** change fails an assertion — restoring a diff-level tripwire.

## Linked issues

Closes #297 (implements the "golden wire-byte tests" option chosen in the issue).

## Type of change

- [x] Test-only change (no production code touched)

## Coverage

- **`mssql-types/encode.rs`**: `encode_uuid`, `encode_decimal`, `encode_money`, `encode_smallmoney`, `encode_date`, `encode_time`, `encode_datetime_legacy`, `encode_smalldatetime`, `encode_datetime2`. (`encode_datetimeoffset` is already byte-pinned by `test_datetimeoffset_encodes_utc_instant`.)
- **`tds-protocol/tvp.rs`**: the `encode_tvp_*` set lacking exact-byte coverage (`bit`, `float`, `varbinary`, `guid`, `date`, `time`, `datetime2`, `datetimeoffset`, `decimal`).
- **`tds-protocol/sql_batch.rs`**: the transaction-descriptor path (`encode_sql_batch_with_transaction`). The zero-descriptor `encode_sql_batch` is already pinned by `test_encode_sql_batch`.

Date/time inputs are constructed as `epoch + known day offset` so the expected day count is the literal offset — no calendar arithmetic to get wrong. Each expected byte array was derived from the documented wire format and the encoders agreed with it on the first run.

## Test plan

- [x] `just ci-all` (fmt, clippy `-D warnings`, nextest all-features, doc, examples)
- [x] `just typos`, `just check-feature-flags` (the `golden` helper is gated `any(uuid, decimal, chrono)` so `--no-default-features` stays warning-clean)
- [x] live ignored suite vs SQL Server 2022 (293 tests)

## Notes

- This deliberately does **not** re-freeze the encoders as semver-public (per #296's intent); it adds a behavioral guard, not an API one.
- Not all sealed encoders are covered where an exact-byte test already exists; comments point to the pre-existing pins so the guard set is discoverable.