### PR TITLE
feat(client): stream multiple trailing MAX columns via query_stream_rows (#258)

### DIFF
--- a/LIMITATIONS.md
+++ b/LIMITATIONS.md
@@ -85,19 +85,25 @@ committed or rolled back.
 
 ---
 
-### Large Object (LOB) Streaming — `query_stream_blob()`
+### Large Object (LOB) Streaming — `query_stream_blob()` / `query_stream_rows()`
 
-**Status:** Supported for a row's trailing MAX column.
+**Status:** Supported for a row's trailing MAX column(s).
 
 A row's trailing `VARBINARY(MAX)` / `NVARCHAR(MAX)` / `VARCHAR(MAX)` / `XML`
 column can be sub-streamed from the socket with **`query_stream_blob()`**
 (`stream.copy_blob_to(&mut writer).await?`), so a multi-GB cell is read in
-bounded memory rather than materialized. The MAX column must be the last
-column, and Always Encrypted result sets are not yet supported on this path.
+bounded memory rather than materialized. For result sets with **more than one**
+trailing MAX column, **`query_stream_rows()`** streams each in turn — iterate a
+row's trailing MAX columns with `while stream.next_blob().await? { … }`.
+
+The MAX column(s) must be **trailing**: a non-MAX column may not follow a MAX
+column (interleaved MAX columns are rejected with a clear error — supporting
+them needs a resumable per-column decoder, tracked in #258). Always Encrypted
+result sets are not yet supported on either path.
 
 For the buffered `query()` path, a MAX cell is fully buffered; chunk via SQL
 (`SUBSTRING`) or store large binary data externally if you cannot use
-`query_stream_blob()`.
+`query_stream_blob()` / `query_stream_rows()`.
 
 ---
 

--- a/crates/mssql-client/src/blob_stream.rs
+++ b/crates/mssql-client/src/blob_stream.rs
@@ -8,14 +8,19 @@
 //! into the row.
 //!
 //! [`BlobStream`] decodes each row's **leading scalar columns** into a [`Row`]
-//! (they are small), then exposes the **trailing MAX column** as a chunk stream
-//! pulled from the connection on demand via the `PlpDecoder`. Peak memory is
-//! one packet plus one PLP chunk.
+//! (they are small), then exposes the **trailing MAX column(s)** as chunk
+//! streams pulled from the connection on demand via the `PlpDecoder`. Peak
+//! memory is one packet plus one PLP chunk.
 //!
-//! Because TDS sends columns inline and sequentially, the MAX column must be the
-//! **last** column (anything after it could not be decoded until the BLOB was
-//! consumed). The blob of one row must be consumed before the next row; calling
-//! [`BlobStream::next`] auto-drains an unconsumed blob so the wire stays aligned.
+//! Because TDS sends columns inline and sequentially, the MAX column(s) must be
+//! **trailing** — every column must precede them (a scalar column after a BLOB
+//! could not be decoded until that BLOB was consumed).
+//! [`Client::query_stream_blob`](crate::Client::query_stream_blob) targets the
+//! single-trailing-MAX case; [`Client::query_stream_rows`](crate::Client::query_stream_rows)
+//! generalizes it to a run of trailing MAX columns, iterated with
+//! [`BlobStream::next_blob`]. The blob(s) of one row must be consumed before the
+//! next row; calling [`BlobStream::next`] auto-drains any unconsumed blob so the
+//! wire stays aligned.
 //!
 //! ```no_run
 //! # async fn ex(client: &mut mssql_client::Client<mssql_client::Ready>) -> Result<(), mssql_client::Error> {
@@ -67,35 +72,67 @@ pub struct BlobStream<'a, S: ConnectionState = Ready> {
     /// END_OF_MESSAGE seen — no more packets will arrive.
     eom: bool,
     encryption_enabled: bool,
-    /// Full result-set metadata (all columns, including the trailing MAX one).
+    /// Full result-set metadata (all columns, including the trailing MAX ones).
     meta: ColMetaData,
     /// Metadata for just the leading scalar columns (for row decoding).
     prefix_meta: ColMetaData,
     /// `Column`s for the leading scalar columns.
     scalar_row_meta: std::sync::Arc<crate::row::ColMetaData>,
-    /// Index of the trailing MAX column.
-    blob_index: usize,
-    /// PLP decoder for the current row's blob; `Some` between `next` and drain.
+    /// `Column`s for the trailing MAX columns, in wire order.
+    blob_row_meta: std::sync::Arc<crate::row::ColMetaData>,
+    /// Index of the first trailing MAX column; the scalar prefix is `0..first_blob`.
+    first_blob: usize,
+    /// Number of trailing MAX columns (1 for `query_stream_blob`).
+    blob_count: usize,
+    /// Index (within the trailing run, `0..blob_count`) of the next blob to
+    /// position; reset to 0 at the start of each row.
+    next_blob_idx: usize,
+    /// The blob currently positioned for reading (within the trailing run), or
+    /// `None` before the first is positioned / after the row is exhausted.
+    current_blob_idx: Option<usize>,
+    /// When the current row arrived as an NBCROW, its null bitmap (so each
+    /// trailing blob's nullness can be looked up); `None` for a plain ROW.
+    current_nbc: Option<NbcRow>,
+    /// Whether `next` should auto-position the first trailing blob. True for the
+    /// single-blob `query_stream_blob` path (preserves its API: the blob is
+    /// ready to read after `next`); false for the multi-blob `query_stream_rows`
+    /// path (the caller drives blobs explicitly via [`next_blob`](Self::next_blob)).
+    auto_position_first: bool,
+    /// PLP decoder for the current blob; `Some` while a non-NULL blob is being read.
     plp: Option<PlpDecoder>,
-    /// The current row's blob is NULL (an NBCROW omitted its value).
+    /// The current blob is NULL (an NBCROW omitted its value).
     blob_null: bool,
     finished: bool,
 }
 
 impl<'a, S: ConnectionState> BlobStream<'a, S> {
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         client: &'a mut Client<S>,
         buf: Bytes,
         eom: bool,
         encryption_enabled: bool,
         meta: ColMetaData,
-        blob_index: usize,
+        first_blob: usize,
+        blob_count: usize,
+        auto_position_first: bool,
     ) -> Self {
         let prefix_meta = ColMetaData {
-            columns: meta.columns.iter().take(blob_index).cloned().collect(),
+            columns: meta.columns.iter().take(first_blob).cloned().collect(),
+            cek_table: meta.cek_table.clone(),
+        };
+        let blob_meta = ColMetaData {
+            columns: meta
+                .columns
+                .iter()
+                .skip(first_blob)
+                .take(blob_count)
+                .cloned()
+                .collect(),
             cek_table: meta.cek_table.clone(),
         };
         let scalar_columns = Client::<S>::build_columns(&prefix_meta);
+        let blob_columns = Client::<S>::build_columns(&blob_meta);
         Self {
             client,
             buf,
@@ -104,7 +141,15 @@ impl<'a, S: ConnectionState> BlobStream<'a, S> {
             meta,
             prefix_meta,
             scalar_row_meta: std::sync::Arc::new(crate::row::ColMetaData::new(scalar_columns)),
-            blob_index,
+            blob_row_meta: std::sync::Arc::new(crate::row::ColMetaData::new(blob_columns)),
+            first_blob,
+            blob_count,
+            // Start as if the previous row were fully consumed, so the first
+            // `next` does not try to drain a nonexistent prior row.
+            next_blob_idx: blob_count,
+            current_blob_idx: None,
+            current_nbc: None,
+            auto_position_first,
             plp: None,
             blob_null: false,
             finished: true, // set false once construction succeeds below
@@ -117,22 +162,42 @@ impl<'a, S: ConnectionState> BlobStream<'a, S> {
         self
     }
 
-    /// The leading (scalar) columns of the result set — everything except the
-    /// trailing MAX column.
+    /// The leading (scalar) columns of the result set — everything before the
+    /// trailing MAX column(s).
     #[must_use]
     pub fn columns(&self) -> &[Column] {
         &self.scalar_row_meta.columns
     }
 
+    /// The trailing MAX (blob) columns of the result set, in wire order.
+    ///
+    /// For a [`query_stream_blob`](crate::Client::query_stream_blob) stream this
+    /// is a single column; for
+    /// [`query_stream_rows`](crate::Client::query_stream_rows) it is the run of
+    /// trailing MAX columns, in the order [`next_blob`](Self::next_blob) visits
+    /// them.
+    #[must_use]
+    pub fn blob_columns(&self) -> &[Column] {
+        &self.blob_row_meta.columns
+    }
+
+    /// The column metadata of the currently positioned blob, or `None` before
+    /// the first blob of a row is positioned (or after the row is exhausted).
+    #[must_use]
+    pub fn current_blob_column(&self) -> Option<&Column> {
+        self.current_blob_idx
+            .and_then(|j| self.blob_row_meta.columns.get(j))
+    }
+
     /// Advance to the next row, returning its scalar columns.
     ///
-    /// Auto-drains the previous row's blob if it was not fully read, so the wire
+    /// Auto-drains any unread trailing blob(s) of the previous row, so the wire
     /// stays aligned. Returns `Ok(None)` at end of stream (connection clean).
     pub async fn next(&mut self) -> Result<Option<Row>> {
         if self.finished {
             return Ok(None);
         }
-        self.drain_current_blob().await?;
+        self.drain_to_row_end().await?;
 
         loop {
             if self.buf.is_empty() {
@@ -156,7 +221,49 @@ impl<'a, S: ConnectionState> BlobStream<'a, S> {
         }
     }
 
-    /// Read the next chunk of the current row's blob, or `None` when it is fully
+    /// Advance to the next trailing MAX column of the current row, returning
+    /// `true` while one is positioned and `false` once the row's blobs are
+    /// exhausted.
+    ///
+    /// Auto-drains the previously positioned blob (if not fully read) before
+    /// advancing, so the wire stays aligned. After this returns `true`, read the
+    /// blob with [`read_chunk`](Self::read_chunk) / [`copy_blob_to`](Self::copy_blob_to)
+    /// and inspect it with [`current_blob_column`](Self::current_blob_column) /
+    /// [`blob_is_null`](Self::blob_is_null) / [`blob_len`](Self::blob_len).
+    ///
+    /// This is the iteration primitive for
+    /// [`query_stream_rows`](crate::Client::query_stream_rows):
+    ///
+    /// ```no_run
+    /// # async fn ex(client: &mut mssql_client::Client<mssql_client::Ready>) -> Result<(), mssql_client::Error> {
+    /// # let mut sink: Vec<u8> = Vec::new();
+    /// let mut stream = client
+    ///     .query_stream_rows("SELECT id, doc1, doc2 FROM files", &[])
+    ///     .await?;
+    /// while let Some(row) = stream.next().await? {
+    ///     let id: i32 = row.get_by_name("id")?;
+    ///     let _ = id;
+    ///     while stream.next_blob().await? {
+    ///         stream.copy_blob_to(&mut sink).await?; // each trailing MAX column
+    ///     }
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn next_blob(&mut self) -> Result<bool> {
+        if self.finished {
+            return Ok(false);
+        }
+        self.drain_current_blob().await?;
+        if self.next_blob_idx >= self.blob_count {
+            self.current_blob_idx = None;
+            return Ok(false);
+        }
+        self.position_next_blob();
+        Ok(true)
+    }
+
+    /// Read the next chunk of the current blob, or `None` when it is fully
     /// read (or NULL). Reads more packets from the socket as needed.
     ///
     /// Chunks are **raw bytes**, not decoded text. For an `NVARCHAR(MAX)` /
@@ -223,7 +330,7 @@ impl<'a, S: ConnectionState> BlobStream<'a, S> {
             let mut view: &[u8] = &self.buf[..];
             let before = view.len();
             view.advance(1); // ROW token byte
-            match RawRow::decode_prefix(&mut view, &self.meta, self.blob_index) {
+            match RawRow::decode_prefix(&mut view, &self.meta, self.first_blob) {
                 Ok(raw) => {
                     let consumed = before - view.len();
                     self.buf.advance(consumed);
@@ -232,8 +339,7 @@ impl<'a, S: ConnectionState> BlobStream<'a, S> {
                         &self.prefix_meta,
                         &self.scalar_row_meta,
                     )?;
-                    self.plp = Some(PlpDecoder::new());
-                    self.blob_null = false;
+                    self.begin_row(None);
                     return Ok(row);
                 }
                 Err(ProtocolError::UnexpectedEof) if !self.eom => {
@@ -249,22 +355,16 @@ impl<'a, S: ConnectionState> BlobStream<'a, S> {
             let mut view: &[u8] = &self.buf[..];
             let before = view.len();
             view.advance(1); // NBCROW token byte
-            match NbcRow::decode_prefix(&mut view, &self.meta, self.blob_index) {
+            match NbcRow::decode_prefix(&mut view, &self.meta, self.first_blob) {
                 Ok(nbc) => {
                     let consumed = before - view.len();
                     self.buf.advance(consumed);
-                    let blob_null = nbc.is_null(self.blob_index);
                     let row = crate::column_parser::convert_nbc_row(
                         &nbc,
                         &self.prefix_meta,
                         &self.scalar_row_meta,
                     )?;
-                    self.blob_null = blob_null;
-                    self.plp = if blob_null {
-                        None
-                    } else {
-                        Some(PlpDecoder::new())
-                    };
+                    self.begin_row(Some(nbc));
                     return Ok(row);
                 }
                 Err(ProtocolError::UnexpectedEof) if !self.eom => {
@@ -319,7 +419,7 @@ impl<'a, S: ConnectionState> BlobStream<'a, S> {
             }
             Token::Error(e) => Err(server_token_to_error(&e)),
             Token::ColMetaData(_) => Err(Error::Protocol(
-                "query_stream_blob does not support multiple result sets".to_string(),
+                "blob streaming does not support multiple result sets".to_string(),
             )),
             Token::EnvChange(ref e) => {
                 // Keep the transaction descriptor in sync with raw
@@ -333,13 +433,59 @@ impl<'a, S: ConnectionState> BlobStream<'a, S> {
         }
     }
 
+    /// Reset per-row blob state after decoding a row's scalar prefix, optionally
+    /// auto-positioning the first trailing blob (for the single-blob path).
+    fn begin_row(&mut self, nbc: Option<NbcRow>) {
+        self.current_nbc = nbc;
+        self.next_blob_idx = 0;
+        self.current_blob_idx = None;
+        self.plp = None;
+        self.blob_null = false;
+        if self.auto_position_first {
+            self.position_next_blob();
+        }
+    }
+
+    /// Position the next trailing blob (sync; no socket IO). Sets up its PLP
+    /// decoder, or marks it NULL when an NBCROW omitted its value.
+    fn position_next_blob(&mut self) {
+        let j = self.next_blob_idx;
+        self.next_blob_idx += 1;
+        self.current_blob_idx = Some(j);
+        let col_idx = self.first_blob + j;
+        let is_null = self
+            .current_nbc
+            .as_ref()
+            .is_some_and(|n| n.is_null(col_idx));
+        self.blob_null = is_null;
+        self.plp = if is_null {
+            None
+        } else {
+            Some(PlpDecoder::new())
+        };
+    }
+
+    /// Drain the currently positioned blob off the wire (if not fully read).
     async fn drain_current_blob(&mut self) -> Result<()> {
         if self.plp.is_some() && !self.blob_null {
             while self.read_chunk().await?.is_some() {}
         }
         self.plp = None;
-        self.blob_null = false;
         Ok(())
+    }
+
+    /// Consume every remaining trailing blob of the current row off the wire, so
+    /// the next ROW/NBCROW token is reachable. Drains the positioned blob, then
+    /// positions and drains each not-yet-visited trailing blob in turn.
+    async fn drain_to_row_end(&mut self) -> Result<()> {
+        loop {
+            self.drain_current_blob().await?;
+            if self.next_blob_idx >= self.blob_count {
+                self.current_blob_idx = None;
+                return Ok(());
+            }
+            self.position_next_blob();
+        }
     }
 
     /// Pull one packet onto the rolling buffer. Returns `false` at EOF.

--- a/crates/mssql-client/src/client.rs
+++ b/crates/mssql-client/src/client.rs
@@ -1299,6 +1299,52 @@ impl<S: ConnectionState> Client<S> {
         sql: &str,
         params: &[&(dyn crate::ToSql + Sync)],
     ) -> Result<crate::blob_stream::BlobStream<'a, S>> {
+        let (meta, buf, eom, encryption_enabled) = self.open_blob_stream(sql, params).await?;
+        let first_blob = Self::validate_blob_result_set(&meta)?;
+        Ok(crate::blob_stream::BlobStream::new(
+            self,
+            buf,
+            eom,
+            encryption_enabled,
+            meta,
+            first_blob,
+            // Single trailing MAX column; auto-position it so the existing
+            // `next` → `copy_blob_to` flow works without an explicit `next_blob`.
+            1,
+            true,
+        ))
+    }
+
+    /// Shared implementation behind `query_stream_rows` for both `Ready` and
+    /// `InTransaction`.
+    pub(crate) async fn query_stream_rows_inner<'a>(
+        &'a mut self,
+        sql: &str,
+        params: &[&(dyn crate::ToSql + Sync)],
+    ) -> Result<crate::blob_stream::BlobStream<'a, S>> {
+        let (meta, buf, eom, encryption_enabled) = self.open_blob_stream(sql, params).await?;
+        let (first_blob, blob_count) = Self::validate_blob_rows_result_set(&meta)?;
+        Ok(crate::blob_stream::BlobStream::new(
+            self,
+            buf,
+            eom,
+            encryption_enabled,
+            meta,
+            first_blob,
+            blob_count,
+            // Caller drives blobs explicitly via `next_blob`.
+            false,
+        ))
+    }
+
+    /// Send the query and pull tokens until the first `ColMetaData`, returning
+    /// the result-set metadata plus the unconsumed post-metadata wire bytes.
+    /// Shared by the single-blob and multi-blob streaming paths.
+    async fn open_blob_stream(
+        &mut self,
+        sql: &str,
+        params: &[&(dyn crate::ToSql + Sync)],
+    ) -> Result<(tds_protocol::token::ColMetaData, bytes::Bytes, bool, bool)> {
         use crate::client::response::server_token_to_error;
         use crate::row_source::{Pull, RowSource};
         use tds_protocol::token::Token;
@@ -1321,16 +1367,8 @@ impl<S: ConnectionState> Client<S> {
         loop {
             match source.pull()? {
                 Pull::Token(Token::ColMetaData(meta)) => {
-                    let blob_index = Self::validate_blob_result_set(&meta)?;
                     let (buf, eom) = source.into_parts();
-                    return Ok(crate::blob_stream::BlobStream::new(
-                        self,
-                        buf,
-                        eom,
-                        encryption_enabled,
-                        meta,
-                        blob_index,
-                    ));
+                    return Ok((meta, buf, eom, encryption_enabled));
                 }
                 Pull::Token(Token::Error(err)) => {
                     self.in_flight = false;
@@ -1339,7 +1377,7 @@ impl<S: ConnectionState> Client<S> {
                 Pull::Token(Token::Done(_)) => {
                     self.in_flight = false;
                     return Err(Error::Protocol(
-                        "query_stream_blob: query produced no result set".to_string(),
+                        "blob streaming: query produced no result set".to_string(),
                     ));
                 }
                 Pull::Token(_) => {}
@@ -1353,7 +1391,7 @@ impl<S: ConnectionState> Client<S> {
                 Pull::End => {
                     self.in_flight = false;
                     return Err(Error::Protocol(
-                        "query_stream_blob: query produced no result set".to_string(),
+                        "blob streaming: query produced no result set".to_string(),
                     ));
                 }
             }
@@ -1387,6 +1425,48 @@ impl<S: ConnectionState> Client<S> {
                 "query_stream_blob: result set has more than one MAX column".to_string(),
             )),
         }
+    }
+
+    /// Validate that a result set is shaped for [`query_stream_rows`] and return
+    /// `(first_blob_index, blob_count)` — the start and length of the trailing
+    /// run of MAX columns.
+    ///
+    /// Requires at least one MAX column and that every MAX column be trailing
+    /// (no scalar column may follow a MAX column). The interleaved case (a
+    /// scalar column after a MAX column) is rejected — supporting it needs a
+    /// resumable per-column decoder (tracked in #258).
+    fn validate_blob_rows_result_set(
+        meta: &tds_protocol::token::ColMetaData,
+    ) -> Result<(usize, usize)> {
+        if meta.cek_table.is_some() {
+            return Err(Error::Protocol(
+                "query_stream_rows does not support Always Encrypted result sets".to_string(),
+            ));
+        }
+        let first_blob = meta
+            .columns
+            .iter()
+            .position(crate::blob_stream::is_plp_max)
+            .ok_or_else(|| {
+                Error::Protocol(
+                    "query_stream_rows: result set has no MAX column — use query_stream"
+                        .to_string(),
+                )
+            })?;
+        // Every column from the first MAX column onward must itself be a MAX
+        // column; a scalar column after a blob cannot be decoded until the blob
+        // is consumed.
+        if !meta.columns[first_blob..]
+            .iter()
+            .all(crate::blob_stream::is_plp_max)
+        {
+            return Err(Error::Protocol(
+                "query_stream_rows: a non-MAX column follows a MAX column; interleaved MAX \
+                 columns are not supported (the MAX columns must be trailing)"
+                    .to_string(),
+            ));
+        }
+        Ok((first_blob, meta.columns.len() - first_blob))
     }
 }
 
@@ -1580,6 +1660,36 @@ impl Client<Ready> {
         params: &[&(dyn crate::ToSql + Sync)],
     ) -> Result<crate::blob_stream::BlobStream<'a, Ready>> {
         self.query_stream_blob_inner(sql, params).await
+    }
+
+    /// Execute a query and stream a row's **trailing MAX columns** from the
+    /// network — the multi-column generalization of
+    /// [`query_stream_blob`](Self::query_stream_blob).
+    ///
+    /// For result sets whose trailing columns are one or more MAX types
+    /// (`VARBINARY(MAX)`, `NVARCHAR(MAX)`, `VARCHAR(MAX)`, `XML`), this decodes
+    /// the leading scalar columns eagerly into the per-row [`Row`](crate::Row)
+    /// and streams each trailing MAX column's bytes incrementally from the
+    /// socket, in bounded memory. The returned
+    /// [`BlobStream`](crate::BlobStream) yields scalar rows via
+    /// [`next`](crate::BlobStream::next); within each row, iterate the trailing
+    /// MAX columns with [`next_blob`](crate::BlobStream::next_blob), reading each
+    /// with [`copy_blob_to`](crate::BlobStream::copy_blob_to) /
+    /// [`read_chunk`](crate::BlobStream::read_chunk). Also available on
+    /// `Client<InTransaction>`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the result set has no trailing MAX column, has a
+    /// non-MAX column after a MAX column (interleaved MAX columns are not
+    /// supported — the MAX columns must be trailing), or uses Always Encrypted
+    /// (not yet supported on this path).
+    pub async fn query_stream_rows<'a>(
+        &'a mut self,
+        sql: &str,
+        params: &[&(dyn crate::ToSql + Sync)],
+    ) -> Result<crate::blob_stream::BlobStream<'a, Ready>> {
+        self.query_stream_rows_inner(sql, params).await
     }
 
     /// Execute a query with a specific timeout.
@@ -2206,6 +2316,19 @@ impl Client<InTransaction> {
         self.query_stream_blob_inner(sql, params).await
     }
 
+    /// Stream a row's trailing MAX columns from the network within the
+    /// transaction.
+    ///
+    /// See [`Client<Ready>::query_stream_rows`] for semantics and constraints;
+    /// the only difference is that the query runs inside the open transaction.
+    pub async fn query_stream_rows<'a>(
+        &'a mut self,
+        sql: &str,
+        params: &[&(dyn crate::ToSql + Sync)],
+    ) -> Result<crate::blob_stream::BlobStream<'a, InTransaction>> {
+        self.query_stream_rows_inner(sql, params).await
+    }
+
     /// Execute a statement within the transaction.
     ///
     /// Returns the number of affected rows.
@@ -2558,5 +2681,90 @@ impl<S: ConnectionState> std::fmt::Debug for Client<S> {
             .field("port", &self.config.port)
             .field("database", &self.config.database)
             .finish()
+    }
+}
+
+#[cfg(test)]
+mod blob_result_set_validation_tests {
+    use tds_protocol::token::{ColMetaData, ColumnData, TypeInfo};
+    use tds_protocol::types::TypeId;
+
+    use super::{Client, Ready};
+    use crate::error::Error;
+
+    /// A scalar (non-MAX) column.
+    fn scalar(name: &str) -> ColumnData {
+        col(name, TypeId::Int4, None)
+    }
+
+    /// A MAX (PLP) column: `max_length == 0xFFFF` marks the MAX variant.
+    fn blob(name: &str) -> ColumnData {
+        col(name, TypeId::BigVarBinary, Some(0xFFFF))
+    }
+
+    fn col(name: &str, type_id: TypeId, max_length: Option<u32>) -> ColumnData {
+        ColumnData {
+            name: name.to_string(),
+            type_id,
+            col_type: 0,
+            flags: 0,
+            user_type: 0,
+            type_info: TypeInfo {
+                max_length,
+                ..Default::default()
+            },
+            crypto_metadata: None,
+        }
+    }
+
+    fn meta(columns: Vec<ColumnData>) -> ColMetaData {
+        ColMetaData {
+            columns,
+            cek_table: None,
+        }
+    }
+
+    fn validate(columns: Vec<ColumnData>) -> Result<(usize, usize), Error> {
+        Client::<Ready>::validate_blob_rows_result_set(&meta(columns))
+    }
+
+    #[test]
+    fn single_trailing_blob() {
+        assert_eq!(validate(vec![scalar("id"), blob("doc")]).unwrap(), (1, 1));
+    }
+
+    #[test]
+    fn multiple_trailing_blobs() {
+        assert_eq!(
+            validate(vec![scalar("id"), blob("doc1"), blob("doc2")]).unwrap(),
+            (1, 2)
+        );
+    }
+
+    #[test]
+    fn all_columns_blobs() {
+        assert_eq!(validate(vec![blob("a"), blob("b")]).unwrap(), (0, 2));
+    }
+
+    #[test]
+    fn no_max_column_is_rejected() {
+        assert!(matches!(
+            validate(vec![scalar("id"), scalar("j")]),
+            Err(Error::Protocol(_))
+        ));
+    }
+
+    #[test]
+    fn scalar_after_blob_is_rejected() {
+        // Interleaved MAX columns are out of scope: a scalar after a blob.
+        assert!(matches!(
+            validate(vec![scalar("id"), blob("doc"), scalar("trailing")]),
+            Err(Error::Protocol(_))
+        ));
+        // ...even when more blobs follow the interloping scalar.
+        assert!(matches!(
+            validate(vec![blob("doc1"), scalar("mid"), blob("doc2")]),
+            Err(Error::Protocol(_))
+        ));
     }
 }

--- a/crates/mssql-client/src/client/connect.rs
+++ b/crates/mssql-client/src/client/connect.rs
@@ -163,11 +163,11 @@ impl Client<Disconnected> {
                 // observer. Azure SQL always requires TLS anyway.
                 #[cfg(not(feature = "tls"))]
                 {
-                    return Err(Error::Config(
+                    Err(Error::Config(
                         "Azure AD / Entra (FEDAUTH) authentication requires TLS: \
                          enable the 'tls' feature."
                             .into(),
-                    ));
+                    ))
                 }
                 #[cfg(feature = "tls")]
                 {
@@ -1014,9 +1014,8 @@ impl Client<Disconnected> {
         let server_encryption = prelogin_response.encryption;
         if server_encryption != EncryptionLevel::NotSupported {
             return Err(Error::Config(format!(
-                "Server requires encryption (level: {:?}) but TLS feature is disabled. \
-                     Either enable the 'tls' feature or configure the server to allow unencrypted connections.",
-                server_encryption
+                "Server requires encryption (level: {server_encryption:?}) but TLS feature is disabled. \
+                     Either enable the 'tls' feature or configure the server to allow unencrypted connections."
             )));
         }
 

--- a/crates/mssql-client/tests/blob_stream.rs
+++ b/crates/mssql-client/tests/blob_stream.rs
@@ -254,3 +254,205 @@ async fn blob_stream_rejects_non_trailing_max() {
         "expected Protocol error for non-trailing MAX column"
     );
 }
+
+// ---------------------------------------------------------------------------
+// query_stream_rows: multiple trailing MAX columns per row (#258)
+// ---------------------------------------------------------------------------
+
+/// Two trailing VARBINARY(MAX) columns, both streamed per row via `next_blob`.
+#[tokio::test]
+#[ignore = "Requires SQL Server"]
+async fn stream_rows_two_trailing_blobs() {
+    let Some(cfg) = get_test_config() else {
+        return;
+    };
+    let mut client = Client::connect(cfg).await.expect("connect");
+
+    // doc1 = 30000 bytes of 'A', doc2 = 50000 bytes of 'B'.
+    const SQL: &str = "SELECT 7 AS id, \
+        CAST(REPLICATE(CAST('A' AS VARCHAR(MAX)), 30000) AS VARBINARY(MAX)) AS doc1, \
+        CAST(REPLICATE(CAST('B' AS VARCHAR(MAX)), 50000) AS VARBINARY(MAX)) AS doc2";
+
+    let mut stream = client.query_stream_rows(SQL, &[]).await.expect("stream");
+    // The trailing MAX columns are reported in wire order.
+    let blob_names: Vec<String> = stream
+        .blob_columns()
+        .iter()
+        .map(|c| c.name.clone())
+        .collect();
+    assert_eq!(blob_names, vec!["doc1".to_string(), "doc2".to_string()]);
+
+    let row = stream.next().await.expect("next").expect("one row");
+    assert_eq!(row.get_by_name::<i32>("id").unwrap(), 7);
+
+    let mut collected: Vec<(String, Vec<u8>)> = Vec::new();
+    while stream.next_blob().await.expect("next_blob") {
+        let name = stream
+            .current_blob_column()
+            .expect("blob column")
+            .name
+            .clone();
+        let mut sink: Vec<u8> = Vec::new();
+        stream.copy_blob_to(&mut sink).await.expect("copy blob");
+        collected.push((name, sink));
+    }
+
+    assert_eq!(collected.len(), 2);
+    assert_eq!(collected[0].0, "doc1");
+    assert_eq!(collected[0].1.len(), 30_000);
+    assert!(collected[0].1.iter().all(|&b| b == 0x41));
+    assert_eq!(collected[1].0, "doc2");
+    assert_eq!(collected[1].1.len(), 50_000);
+    assert!(collected[1].1.iter().all(|&b| b == 0x42));
+
+    assert!(stream.next().await.expect("next").is_none());
+}
+
+/// A NULL blob between two non-NULL blobs (NBCROW path): the null one yields no
+/// chunks and does not desynchronize the following blob.
+#[tokio::test]
+#[ignore = "Requires SQL Server"]
+async fn stream_rows_null_blob_among_blobs() {
+    let Some(cfg) = get_test_config() else {
+        return;
+    };
+    let mut client = Client::connect(cfg).await.expect("connect");
+
+    const SQL: &str = "SELECT 1 AS id, \
+        CAST(REPLICATE(CAST('A' AS VARCHAR(MAX)), 20000) AS VARBINARY(MAX)) AS doc1, \
+        CAST(NULL AS VARBINARY(MAX)) AS doc2, \
+        CAST(REPLICATE(CAST('C' AS VARCHAR(MAX)), 20000) AS VARBINARY(MAX)) AS doc3";
+
+    let mut stream = client.query_stream_rows(SQL, &[]).await.expect("stream");
+    let _ = stream.next().await.expect("next").expect("one row");
+
+    // doc1: non-null
+    assert!(stream.next_blob().await.expect("next_blob"));
+    assert!(!stream.blob_is_null());
+    let mut b1 = Vec::new();
+    while let Some(c) = stream.read_chunk().await.expect("chunk") {
+        b1.extend_from_slice(&c);
+    }
+    assert_eq!(b1.len(), 20_000);
+    assert!(b1.iter().all(|&b| b == 0x41));
+
+    // doc2: NULL
+    assert!(stream.next_blob().await.expect("next_blob"));
+    assert!(stream.blob_is_null());
+    assert!(stream.read_chunk().await.expect("chunk").is_none());
+
+    // doc3: non-null, must be intact after the NULL blob
+    assert!(stream.next_blob().await.expect("next_blob"));
+    assert!(!stream.blob_is_null());
+    let mut b3 = Vec::new();
+    while let Some(c) = stream.read_chunk().await.expect("chunk") {
+        b3.extend_from_slice(&c);
+    }
+    assert_eq!(b3.len(), 20_000);
+    assert!(b3.iter().all(|&b| b == 0x43));
+
+    // No more blobs, no more rows.
+    assert!(!stream.next_blob().await.expect("next_blob"));
+    assert!(stream.next().await.expect("next").is_none());
+}
+
+/// Advancing rows without reading the trailing blobs auto-drains all of them;
+/// subsequent rows and the connection stay intact.
+#[tokio::test]
+#[ignore = "Requires SQL Server"]
+async fn stream_rows_auto_drain_unread_blobs() {
+    let Some(cfg) = get_test_config() else {
+        return;
+    };
+    let mut client = Client::connect(cfg).await.expect("connect");
+
+    const SQL: &str = "SELECT n AS id, \
+        CAST(REPLICATE(CAST('A' AS VARCHAR(MAX)), 40000) AS VARBINARY(MAX)) AS doc1, \
+        CAST(REPLICATE(CAST('B' AS VARCHAR(MAX)), 40000) AS VARBINARY(MAX)) AS doc2 \
+        FROM (VALUES (1), (2), (3)) v(n)";
+
+    let mut stream = client.query_stream_rows(SQL, &[]).await.expect("stream");
+    let mut ids = Vec::new();
+    // Read no blobs at all — next() must drain both trailing blobs per row.
+    while let Some(row) = stream.next().await.expect("next") {
+        ids.push(row.get_by_name::<i32>("id").unwrap());
+    }
+    assert_eq!(ids, vec![1, 2, 3]);
+
+    // Partially-read case: read only the first blob of a fresh stream, then advance.
+    let mut stream = client.query_stream_rows(SQL, &[]).await.expect("stream");
+    let _ = stream.next().await.expect("next").expect("row 1");
+    assert!(stream.next_blob().await.expect("next_blob"));
+    let _ = stream.read_chunk().await.expect("chunk"); // one chunk of doc1, leave doc2 untouched
+    // Advancing must drain the rest of doc1 AND all of doc2.
+    let mut rest = Vec::new();
+    while let Some(row) = stream.next().await.expect("next") {
+        rest.push(row.get_by_name::<i32>("id").unwrap());
+    }
+    assert_eq!(rest, vec![2, 3]);
+
+    // Connection must be clean afterwards.
+    let rows = client
+        .query("SELECT 99 AS v", &[])
+        .await
+        .expect("reuse")
+        .collect_all()
+        .await
+        .expect("collect");
+    assert_eq!(rows[0].get_by_name::<i32>("v").unwrap(), 99);
+}
+
+/// `query_stream_rows` rejects an interleaved layout (a scalar column after a
+/// MAX column).
+#[tokio::test]
+#[ignore = "Requires SQL Server"]
+async fn stream_rows_rejects_scalar_after_blob() {
+    let Some(cfg) = get_test_config() else {
+        return;
+    };
+    let mut client = Client::connect(cfg).await.expect("connect");
+    let result = client
+        .query_stream_rows("SELECT CAST('x' AS VARCHAR(MAX)) AS doc, 1 AS id", &[])
+        .await;
+    assert!(
+        matches!(result, Err(Error::Protocol(_))),
+        "expected Protocol error for a scalar column after a MAX column"
+    );
+}
+
+/// `query_stream_rows` works on a `Client<InTransaction>`.
+#[tokio::test]
+#[ignore = "Requires SQL Server"]
+async fn stream_rows_within_transaction() {
+    let Some(cfg) = get_test_config() else {
+        return;
+    };
+    let client = Client::connect(cfg).await.expect("connect");
+    let mut tx = client.begin_transaction().await.expect("begin");
+
+    const SQL: &str = "SELECT 1 AS id, \
+        CAST(REPLICATE(CAST('A' AS VARCHAR(MAX)), 10000) AS VARBINARY(MAX)) AS doc1, \
+        CAST(REPLICATE(CAST('B' AS VARCHAR(MAX)), 10000) AS VARBINARY(MAX)) AS doc2";
+
+    {
+        let mut stream = tx.query_stream_rows(SQL, &[]).await.expect("stream in tx");
+        let _ = stream.next().await.expect("next").expect("one row");
+        let mut total = 0u64;
+        while stream.next_blob().await.expect("next_blob") {
+            let mut sink: Vec<u8> = Vec::new();
+            total += stream.copy_blob_to(&mut sink).await.expect("copy blob");
+        }
+        assert_eq!(total, 20_000);
+        assert!(stream.next().await.expect("next").is_none());
+    }
+
+    let mut client = tx.commit().await.expect("commit");
+    let rows = client
+        .query("SELECT 29 AS v", &[])
+        .await
+        .expect("reuse after commit")
+        .collect_all()
+        .await
+        .expect("collect");
+    assert_eq!(rows[0].get_by_name::<i32>("v").unwrap(), 29);
+}

--- a/crates/mssql-client/tests/streaming_memory.rs
+++ b/crates/mssql-client/tests/streaming_memory.rs
@@ -141,3 +141,44 @@ async fn blob_streaming_bounds_peak_memory() {
          this to ~one chunk, not the whole 30 MB cell"
     );
 }
+
+/// A row with *two* ~15 MB `VARBINARY(MAX)` columns streamed in sequence via
+/// [`Client::query_stream_rows`] must keep peak heap far below either cell —
+/// proving the multi-blob path streams each trailing column from the socket
+/// rather than materializing it. The buffered path would hold ~30 MB.
+#[tokio::test]
+#[ignore = "Requires a live SQL Server"]
+async fn multi_blob_streaming_bounds_peak_memory() {
+    let Some(cfg) = config() else {
+        return;
+    };
+    let mut client = Client::connect(cfg).await.expect("connect");
+
+    const TWO_BIG_BLOBS: &str = "SELECT 1 AS id, \
+        CAST(REPLICATE(CAST('A' AS VARCHAR(MAX)), 15000000) AS VARBINARY(MAX)) AS doc1, \
+        CAST(REPLICATE(CAST('B' AS VARCHAR(MAX)), 15000000) AS VARBINARY(MAX)) AS doc2";
+
+    let baseline = LIVE.load(Ordering::Relaxed);
+    PEAK.store(baseline, Ordering::Relaxed);
+
+    let mut stream = client
+        .query_stream_rows(TWO_BIG_BLOBS, &[])
+        .await
+        .expect("stream");
+    let _ = stream.next().await.expect("next").expect("one row");
+    let mut sink = tokio::io::sink();
+    let mut total = 0u64;
+    while stream.next_blob().await.expect("next_blob") {
+        total += stream.copy_blob_to(&mut sink).await.expect("copy blob");
+    }
+
+    let peak_delta = PEAK.load(Ordering::Relaxed).saturating_sub(baseline);
+    eprintln!("total_blob_bytes={total} peak_delta={peak_delta} bytes");
+
+    assert_eq!(total, 30_000_000, "expected two 15 MB blobs");
+    assert!(
+        peak_delta < 2_000_000,
+        "peak heap delta was {peak_delta} bytes — multi-blob streaming should \
+         bound this to ~one chunk, not a whole 15 MB cell"
+    );
+}

--- a/public-api/mssql-client.txt
+++ b/public-api/mssql-client.txt
@@ -129,11 +129,14 @@ pub fn mssql_client::blob::BlobReader::vzip(self) -> V
 pub mod mssql_client::blob_stream
 pub struct mssql_client::blob_stream::BlobStream<'a, S: mssql_client::state::ConnectionState>
 impl<'a, S: mssql_client::state::ConnectionState> mssql_client::blob_stream::BlobStream<'a, S>
+pub fn mssql_client::blob_stream::BlobStream<'a, S>::blob_columns(&self) -> &[mssql_client::row::Column]
 pub fn mssql_client::blob_stream::BlobStream<'a, S>::blob_is_null(&self) -> bool
 pub fn mssql_client::blob_stream::BlobStream<'a, S>::blob_len(&self) -> core::option::Option<u64>
 pub fn mssql_client::blob_stream::BlobStream<'a, S>::columns(&self) -> &[mssql_client::row::Column]
 pub async fn mssql_client::blob_stream::BlobStream<'a, S>::copy_blob_to<W>(&mut self, &mut W) -> mssql_client::error::Result<u64> where W: tokio::io::async_write::AsyncWrite + core::marker::Unpin
+pub fn mssql_client::blob_stream::BlobStream<'a, S>::current_blob_column(&self) -> core::option::Option<&mssql_client::row::Column>
 pub async fn mssql_client::blob_stream::BlobStream<'a, S>::next(&mut self) -> mssql_client::error::Result<core::option::Option<mssql_client::row::Row>>
+pub async fn mssql_client::blob_stream::BlobStream<'a, S>::next_blob(&mut self) -> mssql_client::error::Result<bool>
 pub async fn mssql_client::blob_stream::BlobStream<'a, S>::read_chunk(&mut self) -> mssql_client::error::Result<core::option::Option<bytes::bytes::Bytes>>
 impl<'a, S> !core::marker::Freeze for mssql_client::blob_stream::BlobStream<'a, S>
 impl<'a, S> core::marker::Send for mssql_client::blob_stream::BlobStream<'a, S> where S: core::marker::Send
@@ -791,6 +794,7 @@ pub async fn mssql_client::client::Client<mssql_client::state::InTransaction>::e
 pub async fn mssql_client::client::Client<mssql_client::state::InTransaction>::query<'a>(&'a mut self, &str, &[&(dyn mssql_types::to_sql::ToSql + core::marker::Sync)]) -> mssql_client::error::Result<mssql_client::stream::QueryStream<'a>>
 pub async fn mssql_client::client::Client<mssql_client::state::InTransaction>::query_stream<'a>(&'a mut self, &str, &[&(dyn mssql_types::to_sql::ToSql + core::marker::Sync)]) -> mssql_client::error::Result<mssql_client::row_stream::RowStream<'a, mssql_client::state::InTransaction>>
 pub async fn mssql_client::client::Client<mssql_client::state::InTransaction>::query_stream_blob<'a>(&'a mut self, &str, &[&(dyn mssql_types::to_sql::ToSql + core::marker::Sync)]) -> mssql_client::error::Result<mssql_client::blob_stream::BlobStream<'a, mssql_client::state::InTransaction>>
+pub async fn mssql_client::client::Client<mssql_client::state::InTransaction>::query_stream_rows<'a>(&'a mut self, &str, &[&(dyn mssql_types::to_sql::ToSql + core::marker::Sync)]) -> mssql_client::error::Result<mssql_client::blob_stream::BlobStream<'a, mssql_client::state::InTransaction>>
 pub async fn mssql_client::client::Client<mssql_client::state::InTransaction>::query_with_timeout<'a>(&'a mut self, &str, &[&(dyn mssql_types::to_sql::ToSql + core::marker::Sync)], core::time::Duration) -> mssql_client::error::Result<mssql_client::stream::QueryStream<'a>>
 pub async fn mssql_client::client::Client<mssql_client::state::InTransaction>::release_savepoint(&mut self, mssql_client::transaction::SavePoint) -> mssql_client::error::Result<()>
 pub async fn mssql_client::client::Client<mssql_client::state::InTransaction>::rollback(self) -> mssql_client::error::Result<mssql_client::client::Client<mssql_client::state::Ready>>
@@ -815,6 +819,7 @@ pub async fn mssql_client::client::Client<mssql_client::state::Ready>::query<'a>
 pub async fn mssql_client::client::Client<mssql_client::state::Ready>::query_multiple<'a>(&'a mut self, &str, &[&(dyn mssql_types::to_sql::ToSql + core::marker::Sync)]) -> mssql_client::error::Result<mssql_client::stream::MultiResultStream<'a>>
 pub async fn mssql_client::client::Client<mssql_client::state::Ready>::query_stream<'a>(&'a mut self, &str, &[&(dyn mssql_types::to_sql::ToSql + core::marker::Sync)]) -> mssql_client::error::Result<mssql_client::row_stream::RowStream<'a, mssql_client::state::Ready>>
 pub async fn mssql_client::client::Client<mssql_client::state::Ready>::query_stream_blob<'a>(&'a mut self, &str, &[&(dyn mssql_types::to_sql::ToSql + core::marker::Sync)]) -> mssql_client::error::Result<mssql_client::blob_stream::BlobStream<'a, mssql_client::state::Ready>>
+pub async fn mssql_client::client::Client<mssql_client::state::Ready>::query_stream_rows<'a>(&'a mut self, &str, &[&(dyn mssql_types::to_sql::ToSql + core::marker::Sync)]) -> mssql_client::error::Result<mssql_client::blob_stream::BlobStream<'a, mssql_client::state::Ready>>
 pub async fn mssql_client::client::Client<mssql_client::state::Ready>::query_with_timeout<'a>(&'a mut self, &str, &[&(dyn mssql_types::to_sql::ToSql + core::marker::Sync)], core::time::Duration) -> mssql_client::error::Result<mssql_client::stream::QueryStream<'a>>
 pub async fn mssql_client::client::Client<mssql_client::state::Ready>::simple_query(&mut self, &str) -> mssql_client::error::Result<()>
 impl<S: mssql_client::state::ConnectionState> mssql_client::client::Client<S>
@@ -3500,11 +3505,14 @@ impl<V, T> ppv_lite86::types::VZip<V> for mssql_client::change_tracking::SyncVer
 pub fn mssql_client::change_tracking::SyncVersionStatus::vzip(self) -> V
 pub struct mssql_client::BlobStream<'a, S: mssql_client::state::ConnectionState>
 impl<'a, S: mssql_client::state::ConnectionState> mssql_client::blob_stream::BlobStream<'a, S>
+pub fn mssql_client::blob_stream::BlobStream<'a, S>::blob_columns(&self) -> &[mssql_client::row::Column]
 pub fn mssql_client::blob_stream::BlobStream<'a, S>::blob_is_null(&self) -> bool
 pub fn mssql_client::blob_stream::BlobStream<'a, S>::blob_len(&self) -> core::option::Option<u64>
 pub fn mssql_client::blob_stream::BlobStream<'a, S>::columns(&self) -> &[mssql_client::row::Column]
 pub async fn mssql_client::blob_stream::BlobStream<'a, S>::copy_blob_to<W>(&mut self, &mut W) -> mssql_client::error::Result<u64> where W: tokio::io::async_write::AsyncWrite + core::marker::Unpin
+pub fn mssql_client::blob_stream::BlobStream<'a, S>::current_blob_column(&self) -> core::option::Option<&mssql_client::row::Column>
 pub async fn mssql_client::blob_stream::BlobStream<'a, S>::next(&mut self) -> mssql_client::error::Result<core::option::Option<mssql_client::row::Row>>
+pub async fn mssql_client::blob_stream::BlobStream<'a, S>::next_blob(&mut self) -> mssql_client::error::Result<bool>
 pub async fn mssql_client::blob_stream::BlobStream<'a, S>::read_chunk(&mut self) -> mssql_client::error::Result<core::option::Option<bytes::bytes::Bytes>>
 impl<'a, S> !core::marker::Freeze for mssql_client::blob_stream::BlobStream<'a, S>
 impl<'a, S> core::marker::Send for mssql_client::blob_stream::BlobStream<'a, S> where S: core::marker::Send
@@ -4030,6 +4038,7 @@ pub async fn mssql_client::client::Client<mssql_client::state::InTransaction>::e
 pub async fn mssql_client::client::Client<mssql_client::state::InTransaction>::query<'a>(&'a mut self, &str, &[&(dyn mssql_types::to_sql::ToSql + core::marker::Sync)]) -> mssql_client::error::Result<mssql_client::stream::QueryStream<'a>>
 pub async fn mssql_client::client::Client<mssql_client::state::InTransaction>::query_stream<'a>(&'a mut self, &str, &[&(dyn mssql_types::to_sql::ToSql + core::marker::Sync)]) -> mssql_client::error::Result<mssql_client::row_stream::RowStream<'a, mssql_client::state::InTransaction>>
 pub async fn mssql_client::client::Client<mssql_client::state::InTransaction>::query_stream_blob<'a>(&'a mut self, &str, &[&(dyn mssql_types::to_sql::ToSql + core::marker::Sync)]) -> mssql_client::error::Result<mssql_client::blob_stream::BlobStream<'a, mssql_client::state::InTransaction>>
+pub async fn mssql_client::client::Client<mssql_client::state::InTransaction>::query_stream_rows<'a>(&'a mut self, &str, &[&(dyn mssql_types::to_sql::ToSql + core::marker::Sync)]) -> mssql_client::error::Result<mssql_client::blob_stream::BlobStream<'a, mssql_client::state::InTransaction>>
 pub async fn mssql_client::client::Client<mssql_client::state::InTransaction>::query_with_timeout<'a>(&'a mut self, &str, &[&(dyn mssql_types::to_sql::ToSql + core::marker::Sync)], core::time::Duration) -> mssql_client::error::Result<mssql_client::stream::QueryStream<'a>>
 pub async fn mssql_client::client::Client<mssql_client::state::InTransaction>::release_savepoint(&mut self, mssql_client::transaction::SavePoint) -> mssql_client::error::Result<()>
 pub async fn mssql_client::client::Client<mssql_client::state::InTransaction>::rollback(self) -> mssql_client::error::Result<mssql_client::client::Client<mssql_client::state::Ready>>
@@ -4054,6 +4063,7 @@ pub async fn mssql_client::client::Client<mssql_client::state::Ready>::query<'a>
 pub async fn mssql_client::client::Client<mssql_client::state::Ready>::query_multiple<'a>(&'a mut self, &str, &[&(dyn mssql_types::to_sql::ToSql + core::marker::Sync)]) -> mssql_client::error::Result<mssql_client::stream::MultiResultStream<'a>>
 pub async fn mssql_client::client::Client<mssql_client::state::Ready>::query_stream<'a>(&'a mut self, &str, &[&(dyn mssql_types::to_sql::ToSql + core::marker::Sync)]) -> mssql_client::error::Result<mssql_client::row_stream::RowStream<'a, mssql_client::state::Ready>>
 pub async fn mssql_client::client::Client<mssql_client::state::Ready>::query_stream_blob<'a>(&'a mut self, &str, &[&(dyn mssql_types::to_sql::ToSql + core::marker::Sync)]) -> mssql_client::error::Result<mssql_client::blob_stream::BlobStream<'a, mssql_client::state::Ready>>
+pub async fn mssql_client::client::Client<mssql_client::state::Ready>::query_stream_rows<'a>(&'a mut self, &str, &[&(dyn mssql_types::to_sql::ToSql + core::marker::Sync)]) -> mssql_client::error::Result<mssql_client::blob_stream::BlobStream<'a, mssql_client::state::Ready>>
 pub async fn mssql_client::client::Client<mssql_client::state::Ready>::query_with_timeout<'a>(&'a mut self, &str, &[&(dyn mssql_types::to_sql::ToSql + core::marker::Sync)], core::time::Duration) -> mssql_client::error::Result<mssql_client::stream::QueryStream<'a>>
 pub async fn mssql_client::client::Client<mssql_client::state::Ready>::simple_query(&mut self, &str) -> mssql_client::error::Result<()>
 impl<S: mssql_client::state::ConnectionState> mssql_client::client::Client<S>

--- a/public-api/mssql-client.windows.txt
+++ b/public-api/mssql-client.windows.txt
@@ -120,11 +120,14 @@ pub fn mssql_client::blob::BlobReader::vzip(self) -> V
 pub mod mssql_client::blob_stream
 pub struct mssql_client::blob_stream::BlobStream<'a, S: mssql_client::state::ConnectionState>
 impl<'a, S: mssql_client::state::ConnectionState> mssql_client::blob_stream::BlobStream<'a, S>
+pub fn mssql_client::blob_stream::BlobStream<'a, S>::blob_columns(&self) -> &[mssql_client::row::Column]
 pub fn mssql_client::blob_stream::BlobStream<'a, S>::blob_is_null(&self) -> bool
 pub fn mssql_client::blob_stream::BlobStream<'a, S>::blob_len(&self) -> core::option::Option<u64>
 pub fn mssql_client::blob_stream::BlobStream<'a, S>::columns(&self) -> &[mssql_client::row::Column]
 pub async fn mssql_client::blob_stream::BlobStream<'a, S>::copy_blob_to<W>(&mut self, &mut W) -> mssql_client::error::Result<u64> where W: tokio::io::async_write::AsyncWrite + core::marker::Unpin
+pub fn mssql_client::blob_stream::BlobStream<'a, S>::current_blob_column(&self) -> core::option::Option<&mssql_client::row::Column>
 pub async fn mssql_client::blob_stream::BlobStream<'a, S>::next(&mut self) -> mssql_client::error::Result<core::option::Option<mssql_client::row::Row>>
+pub async fn mssql_client::blob_stream::BlobStream<'a, S>::next_blob(&mut self) -> mssql_client::error::Result<bool>
 pub async fn mssql_client::blob_stream::BlobStream<'a, S>::read_chunk(&mut self) -> mssql_client::error::Result<core::option::Option<bytes::bytes::Bytes>>
 impl<'a, S> !core::marker::Freeze for mssql_client::blob_stream::BlobStream<'a, S>
 impl<'a, S> core::marker::Send for mssql_client::blob_stream::BlobStream<'a, S> where S: core::marker::Send
@@ -713,6 +716,7 @@ pub async fn mssql_client::client::Client<mssql_client::state::InTransaction>::o
 pub async fn mssql_client::client::Client<mssql_client::state::InTransaction>::query<'a>(&'a mut self, &str, &[&(dyn mssql_types::to_sql::ToSql + core::marker::Sync)]) -> mssql_client::error::Result<mssql_client::stream::QueryStream<'a>>
 pub async fn mssql_client::client::Client<mssql_client::state::InTransaction>::query_stream<'a>(&'a mut self, &str, &[&(dyn mssql_types::to_sql::ToSql + core::marker::Sync)]) -> mssql_client::error::Result<mssql_client::row_stream::RowStream<'a, mssql_client::state::InTransaction>>
 pub async fn mssql_client::client::Client<mssql_client::state::InTransaction>::query_stream_blob<'a>(&'a mut self, &str, &[&(dyn mssql_types::to_sql::ToSql + core::marker::Sync)]) -> mssql_client::error::Result<mssql_client::blob_stream::BlobStream<'a, mssql_client::state::InTransaction>>
+pub async fn mssql_client::client::Client<mssql_client::state::InTransaction>::query_stream_rows<'a>(&'a mut self, &str, &[&(dyn mssql_types::to_sql::ToSql + core::marker::Sync)]) -> mssql_client::error::Result<mssql_client::blob_stream::BlobStream<'a, mssql_client::state::InTransaction>>
 pub async fn mssql_client::client::Client<mssql_client::state::InTransaction>::query_with_timeout<'a>(&'a mut self, &str, &[&(dyn mssql_types::to_sql::ToSql + core::marker::Sync)], core::time::Duration) -> mssql_client::error::Result<mssql_client::stream::QueryStream<'a>>
 pub async fn mssql_client::client::Client<mssql_client::state::InTransaction>::release_savepoint(&mut self, mssql_client::transaction::SavePoint) -> mssql_client::error::Result<()>
 pub async fn mssql_client::client::Client<mssql_client::state::InTransaction>::rollback(self) -> mssql_client::error::Result<mssql_client::client::Client<mssql_client::state::Ready>>
@@ -736,6 +740,7 @@ pub async fn mssql_client::client::Client<mssql_client::state::Ready>::query<'a>
 pub async fn mssql_client::client::Client<mssql_client::state::Ready>::query_multiple<'a>(&'a mut self, &str, &[&(dyn mssql_types::to_sql::ToSql + core::marker::Sync)]) -> mssql_client::error::Result<mssql_client::stream::MultiResultStream<'a>>
 pub async fn mssql_client::client::Client<mssql_client::state::Ready>::query_stream<'a>(&'a mut self, &str, &[&(dyn mssql_types::to_sql::ToSql + core::marker::Sync)]) -> mssql_client::error::Result<mssql_client::row_stream::RowStream<'a, mssql_client::state::Ready>>
 pub async fn mssql_client::client::Client<mssql_client::state::Ready>::query_stream_blob<'a>(&'a mut self, &str, &[&(dyn mssql_types::to_sql::ToSql + core::marker::Sync)]) -> mssql_client::error::Result<mssql_client::blob_stream::BlobStream<'a, mssql_client::state::Ready>>
+pub async fn mssql_client::client::Client<mssql_client::state::Ready>::query_stream_rows<'a>(&'a mut self, &str, &[&(dyn mssql_types::to_sql::ToSql + core::marker::Sync)]) -> mssql_client::error::Result<mssql_client::blob_stream::BlobStream<'a, mssql_client::state::Ready>>
 pub async fn mssql_client::client::Client<mssql_client::state::Ready>::query_with_timeout<'a>(&'a mut self, &str, &[&(dyn mssql_types::to_sql::ToSql + core::marker::Sync)], core::time::Duration) -> mssql_client::error::Result<mssql_client::stream::QueryStream<'a>>
 pub async fn mssql_client::client::Client<mssql_client::state::Ready>::simple_query(&mut self, &str) -> mssql_client::error::Result<()>
 impl<S: mssql_client::state::ConnectionState> mssql_client::client::Client<S>
@@ -3304,11 +3309,14 @@ impl<V, T> ppv_lite86::types::VZip<V> for mssql_client::change_tracking::SyncVer
 pub fn mssql_client::change_tracking::SyncVersionStatus::vzip(self) -> V
 pub struct mssql_client::BlobStream<'a, S: mssql_client::state::ConnectionState>
 impl<'a, S: mssql_client::state::ConnectionState> mssql_client::blob_stream::BlobStream<'a, S>
+pub fn mssql_client::blob_stream::BlobStream<'a, S>::blob_columns(&self) -> &[mssql_client::row::Column]
 pub fn mssql_client::blob_stream::BlobStream<'a, S>::blob_is_null(&self) -> bool
 pub fn mssql_client::blob_stream::BlobStream<'a, S>::blob_len(&self) -> core::option::Option<u64>
 pub fn mssql_client::blob_stream::BlobStream<'a, S>::columns(&self) -> &[mssql_client::row::Column]
 pub async fn mssql_client::blob_stream::BlobStream<'a, S>::copy_blob_to<W>(&mut self, &mut W) -> mssql_client::error::Result<u64> where W: tokio::io::async_write::AsyncWrite + core::marker::Unpin
+pub fn mssql_client::blob_stream::BlobStream<'a, S>::current_blob_column(&self) -> core::option::Option<&mssql_client::row::Column>
 pub async fn mssql_client::blob_stream::BlobStream<'a, S>::next(&mut self) -> mssql_client::error::Result<core::option::Option<mssql_client::row::Row>>
+pub async fn mssql_client::blob_stream::BlobStream<'a, S>::next_blob(&mut self) -> mssql_client::error::Result<bool>
 pub async fn mssql_client::blob_stream::BlobStream<'a, S>::read_chunk(&mut self) -> mssql_client::error::Result<core::option::Option<bytes::bytes::Bytes>>
 impl<'a, S> !core::marker::Freeze for mssql_client::blob_stream::BlobStream<'a, S>
 impl<'a, S> core::marker::Send for mssql_client::blob_stream::BlobStream<'a, S> where S: core::marker::Send
@@ -3779,6 +3787,7 @@ pub async fn mssql_client::client::Client<mssql_client::state::InTransaction>::o
 pub async fn mssql_client::client::Client<mssql_client::state::InTransaction>::query<'a>(&'a mut self, &str, &[&(dyn mssql_types::to_sql::ToSql + core::marker::Sync)]) -> mssql_client::error::Result<mssql_client::stream::QueryStream<'a>>
 pub async fn mssql_client::client::Client<mssql_client::state::InTransaction>::query_stream<'a>(&'a mut self, &str, &[&(dyn mssql_types::to_sql::ToSql + core::marker::Sync)]) -> mssql_client::error::Result<mssql_client::row_stream::RowStream<'a, mssql_client::state::InTransaction>>
 pub async fn mssql_client::client::Client<mssql_client::state::InTransaction>::query_stream_blob<'a>(&'a mut self, &str, &[&(dyn mssql_types::to_sql::ToSql + core::marker::Sync)]) -> mssql_client::error::Result<mssql_client::blob_stream::BlobStream<'a, mssql_client::state::InTransaction>>
+pub async fn mssql_client::client::Client<mssql_client::state::InTransaction>::query_stream_rows<'a>(&'a mut self, &str, &[&(dyn mssql_types::to_sql::ToSql + core::marker::Sync)]) -> mssql_client::error::Result<mssql_client::blob_stream::BlobStream<'a, mssql_client::state::InTransaction>>
 pub async fn mssql_client::client::Client<mssql_client::state::InTransaction>::query_with_timeout<'a>(&'a mut self, &str, &[&(dyn mssql_types::to_sql::ToSql + core::marker::Sync)], core::time::Duration) -> mssql_client::error::Result<mssql_client::stream::QueryStream<'a>>
 pub async fn mssql_client::client::Client<mssql_client::state::InTransaction>::release_savepoint(&mut self, mssql_client::transaction::SavePoint) -> mssql_client::error::Result<()>
 pub async fn mssql_client::client::Client<mssql_client::state::InTransaction>::rollback(self) -> mssql_client::error::Result<mssql_client::client::Client<mssql_client::state::Ready>>
@@ -3802,6 +3811,7 @@ pub async fn mssql_client::client::Client<mssql_client::state::Ready>::query<'a>
 pub async fn mssql_client::client::Client<mssql_client::state::Ready>::query_multiple<'a>(&'a mut self, &str, &[&(dyn mssql_types::to_sql::ToSql + core::marker::Sync)]) -> mssql_client::error::Result<mssql_client::stream::MultiResultStream<'a>>
 pub async fn mssql_client::client::Client<mssql_client::state::Ready>::query_stream<'a>(&'a mut self, &str, &[&(dyn mssql_types::to_sql::ToSql + core::marker::Sync)]) -> mssql_client::error::Result<mssql_client::row_stream::RowStream<'a, mssql_client::state::Ready>>
 pub async fn mssql_client::client::Client<mssql_client::state::Ready>::query_stream_blob<'a>(&'a mut self, &str, &[&(dyn mssql_types::to_sql::ToSql + core::marker::Sync)]) -> mssql_client::error::Result<mssql_client::blob_stream::BlobStream<'a, mssql_client::state::Ready>>
+pub async fn mssql_client::client::Client<mssql_client::state::Ready>::query_stream_rows<'a>(&'a mut self, &str, &[&(dyn mssql_types::to_sql::ToSql + core::marker::Sync)]) -> mssql_client::error::Result<mssql_client::blob_stream::BlobStream<'a, mssql_client::state::Ready>>
 pub async fn mssql_client::client::Client<mssql_client::state::Ready>::query_with_timeout<'a>(&'a mut self, &str, &[&(dyn mssql_types::to_sql::ToSql + core::marker::Sync)], core::time::Duration) -> mssql_client::error::Result<mssql_client::stream::QueryStream<'a>>
 pub async fn mssql_client::client::Client<mssql_client::state::Ready>::simple_query(&mut self, &str) -> mssql_client::error::Result<()>
 impl<S: mssql_client::state::ConnectionState> mssql_client::client::Client<S>


### PR DESCRIPTION
## What

Adds `Client::query_stream_rows` (on `Ready` and `InTransaction`) — the multi-column generalization of `query_stream_blob`. It streams a run of **one or more trailing MAX columns** (`VARBINARY(MAX)` / `NVARCHAR(MAX)` / `VARCHAR(MAX)` / `XML`): the leading scalar columns decode eagerly into the per-row `Row`, and each trailing MAX column streams from the socket in turn, iterated with the new `BlobStream::next_blob()`.

Closes the first part of #258 (the "single trailing MAX column" constraint of `query_stream_blob`).

```rust
let mut stream = client.query_stream_rows("SELECT id, doc1, doc2 FROM files", &[]).await?;
while let Some(row) = stream.next().await? {
    let id: i32 = row.get_by_name("id")?;
    while stream.next_blob().await? {
        stream.copy_blob_to(&mut sink).await?; // each trailing MAX column, in order
    }
}
```

## Scope / design

- **Trailing-only.** The supported shape is "one or more MAX columns, all trailing" — a non-MAX column after a MAX column is rejected with a clear `Error::Protocol`. This keeps the scalar columns a **contiguous prefix**, so `RawRow::decode_prefix` is reused unchanged and there are **zero `tds-protocol` changes**.
- The interleaved case (`SELECT doc1, id, doc2`) needs a resumable per-column decoder and is deliberately deferred under #258.
- `BlobStream` is generalized from one blob to N trailing blobs (`first_blob` + `blob_count` + a per-row blob cursor). The single-blob `query_stream_blob` path is preserved exactly — it auto-positions its one blob, so `next` → `copy_blob_to` works without `next_blob`.
- New public API: `query_stream_rows`, `BlobStream::{next_blob, blob_columns, current_blob_column}`.

## Testing

- **New unit tests** (server-free, run in CI): `validate_blob_rows_result_set` — trailing runs, all-blobs, no-MAX rejection, scalar-after-blob rejection.
- **New live tests** (`tests/blob_stream.rs`): two trailing blobs, a NULL blob between two non-NULL blobs (NBCROW path), auto-drain of unread/partially-read blobs, scalar-after-blob rejection, within-transaction.
- **New live memory proof** (`tests/streaming_memory.rs`): two 15 MB `VARBINARY(MAX)` columns stream at **9,364 bytes peak heap** (vs ~30 MB buffered).
- Full local gate green: fmt, clippy `--all-features -D warnings`, `cargo doc -D warnings`, feature-matrix `cargo hack check -D warnings`, typos, 457 unit + 66 doctests, **14/14 live blob_stream** (9 existing + 5 new, no regression).

## Notes for the reviewer

- **Windows public-api baseline** (`public-api/mssql-client.windows.txt`) was hand-edited to add the 5 new (platform-agnostic) API lines — it cannot be regenerated on Linux. The additions follow cargo-public-api's alphabetical ordering; the `public-api-windows` CI leg is the authoritative check.
- Second commit (`style`) fixes two pre-existing clippy lints in `client/connect.rs` that only surface in the `--no-default-features` build (a tail-position `return`, a non-inlined `format!` arg). No behavior change.
- `LIMITATIONS.md` LOB section updated.