### PR TITLE
feat(client): sp_prepexec on cold cache miss — one round-trip, not two (#205)

### DIFF
--- a/crates/mssql-client/src/client.rs
+++ b/crates/mssql-client/src/client.rs
@@ -614,45 +614,53 @@ impl<S: ConnectionState> Client<S> {
         );
 
         if let Some(handle) = self.statement_cache.get(&key) {
+            // Hit: sp_execute the cached handle. Clear any stale pending key
+            // (e.g. from a prior request whose read aborted) so the read path
+            // does not try to capture a handle from this response.
+            self.statement_cache.set_pending(None);
             let rpc = RpcRequest::execute(handle, rpc_params);
             self.send_rpc(&rpc).await?;
         } else {
-            // Miss: sp_prepare for a handle, then sp_execute. The caller's
-            // read_query_response reads the execute (row) response.
-            let prepare = RpcRequest::prepare(sql, &rpc_params);
-            self.send_rpc(&prepare).await?;
-            let prepared = self.read_procedure_result().await?;
-            let handle = Self::prepare_handle(&prepared)?;
-
-            if let Some(evicted) = self
-                .statement_cache
-                .insert(crate::statement_cache::PreparedStatement::new(handle, key))
-            {
-                // Release the evicted server-side handle. Best-effort: a failed
-                // sp_unprepare leaks one handle until connection reset, never
-                // corrupts data.
-                let unprepare = RpcRequest::unprepare(evicted.handle());
-                self.send_rpc(&unprepare).await?;
-                let _ = self.read_procedure_result().await?;
-            }
-
-            let rpc = RpcRequest::execute(handle, rpc_params);
+            // Miss: sp_prepexec prepares and executes in ONE round-trip. The
+            // caller's read_query_response reads the row response and captures
+            // the `@handle` RETURNVALUE, then stores it under `key` (see
+            // `store_pending_prepared_handle`).
+            self.statement_cache.set_pending(Some(key));
+            let rpc = RpcRequest::prepexec(sql, rpc_params);
             self.send_rpc(&rpc).await?;
         }
         Ok(())
     }
 
-    /// Extract the statement handle from an `sp_prepare` response — the
-    /// `@handle` OUTPUT parameter, surfaced as a RETURNVALUE / output param.
-    fn prepare_handle(result: &crate::stream::ProcedureResult) -> Result<i32> {
-        result
-            .output_params
-            .iter()
-            .find_map(|p| match &p.value {
-                mssql_types::SqlValue::Int(h) => Some(*h),
-                _ => None,
-            })
-            .ok_or_else(|| Error::Protocol("sp_prepare returned no statement handle".into()))
+    /// Store the handle captured from an `sp_prepexec` execution response under
+    /// the pending cache key (set by [`send_query_request`](Self::send_query_request)
+    /// on a cold miss), releasing any LRU-evicted server-side handle.
+    ///
+    /// Called by `read_query_response` after it has read the row response and
+    /// the trailing `@handle` RETURNVALUE. A no-op when no prepexec is pending.
+    /// Eviction `sp_unprepare` is best-effort: a failure leaks one handle until
+    /// connection reset, never corrupts data.
+    pub(super) async fn store_pending_prepared_handle(
+        &mut self,
+        handle: Option<i32>,
+    ) -> Result<()> {
+        let Some(key) = self.statement_cache.take_pending() else {
+            return Ok(());
+        };
+        let Some(handle) = handle else {
+            // No @handle came back (unexpected for sp_prepexec): leave the
+            // statement uncached so the next call simply re-prepares.
+            return Ok(());
+        };
+        if let Some(evicted) = self
+            .statement_cache
+            .insert(crate::statement_cache::PreparedStatement::new(handle, key))
+        {
+            let unprepare = RpcRequest::unprepare(evicted.handle());
+            self.send_rpc(&unprepare).await?;
+            let _ = self.read_procedure_result().await?;
+        }
+        Ok(())
     }
 
     /// Encrypt the Always Encrypted parameters of a statement, then build its

--- a/crates/mssql-client/src/client/response.rs
+++ b/crates/mssql-client/src/client/response.rs
@@ -185,6 +185,11 @@ impl<S: ConnectionState> Client<S> {
         let mut columns: Vec<crate::row::Column> = Vec::new();
         let mut pending_rows: Vec<crate::stream::PendingRow> = Vec::new();
         let mut protocol_metadata: Option<ColMetaData> = None;
+        // sp_prepexec (cold-miss cache path) returns the prepared-statement
+        // handle via its `@handle` OUTPUT parameter, which arrives as a
+        // RETURNVALUE token after the rows. Capture it for the post-read cache
+        // store; `None` for every other query.
+        let mut prepared_handle: Option<i32> = None;
         #[cfg(feature = "always-encrypted")]
         let mut current_decryptor: Option<
             std::sync::Arc<crate::column_decryptor::ColumnDecryptor>,
@@ -276,9 +281,38 @@ impl<S: ConnectionState> Client<S> {
                     // to properly update the transaction descriptor.
                     Self::process_transaction_env_change(&env, &mut self.transaction_descriptor);
                 }
+                Token::ReturnValue(ret_val) if prepared_handle.is_none() => {
+                    // sp_prepexec's `@handle` OUTPUT parameter. Decode it with the
+                    // same parser used for column values (mirrors the procedure
+                    // reader). A non-INT or undecodable value leaves the handle
+                    // uncaptured, so the statement is simply re-prepared next time.
+                    use tds_protocol::token::ColumnData;
+                    use tds_protocol::types::TypeId;
+
+                    let type_id = TypeId::from_u8(ret_val.col_type).unwrap_or(TypeId::Null);
+                    let col_data = ColumnData {
+                        name: String::new(),
+                        type_id,
+                        col_type: ret_val.col_type,
+                        flags: ret_val.flags,
+                        user_type: ret_val.user_type,
+                        type_info: ret_val.type_info.clone(),
+                        crypto_metadata: None,
+                    };
+                    let mut buf = ret_val.value.as_ref();
+                    if let Ok(mssql_types::SqlValue::Int(h)) =
+                        crate::column_parser::parse_column_value(&mut buf, &col_data)
+                    {
+                        prepared_handle = Some(h);
+                    }
+                }
                 _ => {}
             }
         }
+
+        // Cold-miss cache path: if an sp_prepexec is pending, cache its handle
+        // (and release any LRU-evicted server handle). No-op otherwise.
+        self.store_pending_prepared_handle(prepared_handle).await?;
 
         tracing::debug!(
             columns = columns.len(),

--- a/crates/mssql-client/src/statement_cache.rs
+++ b/crates/mssql-client/src/statement_cache.rs
@@ -105,6 +105,10 @@ pub struct StatementCache {
     hits: u64,
     /// Total number of cache misses (for metrics).
     misses: u64,
+    /// Key of an in-flight `sp_prepexec` whose handle has not yet been read off
+    /// the response. Set by the send path on a cold miss, consumed by the read
+    /// path once the `@handle` RETURNVALUE arrives. See [`set_pending`](Self::set_pending).
+    pending_prepare: Option<String>,
 }
 
 impl StatementCache {
@@ -121,6 +125,7 @@ impl StatementCache {
             max_size,
             hits: 0,
             misses: 0,
+            pending_prepare: None,
         }
     }
 
@@ -145,6 +150,21 @@ impl StatementCache {
             tracing::trace!(sql = sql, "statement cache miss");
             None
         }
+    }
+
+    /// Record the cache key of an in-flight `sp_prepexec` whose handle will be
+    /// read off the execution response. Pass `None` on a cache hit (no handle
+    /// to capture) so a prior miss's key cannot linger.
+    ///
+    /// Internal plumbing for the cold-miss cache path — not part of the public
+    /// API.
+    pub(crate) fn set_pending(&mut self, key: Option<String>) {
+        self.pending_prepare = key;
+    }
+
+    /// Take the in-flight `sp_prepexec` key, if any, clearing it.
+    pub(crate) fn take_pending(&mut self) -> Option<String> {
+        self.pending_prepare.take()
     }
 
     /// Peek at a prepared statement without updating LRU order.

--- a/crates/tds-protocol/src/rpc.rs
+++ b/crates/tds-protocol/src/rpc.rs
@@ -1119,6 +1119,39 @@ impl RpcRequest {
         request
     }
 
+    /// Create an sp_prepexec request: prepare and execute in a single call.
+    ///
+    /// Combines [`prepare`](Self::prepare) and [`execute`](Self::execute) into
+    /// one round-trip: the server compiles the statement, returns its handle via
+    /// the `@handle` OUTPUT parameter (surfaced as a RETURNVALUE token), and
+    /// executes it. The statement parameter values are positional/unnamed, like
+    /// `sp_execute`. Unlike `sp_prepare`, `sp_prepexec` takes no `@options`.
+    pub fn prepexec(sql: &str, params: Vec<RpcParam>) -> Self {
+        let mut request = Self::by_id(ProcId::PrepExec);
+
+        // OUT: handle (INT)
+        request
+            .params
+            .push(RpcParam::null("@handle", TypeInfo::int()).as_output());
+
+        // Param declarations (built before `params` is consumed below).
+        let declarations = Self::build_param_declarations(&params);
+        request
+            .params
+            .push(RpcParam::nvarchar("@params", &declarations));
+
+        // SQL statement
+        request.params.push(RpcParam::nvarchar("@stmt", sql));
+
+        // Statement parameter values, positional (names cleared), like sp_execute.
+        for mut param in params {
+            param.name.clear();
+            request.params.push(param);
+        }
+
+        request
+    }
+
     /// Create an sp_unprepare request.
     pub fn unprepare(handle: i32) -> Self {
         let mut request = Self::by_id(ProcId::Unprepare);
@@ -1406,6 +1439,25 @@ mod tests {
 
         assert_eq!(rpc.proc_id, Some(ProcId::Unprepare));
         assert_eq!(rpc.params.len(), 1); // just the handle
+    }
+
+    #[test]
+    fn test_prepexec_request() {
+        let rpc = RpcRequest::prepexec(
+            "SELECT * FROM users WHERE id = @p1",
+            vec![RpcParam::int("@p1", 42)],
+        );
+
+        assert_eq!(rpc.proc_id, Some(ProcId::PrepExec));
+        // handle (output), @params, @stmt, then one positional value param.
+        assert_eq!(rpc.params.len(), 4);
+        assert!(rpc.params[0].flags.by_ref); // @handle is OUTPUT
+        assert_eq!(rpc.params[1].name, "@params");
+        assert_eq!(rpc.params[2].name, "@stmt");
+        // sp_prepexec, like sp_execute, binds value parameters positionally —
+        // their names must be cleared so the server does not reject the stream.
+        assert!(rpc.params[3].name.is_empty());
+        // Unlike sp_prepare, sp_prepexec carries no trailing @options parameter.
     }
 
     #[test]

--- a/public-api/tds-protocol.txt
+++ b/public-api/tds-protocol.txt
@@ -1326,6 +1326,7 @@ pub fn tds_protocol::rpc::RpcRequest::execute_sql(&str, alloc::vec::Vec<tds_prot
 pub fn tds_protocol::rpc::RpcRequest::named(impl core::convert::Into<alloc::string::String>) -> Self
 pub fn tds_protocol::rpc::RpcRequest::param(self, tds_protocol::rpc::RpcParam) -> Self
 pub fn tds_protocol::rpc::RpcRequest::prepare(&str, &[tds_protocol::rpc::RpcParam]) -> Self
+pub fn tds_protocol::rpc::RpcRequest::prepexec(&str, alloc::vec::Vec<tds_protocol::rpc::RpcParam>) -> Self
 pub fn tds_protocol::rpc::RpcRequest::unprepare(i32) -> Self
 pub fn tds_protocol::rpc::RpcRequest::with_options(self, tds_protocol::rpc::RpcOptionFlags) -> Self
 impl core::clone::Clone for tds_protocol::rpc::RpcRequest
@@ -5318,6 +5319,7 @@ pub fn tds_protocol::rpc::RpcRequest::execute_sql(&str, alloc::vec::Vec<tds_prot
 pub fn tds_protocol::rpc::RpcRequest::named(impl core::convert::Into<alloc::string::String>) -> Self
 pub fn tds_protocol::rpc::RpcRequest::param(self, tds_protocol::rpc::RpcParam) -> Self
 pub fn tds_protocol::rpc::RpcRequest::prepare(&str, &[tds_protocol::rpc::RpcParam]) -> Self
+pub fn tds_protocol::rpc::RpcRequest::prepexec(&str, alloc::vec::Vec<tds_protocol::rpc::RpcParam>) -> Self
 pub fn tds_protocol::rpc::RpcRequest::unprepare(i32) -> Self
 pub fn tds_protocol::rpc::RpcRequest::with_options(self, tds_protocol::rpc::RpcOptionFlags) -> Self
 impl core::clone::Clone for tds_protocol::rpc::RpcRequest


### PR DESCRIPTION
## What

The opt-in prepared-statement cache (#205) paid **two round-trips** on a cold miss: `sp_prepare` to get a handle, then `sp_execute`. This switches the cold-miss path to **`sp_prepexec`**, which prepares *and* executes in one call — returning the `@handle` via a RETURNVALUE token alongside the rows. The extra round-trip that made the cache least attractive to enable is gone.

A follow-up to #205 (the roadmap's listed cache follow-ups). The hit path is unchanged.

## How

- **`RpcRequest::prepexec(sql, params)`** (new, in `tds-protocol`) — `sp_prepexec` (ProcId `0x000D`): `@handle` OUTPUT + `@params` + `@stmt` + positional value params (no `@options`, unlike `sp_prepare`).
- **Send path** (`send_query_request`): on a cold miss, record a pending cache key (`StatementCache::set_pending`) and send `sp_prepexec`. The hit path clears any stale pending key and sends `sp_execute` as before.
- **Read path** (`read_query_response`): capture the `@handle` from the RETURNVALUE token, then `store_pending_prepared_handle` inserts it under the pending key (and `sp_unprepare`s any LRU-evicted handle, best-effort). No-op for every non-prepexec query.
- The handle-capture crosses the send/read boundary, so the pending key lives on the cache (`pub(crate)` plumbing — not public API). Stale-pending is self-healing: the store only inserts when a handle was actually captured.

## Testing

- **Unit**: `test_prepexec_request` (`tds-protocol`) asserts the RPC shape — `@handle` OUTPUT, positional (unnamed) value params, no `@options`.
- **Live** (`statement_cache_live.rs`, unchanged): the cache suite passes through the new path — prepares once and reuses the handle (`misses=1, hits=3, entries=1`), proving `sp_prepexec` executes, returns rows, *and* the handle is captured + cached in one round-trip. (If capture failed, every call would re-miss.)
- Full local gate green: clippy `--all-features` + `--no-default-features` `-D warnings`, `cargo doc -D warnings`, `cargo xtask check-features`, typos, **641 unit/integration + 276 live tests** (incl. AE round-trips and multi-result streaming — the regression check for the shared `read_query_response` path), public-api regenerated.

## Notes

- Public API: only `tds_protocol::RpcRequest::prepexec` is added (snapshot updated; `tds-protocol` has no Windows variant). `mssql-client`'s surface is unchanged — the cache plumbing is `pub(crate)`.
- Scope stays on buffered `query` (matching #205). `query_stream`/`query_multiple`/AE still use `sp_executesql`. Pool-level handle cache remains a separate follow-up.