### PR TITLE
feat(client): opt-in client-side prepared-statement cache (#205)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,16 +133,29 @@ impl Client<Ready> {
 
 ### Prepared Statement Lifecycle
 
-**Status: designed, not wired.** The LRU cache exists in
-`mssql-client/src/statement_cache.rs` but no query path consults it — every
-parameterized query uses `sp_executesql` (server-side plan cache still gives
-plan reuse). The intended design when wiring lands:
+**Status: wired into the buffered `query` path, opt-in (off by default).** The
+LRU cache (`mssql-client/src/statement_cache.rs`) is consulted only when the
+`statement_cache` config flag is set (`Statement Cache=true` /
+`Config::with_statement_cache(true)`). When off (default), parameterized
+queries use `sp_executesql` (server-side plan cache still gives plan reuse).
+The wired lifecycle (in `Client::send_query_request`):
 
-1. Hash SQL → check LRU cache
-2. Cache miss → `sp_prepare` → store handle
-3. Execute via `sp_execute` with handle
-4. On eviction/close → `sp_unprepare`
-5. Pool returns handle to pool-level cache
+1. Key = param declaration + SQL → check LRU cache (`StatementCache::get`)
+2. Miss → `sp_prepare` (`RpcRequest::prepare`) → read `@handle` from the
+   procedure result → store; **`sp_execute` params are positional/unnamed**
+   (the server binds by position — naming them makes the server reject the
+   stream)
+3. Hit → `sp_execute` with the cached handle
+4. On LRU eviction → `sp_unprepare` the evicted handle (best-effort)
+5. On connection reset (RESETCONNECTION) → clear the cache (server already
+   invalidated the handles)
+
+Scope of this first increment (the rest stays on `sp_executesql`): buffered
+`query` only — not `query_stream`/`query_multiple`/Always Encrypted; no
+pool-level handle cache. Read effectiveness via
+`Client::statement_cache_stats()`. A cold miss costs two round-trips, so the
+cache wins on repeated execution — hence opt-in, to gather real numbers
+(#205).
 
 ### Azure SQL Redirect Handling
 
@@ -312,7 +325,7 @@ Key differences for migrators:
 | External pooling (bb8) | Built-in `Pool` |
 | Runtime agnostic | Tokio-only |
 | `QueryResult` iterator | `query` → buffered `QueryStream` (lazy decode), or `query_stream` → incremental `RowStream` / `query_stream_blob` → `BlobStream` (true socket streaming) |
-| Manual prepared | `sp_executesql` (client cache planned) |
+| Manual prepared | `sp_executesql`; opt-in client cache (`Statement Cache=true`) |
 | Manual Azure redirect | Automatic redirect handling |
 
 ## Commit Standards

--- a/LIMITATIONS.md
+++ b/LIMITATIONS.md
@@ -122,16 +122,27 @@ tokio::spawn(async move {
 
 ### Prepared Statement Cache
 
-**Status:** Not wired — all parameterized queries use `sp_executesql`
+**Status:** Opt-in for the buffered `query` path; off by default
 
-An LRU statement cache exists in the codebase but is not consulted by any
-query path: the driver never issues `sp_prepare`/`sp_execute`. Every
-parameterized query goes through `sp_executesql`, which still benefits from
-SQL Server's server-side plan cache, so repeated queries reuse plans —
-there is just no client-side handle caching yet.
+An LRU statement cache is wired into the buffered
+[`Client::query`](https://docs.rs/mssql-client/latest/mssql_client/struct.Client.html#method.query)
+path behind the off-by-default `statement_cache` config flag
+(`Statement Cache=true` in a connection string, or
+`Config::with_statement_cache(true)`). When enabled, a parameterized query is
+prepared once per connection (`sp_prepare`) and subsequent identical queries
+reuse the handle (`sp_execute`); the cache is cleared when the connection is
+reset (RESETCONNECTION) since that invalidates server-side handles. Read
+effectiveness via `Client::statement_cache_stats()`.
 
-**Workaround:** None needed for plan reuse (`sp_executesql` provides it).
-Client-side handle caching is planned.
+When the flag is off (the default), every parameterized query uses
+`sp_executesql`, which still benefits from SQL Server's server-side plan
+cache.
+
+**Not yet covered (still `sp_executesql`):** `query_stream`, `query_multiple`,
+and Always Encrypted queries; and there is no pool-level handle cache. A cold
+miss costs two round-trips (`sp_prepare` then `sp_execute`), so the cache wins
+only on repeated execution — hence the opt-in flag for gathering real numbers
+before any default-on decision.
 
 ---
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -10,7 +10,7 @@ This guide helps you migrate from [tiberius](https://github.com/prisma/tiberius)
 | Type-state | No | Yes (compile-time safety) |
 | Connection pooling | External (bb8/deadpool) | Built-in |
 | TDS 8.0 strict | Not supported | Yes |
-| Prepared statements | Manual | `sp_executesql` (client-side cache planned) |
+| Prepared statements | Manual | `sp_executesql`; opt-in client-side cache (`Statement Cache=true`) |
 | Azure redirects | Manual handling | Automatic |
 | Result streaming | Stream (incremental) | Buffered `query` (sync iterator) + incremental `query_stream` / `query_stream_blob` |
 | Transaction safety | Runtime checks | Compile-time checks |
@@ -393,10 +393,11 @@ for user_id in user_ids {
 ### rust-mssql-driver
 
 ```rust
-// Same model as Tiberius today: each parameterized execution goes through
-// sp_executesql. SQL Server's server-side plan cache reuses the plan across
-// calls; client-side handle caching (sp_prepare/sp_execute) is planned but
-// not yet wired (see LIMITATIONS.md).
+// By default each parameterized execution goes through sp_executesql, with
+// SQL Server's server-side plan cache reusing the plan across calls. Opt into
+// client-side handle caching (sp_prepare/sp_execute, per connection) with
+// `Statement Cache=true` or `Config::with_statement_cache(true)` — see
+// LIMITATIONS.md for the scope of this first increment.
 for user_id in user_ids {
     let mut stream = client.query(
         "SELECT * FROM users WHERE id = @p1",
@@ -576,4 +577,4 @@ let client = tx.commit().await?;  // Capture the returned client
 | `execute("BEGIN TRANSACTION")` | `begin_transaction()` |
 | `execute("COMMIT")` | `commit()` → returns client |
 | Manual Azure redirect | Automatic |
-| `sp_executesql` plan reuse | `sp_executesql` plan reuse (client-side handle cache not yet wired) |
+| `sp_executesql` plan reuse | `sp_executesql` plan reuse (+ opt-in client-side handle cache via `Statement Cache=true`) |

--- a/crates/mssql-client/src/client.rs
+++ b/crates/mssql-client/src/client.rs
@@ -345,6 +345,9 @@ impl<S: ConnectionState> Client<S> {
         let reset = self.needs_reset;
         if reset {
             self.needs_reset = false; // Clear flag before sending
+            // RESETCONNECTION invalidates all server-side prepared handles, so
+            // drop the cache (no sp_unprepare needed — the server released them).
+            let _ = self.statement_cache.clear();
             tracing::debug!("sending SQL batch with RESETCONNECTION flag");
         }
 
@@ -389,6 +392,9 @@ impl<S: ConnectionState> Client<S> {
         let reset = self.needs_reset;
         if reset {
             self.needs_reset = false; // Clear flag before sending
+            // RESETCONNECTION invalidates all server-side prepared handles, so
+            // drop the cache (no sp_unprepare needed — the server released them).
+            let _ = self.statement_cache.clear();
             tracing::debug!("sending RPC with RESETCONNECTION flag");
         }
 
@@ -566,6 +572,87 @@ impl<S: ConnectionState> Client<S> {
         let rpc_params =
             Self::convert_params(params, self.send_unicode(), self.server_collation())?;
         Ok(RpcRequest::execute_sql(sql, rpc_params))
+    }
+
+    /// Send a parameterized `query` request, consulting the prepared-statement
+    /// cache when [`Config::statement_cache`](crate::Config::statement_cache)
+    /// is enabled. Leaves the execution response ready for the caller's
+    /// `read_query_response`.
+    ///
+    /// Falls back to the default path (SQL batch for no params, `sp_executesql`
+    /// otherwise) when the cache is disabled, the query has no parameters, or
+    /// Always Encrypted is active (prepared + AE parameter encryption is out of
+    /// scope for this first increment).
+    async fn send_query_request(
+        &mut self,
+        sql: &str,
+        params: &[&(dyn crate::ToSql + Sync)],
+    ) -> Result<()> {
+        #[cfg(feature = "always-encrypted")]
+        let ae_active = self.encryption_context.is_some();
+        #[cfg(not(feature = "always-encrypted"))]
+        let ae_active = false;
+
+        if !self.config.statement_cache || params.is_empty() || ae_active {
+            if params.is_empty() {
+                self.send_sql_batch(sql).await?;
+            } else {
+                let rpc = self.build_parameterized_rpc(sql, params).await?;
+                self.send_rpc(&rpc).await?;
+            }
+            return Ok(());
+        }
+
+        let rpc_params =
+            Self::convert_params(params, self.send_unicode(), self.server_collation())?;
+        // Key on the parameter declaration + SQL: a cached handle is only valid
+        // for the exact prepared parameter types, so two calls with the same
+        // SQL but different param types must not share a handle.
+        let key = format!(
+            "{}\u{1}{sql}",
+            RpcRequest::build_param_declarations(&rpc_params)
+        );
+
+        if let Some(handle) = self.statement_cache.get(&key) {
+            let rpc = RpcRequest::execute(handle, rpc_params);
+            self.send_rpc(&rpc).await?;
+        } else {
+            // Miss: sp_prepare for a handle, then sp_execute. The caller's
+            // read_query_response reads the execute (row) response.
+            let prepare = RpcRequest::prepare(sql, &rpc_params);
+            self.send_rpc(&prepare).await?;
+            let prepared = self.read_procedure_result().await?;
+            let handle = Self::prepare_handle(&prepared)?;
+
+            if let Some(evicted) = self
+                .statement_cache
+                .insert(crate::statement_cache::PreparedStatement::new(handle, key))
+            {
+                // Release the evicted server-side handle. Best-effort: a failed
+                // sp_unprepare leaks one handle until connection reset, never
+                // corrupts data.
+                let unprepare = RpcRequest::unprepare(evicted.handle());
+                self.send_rpc(&unprepare).await?;
+                let _ = self.read_procedure_result().await?;
+            }
+
+            let rpc = RpcRequest::execute(handle, rpc_params);
+            self.send_rpc(&rpc).await?;
+        }
+        Ok(())
+    }
+
+    /// Extract the statement handle from an `sp_prepare` response — the
+    /// `@handle` OUTPUT parameter, surfaced as a RETURNVALUE / output param.
+    fn prepare_handle(result: &crate::stream::ProcedureResult) -> Result<i32> {
+        result
+            .output_params
+            .iter()
+            .find_map(|p| match &p.value {
+                mssql_types::SqlValue::Int(h) => Some(*h),
+                _ => None,
+            })
+            .ok_or_else(|| Error::Protocol("sp_prepare returned no statement handle".into()))
     }
 
     /// Encrypt the Always Encrypted parameters of a statement, then build its
@@ -1093,6 +1180,17 @@ impl<S: ConnectionState> Client<S> {
         &self.instrumentation
     }
 
+    /// Snapshot this connection's prepared-statement cache statistics.
+    ///
+    /// Reflects activity since the connection was established (or its last
+    /// reset). Meaningful only when
+    /// [`Config::statement_cache`](crate::Config::statement_cache) is enabled;
+    /// otherwise the cache is never consulted and all counts stay zero.
+    #[must_use]
+    pub fn statement_cache_stats(&self) -> crate::StatementCacheStats {
+        self.statement_cache.stats()
+    }
+
     /// Whether string parameters are sent as NVARCHAR (Unicode).
     pub(crate) fn send_unicode(&self) -> bool {
         self.config.send_string_parameters_as_unicode
@@ -1377,14 +1475,9 @@ impl Client<Ready> {
         let canceller = self.cancel_handle();
         let result = run_with_deadline(
             async {
-                if params.is_empty() {
-                    // Simple query without parameters - use SQL batch
-                    self.send_sql_batch(sql).await?;
-                } else {
-                    // Parameterized query - sp_executesql (encrypts Always Encrypted params).
-                    let rpc = self.build_parameterized_rpc(sql, params).await?;
-                    self.send_rpc(&rpc).await?;
-                }
+                // Sends via the prepared-statement cache when enabled, else the
+                // SQL batch / sp_executesql default.
+                self.send_query_request(sql, params).await?;
 
                 // Read complete response including columns and rows
                 self.read_query_response().await
@@ -2041,14 +2134,9 @@ impl Client<InTransaction> {
         let canceller = self.cancel_handle();
         let result = run_with_deadline(
             async {
-                if params.is_empty() {
-                    // Simple query without parameters - use SQL batch
-                    self.send_sql_batch(sql).await?;
-                } else {
-                    // Parameterized query - sp_executesql (encrypts Always Encrypted params).
-                    let rpc = self.build_parameterized_rpc(sql, params).await?;
-                    self.send_rpc(&rpc).await?;
-                }
+                // Sends via the prepared-statement cache when enabled, else the
+                // SQL batch / sp_executesql default.
+                self.send_query_request(sql, params).await?;
 
                 // Read complete response including columns and rows
                 self.read_query_response().await

--- a/crates/mssql-client/src/config.rs
+++ b/crates/mssql-client/src/config.rs
@@ -395,6 +395,23 @@ pub struct Config {
     /// Default: `true`
     pub send_string_parameters_as_unicode: bool,
 
+    /// Enable the client-side prepared-statement cache for parameterized
+    /// [`query`](crate::Client::query) calls.
+    ///
+    /// When `true`, a parameterized query is prepared once per connection
+    /// (`sp_prepare`) and subsequent identical queries reuse the handle
+    /// (`sp_execute`), trading a one-time cold-path round-trip for cheaper
+    /// repeated execution. When `false` (default), every parameterized query
+    /// uses `sp_executesql` (the server still reuses plans).
+    ///
+    /// This is an opt-in first increment (the `query` path only; not
+    /// `query_stream`, `query_multiple`, or Always Encrypted, which fall back
+    /// to `sp_executesql`). Set via `Statement Cache=true` in connection
+    /// strings.
+    ///
+    /// Default: `false`
+    pub statement_cache: bool,
+
     /// Always Encrypted configuration.
     ///
     /// When `Some`, the client will negotiate Always Encrypted support with the
@@ -440,6 +457,7 @@ impl Default for Config {
             language: None,
             multi_subnet_failover: false,
             send_string_parameters_as_unicode: true,
+            statement_cache: false,
             #[cfg(feature = "always-encrypted")]
             column_encryption: None,
         }
@@ -696,6 +714,10 @@ impl Config {
                 // --- String parameter encoding ---
                 "sendstringparametersasunicode" | "send string parameters as unicode" => {
                     config.send_string_parameters_as_unicode = parse_conn_bool(&key, value)?;
+                }
+                // --- Prepared-statement cache (opt-in) ---
+                "statement cache" | "statementcache" => {
+                    config.statement_cache = parse_conn_bool(&key, value)?;
                 }
                 // --- Known ADO.NET keywords not supported by this driver ---
                 "failover partner"
@@ -1062,6 +1084,15 @@ impl Config {
     #[must_use]
     pub fn with_port(mut self, port: u16) -> Self {
         self.port = port;
+        self
+    }
+
+    /// Enable or disable the client-side prepared-statement cache.
+    ///
+    /// See [`Config::statement_cache`]. Off by default.
+    #[must_use]
+    pub fn with_statement_cache(mut self, enabled: bool) -> Self {
+        self.statement_cache = enabled;
         self
     }
 
@@ -1914,6 +1945,34 @@ mod tests {
         let result = Config::from_connection_string(
             "Server=localhost;SendStringParametersAsUnicode=banana;",
         );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_statement_cache_default_off() {
+        assert!(!Config::new().statement_cache);
+    }
+
+    #[test]
+    fn test_statement_cache_connection_string() {
+        let config =
+            Config::from_connection_string("Server=localhost;Statement Cache=true;").unwrap();
+        assert!(config.statement_cache);
+
+        let config =
+            Config::from_connection_string("Server=localhost;StatementCache=false;").unwrap();
+        assert!(!config.statement_cache);
+    }
+
+    #[test]
+    fn test_statement_cache_builder() {
+        assert!(Config::new().with_statement_cache(true).statement_cache);
+        assert!(!Config::new().with_statement_cache(false).statement_cache);
+    }
+
+    #[test]
+    fn test_statement_cache_invalid_value() {
+        let result = Config::from_connection_string("Server=localhost;Statement Cache=banana;");
         assert!(result.is_err());
     }
 

--- a/crates/mssql-client/src/lib.rs
+++ b/crates/mssql-client/src/lib.rs
@@ -43,9 +43,9 @@ pub mod row;
 pub(crate) mod row_source;
 pub mod row_stream;
 pub mod state;
-// Not yet wired into the query path (queries use sp_executesql); kept
-// crate-private until the cache is actually used, so the public API does not
-// expose types for an unshipped feature. Re-export when it lands.
+// Wired into the buffered `query` path behind the off-by-default
+// `Config::statement_cache` flag. The cache types stay crate-private; only the
+// `StatementCacheStats` snapshot is re-exported (below) for observability.
 pub(crate) mod statement_cache;
 pub mod stream;
 pub mod to_params;
@@ -61,6 +61,7 @@ pub use cancel::CancelHandle;
 pub use client::Client;
 pub use config::{ApplicationIntent, Config, RedirectConfig, RetryPolicy, TimeoutConfig};
 pub use error::{Error, SharedIoError};
+pub use statement_cache::StatementCacheStats;
 // Sub-error types carried by `Error` variants and the `FromSql`/`ToSql` trait
 // return type. Re-exported so downstream crates can name them (e.g. match on
 // `Error::Type(e)`, or write `fn from_sql(..) -> Result<Self, TypeError>`)

--- a/crates/mssql-client/src/statement_cache.rs
+++ b/crates/mssql-client/src/statement_cache.rs
@@ -1,11 +1,12 @@
 //! Prepared statement caching with LRU eviction.
 //!
-//! **Status: implemented but not yet wired into the query path.** Queries
-//! currently go through `sp_executesql` (the server still reuses plans), so
-//! this cache is constructed but never consulted; its types are crate-private
-//! until it is wired. The implementation is kept ready for that integration —
-//! hence the `dead_code` allowance below. See LIMITATIONS.md § Prepared
-//! Statement Cache.
+//! **Status: wired into the buffered `query` path behind the off-by-default
+//! [`Config::statement_cache`](crate::Config::statement_cache) flag.** When the
+//! flag is off (the default), parameterized queries use `sp_executesql` and
+//! this cache is never consulted. Some helper methods (`peek`, `remove`,
+//! `hit_ratio`, `reset_stats`, …) are kept for later increments and are not yet
+//! called, hence the `dead_code` allowance below. See LIMITATIONS.md §
+//! Prepared Statement Cache.
 #![allow(dead_code)]
 //!
 //! This module provides automatic caching of prepared statements to improve performance
@@ -242,6 +243,32 @@ impl StatementCache {
         self.hits = 0;
         self.misses = 0;
     }
+
+    /// Take a point-in-time snapshot of the cache statistics.
+    #[must_use]
+    pub fn stats(&self) -> StatementCacheStats {
+        StatementCacheStats {
+            hits: self.hits,
+            misses: self.misses,
+            entries: self.cache.len(),
+        }
+    }
+}
+
+/// A point-in-time snapshot of a connection's prepared-statement cache.
+///
+/// Obtained via [`Client::statement_cache_stats`](crate::Client::statement_cache_stats).
+/// Useful for measuring the cache's effectiveness (the
+/// [`Config::statement_cache`](crate::Config::statement_cache) flag is opt-in
+/// precisely so these numbers can be gathered before defaulting it on).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct StatementCacheStats {
+    /// Number of lookups that found a cached handle.
+    pub hits: u64,
+    /// Number of lookups that missed (triggering an `sp_prepare`).
+    pub misses: u64,
+    /// Number of prepared statements currently cached.
+    pub entries: usize,
 }
 
 impl Default for StatementCache {

--- a/crates/mssql-client/tests/statement_cache_live.rs
+++ b/crates/mssql-client/tests/statement_cache_live.rs
@@ -1,0 +1,114 @@
+//! Live integration tests for the opt-in prepared-statement cache (#205).
+//!
+//! Require a running SQL Server instance; ignored by default. Run with:
+//!
+//! ```bash
+//! MSSQL_HOST=localhost MSSQL_USER=sa MSSQL_PASSWORD='YourStrong@Passw0rd' \
+//!   cargo test -p mssql-client --test statement_cache_live -- --ignored
+//! ```
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+use mssql_client::{Client, Config};
+
+/// Base test configuration from environment variables (cache off).
+fn base_config() -> Option<Config> {
+    let host = std::env::var("MSSQL_HOST").ok()?;
+    let port = std::env::var("MSSQL_PORT")
+        .ok()
+        .and_then(|p| p.parse::<u16>().ok())
+        .unwrap_or(1433);
+    let user = std::env::var("MSSQL_USER").unwrap_or_else(|_| "sa".into());
+    let password = std::env::var("MSSQL_PASSWORD").unwrap_or_else(|_| "MyStrongPassw0rd".into());
+    let database = std::env::var("MSSQL_DATABASE").unwrap_or_else(|_| "master".into());
+    let encrypt = std::env::var("MSSQL_ENCRYPT").unwrap_or_else(|_| "false".into());
+
+    let conn_str = format!(
+        "Server={host},{port};Database={database};User Id={user};Password={password};TrustServerCertificate=true;Encrypt={encrypt}"
+    );
+    Config::from_connection_string(&conn_str).ok()
+}
+
+/// Read the single i32 column of a one-row result set.
+async fn query_one_i32(client: &mut Client<mssql_client::Ready>, param: i32) -> i32 {
+    let rows = client
+        .query("SELECT @p1 AS value", &[&param])
+        .await
+        .expect("query failed");
+    let mut value = None;
+    for result in rows {
+        let row = result.expect("row should be valid");
+        value = Some(row.get::<i32>(0).expect("should get value"));
+    }
+    value.expect("expected one row")
+}
+
+#[tokio::test]
+#[ignore = "Requires SQL Server"]
+async fn statement_cache_prepares_once_then_reuses_handle() {
+    let config = base_config()
+        .expect("SQL Server config required")
+        .with_statement_cache(true);
+    let mut client = Client::connect(config).await.expect("connect");
+
+    // First execution prepares; the next three reuse the cached handle. Correct
+    // results across all four prove the sp_execute-with-cached-handle path.
+    for v in [10, 20, 30, 40] {
+        assert_eq!(query_one_i32(&mut client, v).await, v);
+    }
+
+    let stats = client.statement_cache_stats();
+    assert_eq!(stats.misses, 1, "the statement is prepared exactly once");
+    assert_eq!(stats.hits, 3, "the next three executions reuse the handle");
+    assert_eq!(stats.entries, 1, "one distinct statement cached");
+
+    client.close().await.expect("close");
+}
+
+#[tokio::test]
+#[ignore = "Requires SQL Server"]
+async fn statement_cache_keeps_distinct_statements_separate() {
+    let config = base_config()
+        .expect("SQL Server config required")
+        .with_statement_cache(true);
+    let mut client = Client::connect(config).await.expect("connect");
+
+    assert_eq!(query_one_i32(&mut client, 7).await, 7);
+    // A different SQL text must prepare its own handle, not reuse the first.
+    let rows = client
+        .query("SELECT @p1 + 1 AS value", &[&7i32])
+        .await
+        .expect("query failed");
+    let mut value = None;
+    for result in rows {
+        value = Some(result.expect("row").get::<i32>(0).expect("value"));
+    }
+    assert_eq!(value, Some(8));
+
+    let stats = client.statement_cache_stats();
+    assert_eq!(stats.misses, 2, "two distinct statements prepared");
+    assert_eq!(stats.entries, 2);
+
+    client.close().await.expect("close");
+}
+
+#[tokio::test]
+#[ignore = "Requires SQL Server"]
+async fn statement_cache_off_never_consults_cache() {
+    // Default config has the cache off: the path stays on sp_executesql and the
+    // cache is never touched.
+    let config = base_config().expect("SQL Server config required");
+    assert!(!config.statement_cache, "cache is off by default");
+    let mut client = Client::connect(config).await.expect("connect");
+
+    for v in [1, 2, 3] {
+        assert_eq!(query_one_i32(&mut client, v).await, v);
+    }
+
+    let stats = client.statement_cache_stats();
+    assert_eq!(stats.hits, 0);
+    assert_eq!(stats.misses, 0);
+    assert_eq!(stats.entries, 0);
+
+    client.close().await.expect("close");
+}

--- a/crates/tds-protocol/src/rpc.rs
+++ b/crates/tds-protocol/src/rpc.rs
@@ -1099,14 +1099,22 @@ impl RpcRequest {
     }
 
     /// Create an sp_execute request.
+    ///
+    /// `sp_execute` parameters are positional: the first is the prepared-
+    /// statement handle and the rest are the statement's parameter values in
+    /// order. They are sent unnamed so the server binds them by position rather
+    /// than trying to match a formal parameter by name.
     pub fn execute(handle: i32, params: Vec<RpcParam>) -> Self {
         let mut request = Self::by_id(ProcId::Execute);
 
-        // Handle from sp_prepare
-        request.params.push(RpcParam::int("@handle", handle));
+        // Handle from sp_prepare (positional, unnamed).
+        request.params.push(RpcParam::int("", handle));
 
-        // Add parameters
-        request.params.extend(params);
+        // Statement parameter values, positional (names cleared).
+        for mut param in params {
+            param.name.clear();
+            request.params.push(param);
+        }
 
         request
     }

--- a/public-api/mssql-client.txt
+++ b/public-api/mssql-client.txt
@@ -824,6 +824,7 @@ pub async fn mssql_client::client::Client<S>::call_procedure(&mut self, &str, &[
 pub async fn mssql_client::client::Client<S>::execute_named(&mut self, &str, &[mssql_client::to_params::NamedParam]) -> mssql_client::error::Result<u64>
 pub fn mssql_client::client::Client<S>::procedure(&mut self, &str) -> mssql_client::error::Result<mssql_client::procedure::ProcedureBuilder<'_, S>>
 pub async fn mssql_client::client::Client<S>::query_named<'a>(&'a mut self, &str, &[mssql_client::to_params::NamedParam]) -> mssql_client::error::Result<mssql_client::stream::QueryStream<'a>>
+pub fn mssql_client::client::Client<S>::statement_cache_stats(&self) -> mssql_client::StatementCacheStats
 impl<S: mssql_client::state::ConnectionState> core::fmt::Debug for mssql_client::client::Client<S>
 pub fn mssql_client::client::Client<S>::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl<S> core::marker::Freeze for mssql_client::client::Client<S>
@@ -936,6 +937,7 @@ pub mssql_client::config::Config::port: u16
 pub mssql_client::config::Config::redirect: mssql_client::config::RedirectConfig
 pub mssql_client::config::Config::retry: mssql_client::config::RetryPolicy
 pub mssql_client::config::Config::send_string_parameters_as_unicode: bool
+pub mssql_client::config::Config::statement_cache: bool
 pub mssql_client::config::Config::strict_mode: bool
 pub mssql_client::config::Config::tds_version: tds_protocol::version::TdsVersion
 pub mssql_client::config::Config::timeouts: mssql_client::config::TimeoutConfig
@@ -968,6 +970,7 @@ pub fn mssql_client::config::Config::trust_server_certificate(self, bool) -> Sel
 pub fn mssql_client::config::Config::with_column_encryption(self, mssql_client::encryption::EncryptionConfig) -> Self
 pub fn mssql_client::config::Config::with_host(self, &str) -> Self
 pub fn mssql_client::config::Config::with_port(self, u16) -> Self
+pub fn mssql_client::config::Config::with_statement_cache(self, bool) -> Self
 pub fn mssql_client::config::Config::workstation_id(self, impl core::convert::Into<alloc::string::String>) -> Self
 impl core::clone::Clone for mssql_client::config::Config
 pub fn mssql_client::config::Config::clone(&self) -> mssql_client::config::Config
@@ -4060,6 +4063,7 @@ pub async fn mssql_client::client::Client<S>::call_procedure(&mut self, &str, &[
 pub async fn mssql_client::client::Client<S>::execute_named(&mut self, &str, &[mssql_client::to_params::NamedParam]) -> mssql_client::error::Result<u64>
 pub fn mssql_client::client::Client<S>::procedure(&mut self, &str) -> mssql_client::error::Result<mssql_client::procedure::ProcedureBuilder<'_, S>>
 pub async fn mssql_client::client::Client<S>::query_named<'a>(&'a mut self, &str, &[mssql_client::to_params::NamedParam]) -> mssql_client::error::Result<mssql_client::stream::QueryStream<'a>>
+pub fn mssql_client::client::Client<S>::statement_cache_stats(&self) -> mssql_client::StatementCacheStats
 impl<S: mssql_client::state::ConnectionState> core::fmt::Debug for mssql_client::client::Client<S>
 pub fn mssql_client::client::Client<S>::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl<S> core::marker::Freeze for mssql_client::client::Client<S>
@@ -4177,6 +4181,7 @@ pub mssql_client::Config::port: u16
 pub mssql_client::Config::redirect: mssql_client::config::RedirectConfig
 pub mssql_client::Config::retry: mssql_client::config::RetryPolicy
 pub mssql_client::Config::send_string_parameters_as_unicode: bool
+pub mssql_client::Config::statement_cache: bool
 pub mssql_client::Config::strict_mode: bool
 pub mssql_client::Config::tds_version: tds_protocol::version::TdsVersion
 pub mssql_client::Config::timeouts: mssql_client::config::TimeoutConfig
@@ -4209,6 +4214,7 @@ pub fn mssql_client::config::Config::trust_server_certificate(self, bool) -> Sel
 pub fn mssql_client::config::Config::with_column_encryption(self, mssql_client::encryption::EncryptionConfig) -> Self
 pub fn mssql_client::config::Config::with_host(self, &str) -> Self
 pub fn mssql_client::config::Config::with_port(self, u16) -> Self
+pub fn mssql_client::config::Config::with_statement_cache(self, bool) -> Self
 pub fn mssql_client::config::Config::workstation_id(self, impl core::convert::Into<alloc::string::String>) -> Self
 impl core::clone::Clone for mssql_client::config::Config
 pub fn mssql_client::config::Config::clone(&self) -> mssql_client::config::Config
@@ -5420,6 +5426,61 @@ impl<T> typenum::type_operators::Same for mssql_client::error::SharedIoError
 pub type mssql_client::error::SharedIoError::Output = T
 impl<V, T> ppv_lite86::types::VZip<V> for mssql_client::error::SharedIoError where V: ppv_lite86::types::MultiLane<T>
 pub fn mssql_client::error::SharedIoError::vzip(self) -> V
+pub struct mssql_client::StatementCacheStats
+pub mssql_client::StatementCacheStats::entries: usize
+pub mssql_client::StatementCacheStats::hits: u64
+pub mssql_client::StatementCacheStats::misses: u64
+impl core::clone::Clone for mssql_client::StatementCacheStats
+pub fn mssql_client::StatementCacheStats::clone(&self) -> mssql_client::StatementCacheStats
+impl core::cmp::Eq for mssql_client::StatementCacheStats
+impl core::cmp::PartialEq for mssql_client::StatementCacheStats
+pub fn mssql_client::StatementCacheStats::eq(&self, &mssql_client::StatementCacheStats) -> bool
+impl core::fmt::Debug for mssql_client::StatementCacheStats
+pub fn mssql_client::StatementCacheStats::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for mssql_client::StatementCacheStats
+impl core::marker::StructuralPartialEq for mssql_client::StatementCacheStats
+impl core::marker::Freeze for mssql_client::StatementCacheStats
+impl core::marker::Send for mssql_client::StatementCacheStats
+impl core::marker::Sync for mssql_client::StatementCacheStats
+impl core::marker::Unpin for mssql_client::StatementCacheStats
+impl core::panic::unwind_safe::RefUnwindSafe for mssql_client::StatementCacheStats
+impl core::panic::unwind_safe::UnwindSafe for mssql_client::StatementCacheStats
+impl<Q, K> equivalent::Equivalent<K> for mssql_client::StatementCacheStats where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
+pub fn mssql_client::StatementCacheStats::equivalent(&self, &K) -> bool
+impl<T, U> core::convert::Into<U> for mssql_client::StatementCacheStats where U: core::convert::From<T>
+pub fn mssql_client::StatementCacheStats::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for mssql_client::StatementCacheStats where U: core::convert::Into<T>
+pub type mssql_client::StatementCacheStats::Error = core::convert::Infallible
+pub fn mssql_client::StatementCacheStats::try_from(U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for mssql_client::StatementCacheStats where U: core::convert::TryFrom<T>
+pub type mssql_client::StatementCacheStats::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn mssql_client::StatementCacheStats::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for mssql_client::StatementCacheStats where T: core::clone::Clone
+pub type mssql_client::StatementCacheStats::Owned = T
+pub fn mssql_client::StatementCacheStats::clone_into(&self, &mut T)
+pub fn mssql_client::StatementCacheStats::to_owned(&self) -> T
+impl<T> core::any::Any for mssql_client::StatementCacheStats where T: 'static + ?core::marker::Sized
+pub fn mssql_client::StatementCacheStats::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for mssql_client::StatementCacheStats where T: ?core::marker::Sized
+pub fn mssql_client::StatementCacheStats::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for mssql_client::StatementCacheStats where T: ?core::marker::Sized
+pub fn mssql_client::StatementCacheStats::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for mssql_client::StatementCacheStats where T: core::clone::Clone
+pub unsafe fn mssql_client::StatementCacheStats::clone_to_uninit(&self, *mut u8)
+impl<T> core::convert::From<T> for mssql_client::StatementCacheStats
+pub fn mssql_client::StatementCacheStats::from(T) -> T
+impl<T> dyn_clone::DynClone for mssql_client::StatementCacheStats where T: core::clone::Clone
+pub fn mssql_client::StatementCacheStats::__clone_box(&self, dyn_clone::sealed::Private) -> *mut ()
+impl<T> opentelemetry::context::future_ext::FutureExt for mssql_client::StatementCacheStats
+impl<T> tower_http::follow_redirect::policy::PolicyExt for mssql_client::StatementCacheStats where T: ?core::marker::Sized
+pub fn mssql_client::StatementCacheStats::and<P, B, E>(self, P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+pub fn mssql_client::StatementCacheStats::or<P, B, E>(self, P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
+impl<T> tracing::instrument::Instrument for mssql_client::StatementCacheStats
+impl<T> tracing::instrument::WithSubscriber for mssql_client::StatementCacheStats
+impl<T> typenum::type_operators::Same for mssql_client::StatementCacheStats
+pub type mssql_client::StatementCacheStats::Output = T
+impl<V, T> ppv_lite86::types::VZip<V> for mssql_client::StatementCacheStats where V: ppv_lite86::types::MultiLane<T>
+pub fn mssql_client::StatementCacheStats::vzip(self) -> V
 pub struct mssql_client::TimeoutConfig
 pub mssql_client::TimeoutConfig::command_timeout: core::time::Duration
 pub mssql_client::TimeoutConfig::connect_timeout: core::time::Duration

--- a/public-api/mssql-client.windows.txt
+++ b/public-api/mssql-client.windows.txt
@@ -745,6 +745,7 @@ pub async fn mssql_client::client::Client<S>::call_procedure(&mut self, &str, &[
 pub async fn mssql_client::client::Client<S>::execute_named(&mut self, &str, &[mssql_client::to_params::NamedParam]) -> mssql_client::error::Result<u64>
 pub fn mssql_client::client::Client<S>::procedure(&mut self, &str) -> mssql_client::error::Result<mssql_client::procedure::ProcedureBuilder<'_, S>>
 pub async fn mssql_client::client::Client<S>::query_named<'a>(&'a mut self, &str, &[mssql_client::to_params::NamedParam]) -> mssql_client::error::Result<mssql_client::stream::QueryStream<'a>>
+pub fn mssql_client::client::Client<S>::statement_cache_stats(&self) -> mssql_client::StatementCacheStats
 impl<S: mssql_client::state::ConnectionState> core::fmt::Debug for mssql_client::client::Client<S>
 pub fn mssql_client::client::Client<S>::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl<S> core::marker::Freeze for mssql_client::client::Client<S>
@@ -846,6 +847,7 @@ pub mssql_client::config::Config::port: u16
 pub mssql_client::config::Config::redirect: mssql_client::config::RedirectConfig
 pub mssql_client::config::Config::retry: mssql_client::config::RetryPolicy
 pub mssql_client::config::Config::send_string_parameters_as_unicode: bool
+pub mssql_client::config::Config::statement_cache: bool
 pub mssql_client::config::Config::strict_mode: bool
 pub mssql_client::config::Config::tds_version: tds_protocol::version::TdsVersion
 pub mssql_client::config::Config::timeouts: mssql_client::config::TimeoutConfig
@@ -877,6 +879,7 @@ pub fn mssql_client::config::Config::timeouts(self, mssql_client::config::Timeou
 pub fn mssql_client::config::Config::trust_server_certificate(self, bool) -> Self
 pub fn mssql_client::config::Config::with_host(self, &str) -> Self
 pub fn mssql_client::config::Config::with_port(self, u16) -> Self
+pub fn mssql_client::config::Config::with_statement_cache(self, bool) -> Self
 pub fn mssql_client::config::Config::workstation_id(self, impl core::convert::Into<alloc::string::String>) -> Self
 impl core::clone::Clone for mssql_client::config::Config
 pub fn mssql_client::config::Config::clone(&self) -> mssql_client::config::Config
@@ -3808,6 +3811,7 @@ pub async fn mssql_client::client::Client<S>::call_procedure(&mut self, &str, &[
 pub async fn mssql_client::client::Client<S>::execute_named(&mut self, &str, &[mssql_client::to_params::NamedParam]) -> mssql_client::error::Result<u64>
 pub fn mssql_client::client::Client<S>::procedure(&mut self, &str) -> mssql_client::error::Result<mssql_client::procedure::ProcedureBuilder<'_, S>>
 pub async fn mssql_client::client::Client<S>::query_named<'a>(&'a mut self, &str, &[mssql_client::to_params::NamedParam]) -> mssql_client::error::Result<mssql_client::stream::QueryStream<'a>>
+pub fn mssql_client::client::Client<S>::statement_cache_stats(&self) -> mssql_client::StatementCacheStats
 impl<S: mssql_client::state::ConnectionState> core::fmt::Debug for mssql_client::client::Client<S>
 pub fn mssql_client::client::Client<S>::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl<S> core::marker::Freeze for mssql_client::client::Client<S>
@@ -3914,6 +3918,7 @@ pub mssql_client::Config::port: u16
 pub mssql_client::Config::redirect: mssql_client::config::RedirectConfig
 pub mssql_client::Config::retry: mssql_client::config::RetryPolicy
 pub mssql_client::Config::send_string_parameters_as_unicode: bool
+pub mssql_client::Config::statement_cache: bool
 pub mssql_client::Config::strict_mode: bool
 pub mssql_client::Config::tds_version: tds_protocol::version::TdsVersion
 pub mssql_client::Config::timeouts: mssql_client::config::TimeoutConfig
@@ -3945,6 +3950,7 @@ pub fn mssql_client::config::Config::timeouts(self, mssql_client::config::Timeou
 pub fn mssql_client::config::Config::trust_server_certificate(self, bool) -> Self
 pub fn mssql_client::config::Config::with_host(self, &str) -> Self
 pub fn mssql_client::config::Config::with_port(self, u16) -> Self
+pub fn mssql_client::config::Config::with_statement_cache(self, bool) -> Self
 pub fn mssql_client::config::Config::workstation_id(self, impl core::convert::Into<alloc::string::String>) -> Self
 impl core::clone::Clone for mssql_client::config::Config
 pub fn mssql_client::config::Config::clone(&self) -> mssql_client::config::Config
@@ -5079,6 +5085,55 @@ impl<T> typenum::type_operators::Same for mssql_client::error::SharedIoError
 pub type mssql_client::error::SharedIoError::Output = T
 impl<V, T> ppv_lite86::types::VZip<V> for mssql_client::error::SharedIoError where V: ppv_lite86::types::MultiLane<T>
 pub fn mssql_client::error::SharedIoError::vzip(self) -> V
+pub struct mssql_client::StatementCacheStats
+pub mssql_client::StatementCacheStats::entries: usize
+pub mssql_client::StatementCacheStats::hits: u64
+pub mssql_client::StatementCacheStats::misses: u64
+impl core::clone::Clone for mssql_client::StatementCacheStats
+pub fn mssql_client::StatementCacheStats::clone(&self) -> mssql_client::StatementCacheStats
+impl core::cmp::Eq for mssql_client::StatementCacheStats
+impl core::cmp::PartialEq for mssql_client::StatementCacheStats
+pub fn mssql_client::StatementCacheStats::eq(&self, &mssql_client::StatementCacheStats) -> bool
+impl core::fmt::Debug for mssql_client::StatementCacheStats
+pub fn mssql_client::StatementCacheStats::fmt(&self, &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for mssql_client::StatementCacheStats
+impl core::marker::StructuralPartialEq for mssql_client::StatementCacheStats
+impl core::marker::Freeze for mssql_client::StatementCacheStats
+impl core::marker::Send for mssql_client::StatementCacheStats
+impl core::marker::Sync for mssql_client::StatementCacheStats
+impl core::marker::Unpin for mssql_client::StatementCacheStats
+impl core::panic::unwind_safe::RefUnwindSafe for mssql_client::StatementCacheStats
+impl core::panic::unwind_safe::UnwindSafe for mssql_client::StatementCacheStats
+impl<Q, K> equivalent::Equivalent<K> for mssql_client::StatementCacheStats where Q: core::cmp::Eq + ?core::marker::Sized, K: core::borrow::Borrow<Q> + ?core::marker::Sized
+pub fn mssql_client::StatementCacheStats::equivalent(&self, &K) -> bool
+impl<T, U> core::convert::Into<U> for mssql_client::StatementCacheStats where U: core::convert::From<T>
+pub fn mssql_client::StatementCacheStats::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for mssql_client::StatementCacheStats where U: core::convert::Into<T>
+pub type mssql_client::StatementCacheStats::Error = core::convert::Infallible
+pub fn mssql_client::StatementCacheStats::try_from(U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for mssql_client::StatementCacheStats where U: core::convert::TryFrom<T>
+pub type mssql_client::StatementCacheStats::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn mssql_client::StatementCacheStats::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> alloc::borrow::ToOwned for mssql_client::StatementCacheStats where T: core::clone::Clone
+pub type mssql_client::StatementCacheStats::Owned = T
+pub fn mssql_client::StatementCacheStats::clone_into(&self, &mut T)
+pub fn mssql_client::StatementCacheStats::to_owned(&self) -> T
+impl<T> core::any::Any for mssql_client::StatementCacheStats where T: 'static + ?core::marker::Sized
+pub fn mssql_client::StatementCacheStats::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for mssql_client::StatementCacheStats where T: ?core::marker::Sized
+pub fn mssql_client::StatementCacheStats::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for mssql_client::StatementCacheStats where T: ?core::marker::Sized
+pub fn mssql_client::StatementCacheStats::borrow_mut(&mut self) -> &mut T
+impl<T> core::clone::CloneToUninit for mssql_client::StatementCacheStats where T: core::clone::Clone
+pub unsafe fn mssql_client::StatementCacheStats::clone_to_uninit(&self, *mut u8)
+impl<T> core::convert::From<T> for mssql_client::StatementCacheStats
+pub fn mssql_client::StatementCacheStats::from(T) -> T
+impl<T> tracing::instrument::Instrument for mssql_client::StatementCacheStats
+impl<T> tracing::instrument::WithSubscriber for mssql_client::StatementCacheStats
+impl<T> typenum::type_operators::Same for mssql_client::StatementCacheStats
+pub type mssql_client::StatementCacheStats::Output = T
+impl<V, T> ppv_lite86::types::VZip<V> for mssql_client::StatementCacheStats where V: ppv_lite86::types::MultiLane<T>
+pub fn mssql_client::StatementCacheStats::vzip(self) -> V
 pub struct mssql_client::TimeoutConfig
 pub mssql_client::TimeoutConfig::command_timeout: core::time::Duration
 pub mssql_client::TimeoutConfig::connect_timeout: core::time::Duration


### PR DESCRIPTION
## Summary

Wires the existing (built-but-never-consulted) LRU statement cache into the buffered `query` path, behind a new **off-by-default** `statement_cache` config flag. This is the issue's recommended first increment — opt-in, so real latency/hit numbers can be gathered before any default-on decision.

## Linked issues

Closes #205

## Type of change

- [x] New feature (non-breaking — additive API; cache is off by default)

## How it works

Enable via `Statement Cache=true` (connection string) or `Config::with_statement_cache(true)`. Then, in `Client::send_query_request`:

1. Cache key = parameter declaration + SQL (so the same SQL with different param types never shares a handle).
2. **Hit** → `sp_execute` with the cached handle.
3. **Miss** → `sp_prepare` (read `@handle` from the procedure result) → cache it → `sp_execute`.
4. LRU eviction releases the evicted handle via `sp_unprepare` (best-effort).
5. Connection reset (RESETCONNECTION) clears the cache — the server has already invalidated all handles.

Per the agreed design (see issue discussion), a cold miss costs two round-trips (`sp_prepare` then `sp_execute`), so the cache wins only on repeated execution — exactly why it's opt-in for now. `Client::statement_cache_stats()` exposes hit/miss/entry counts for measurement.

**Scope (rest stays on `sp_executesql`):** buffered `query` only — not `query_stream`/`query_multiple`/Always Encrypted; no pool-level handle cache.

## Latent bug fixed

First live use of `RpcRequest::execute` (never exercised before — tiberius and this driver both only used `sp_executesql`) revealed it sent `sp_execute` parameters **named**, which SQL Server rejects with error 4002 ("the incoming TDS stream is incorrect"). `sp_execute` parameters are positional; they are now sent unnamed. Caught and fixed during live validation.

## Public API additions (additive, non-breaking)

- `Config::statement_cache: bool` + `Config::with_statement_cache(bool)`
- `Client::statement_cache_stats() -> StatementCacheStats`
- `StatementCacheStats { hits, misses, entries }`

Linux `public-api` snapshot updated. **The `public-api-windows` job will need its regenerated snapshot committed** (these platform-agnostic items appear in the Windows surface too; the Windows baseline can't be regenerated on Linux — I'll commit the CI-uploaded artifact).

## Test plan

- [x] `just ci-all`, `just typos`, `just check-feature-flags`
- [x] Full live ignored suite vs SQL Server 2022 — **296 tests** (293 + 3 new)
- [x] New live tests (`statement_cache_live.rs`): prove handle reuse via stats (misses=1, hits=3), distinct statements tracked separately, and cache-off never consults the cache
- [x] New config unit tests for the `Statement Cache` keyword + builder + default-off
- [x] Docs updated: CLAUDE.md, MIGRATION.md, LIMITATIONS.md (no longer "not wired")