### PR TITLE
feat(pool): scoped with_transaction on PooledConnection (#280)

### DIFF
--- a/crates/mssql-pool/src/pool.rs
+++ b/crates/mssql-pool/src/pool.rs
@@ -32,7 +32,7 @@ use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Weak};
 use std::time::{Duration, Instant};
 
-use mssql_client::{Client, Config as ClientConfig, DatabaseMetrics, Ready};
+use mssql_client::{Client, Config as ClientConfig, DatabaseMetrics, InTransaction, Ready};
 use parking_lot::Mutex;
 use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 use tokio::time::timeout;
@@ -1224,6 +1224,90 @@ impl PooledConnection {
             .execute(sql, params)
             .await
             .map_err(PoolError::Connection)
+    }
+
+    /// Run a closure inside a database transaction, keeping the connection in
+    /// the pool.
+    ///
+    /// Begins a transaction, hands the closure a [`Client<InTransaction>`] for
+    /// queries and statements, then **commits if the closure returns `Ok`** and
+    /// **rolls back if it returns `Err`**. Either way the underlying connection
+    /// is returned to the pool when this `PooledConnection` is dropped — unlike
+    /// [`detach`](Self::detach), which removes it from the pool. This is the
+    /// scoped transaction API that lets a pooled connection run a typed
+    /// transaction without detaching.
+    ///
+    /// The closure returns `Result<T, PoolError>`, so `?` works directly on the
+    /// transaction's `query`/`execute` calls — their [`mssql_client::Error`]
+    /// converts into [`PoolError`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PoolError`] if the connection was detached, if beginning,
+    /// committing, or rolling back the transaction fails, or if the closure
+    /// returns an error (after the rollback is attempted). If begin / commit /
+    /// rollback fails, the connection is dropped rather than returned to the
+    /// pool, and the pool replaces it on the next checkout.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # async fn ex(pool: &mssql_driver_pool::Pool) -> Result<(), mssql_driver_pool::PoolError> {
+    /// let mut conn = pool.get().await?;
+    /// let affected = conn
+    ///     .with_transaction(async |tx| {
+    ///         tx.execute(
+    ///             "UPDATE accounts SET balance = balance - @p1 WHERE id = @p2",
+    ///             &[&10i32, &1i32],
+    ///         )
+    ///         .await?;
+    ///         tx.execute(
+    ///             "UPDATE accounts SET balance = balance + @p1 WHERE id = @p2",
+    ///             &[&10i32, &2i32],
+    ///         )
+    ///         .await?;
+    ///         Ok(())
+    ///     })
+    ///     .await?;
+    /// # let _ = affected;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn with_transaction<F, T>(&mut self, f: F) -> Result<T, PoolError>
+    where
+        F: AsyncFnOnce(&mut Client<InTransaction>) -> Result<T, PoolError>,
+    {
+        let client = self.client.take().ok_or_else(|| {
+            PoolError::ConnectionCreation("connection detached or invalid".to_string())
+        })?;
+
+        // begin_transaction consumes the client; on failure it is gone, so the
+        // connection is not returned to the pool (the pool replaces it).
+        let mut tx = client.begin_transaction().await?;
+
+        match f(&mut tx).await {
+            Ok(value) => {
+                // Commit and return the now-Ready client to the pool. A commit
+                // failure leaves the connection dropped (suspect state).
+                self.client = Some(tx.commit().await?);
+                Ok(value)
+            }
+            Err(err) => {
+                // Roll back the closure's failure, best-effort: a rollback
+                // failure means the connection is in an unknown state, so drop
+                // it rather than return it to the pool.
+                match tx.rollback().await {
+                    Ok(client) => self.client = Some(client),
+                    Err(rollback_err) => {
+                        tracing::warn!(
+                            error = %rollback_err,
+                            "transaction rollback failed; dropping connection rather than returning it to the pool"
+                        );
+                    }
+                }
+                Err(err)
+            }
+        }
     }
 }
 

--- a/crates/mssql-pool/tests/integration.rs
+++ b/crates/mssql-pool/tests/integration.rs
@@ -1263,3 +1263,106 @@ async fn test_reaper_does_not_inflate_max_connections() {
 
     pool.close().await;
 }
+
+// =============================================================================
+// Scoped transaction API (#280)
+// =============================================================================
+
+/// `with_transaction` commits on `Ok` and rolls back on `Err`, and the
+/// connection stays usable and returns to the pool either way.
+#[tokio::test]
+#[ignore = "Requires SQL Server"]
+async fn test_pool_with_transaction_commit_and_rollback() {
+    let client_config = get_test_config().expect("SQL Server config required");
+    let pool = Pool::builder()
+        .client_config(client_config)
+        .max_connections(2)
+        .build()
+        .await
+        .expect("Failed to create pool");
+
+    let mut conn = pool.get().await.expect("get connection");
+
+    // A connection-scoped temp table created OUTSIDE the transaction, so a
+    // rollback undoes the in-transaction INSERT but not the table itself.
+    conn.execute("CREATE TABLE #t280 (v INT)", &[])
+        .await
+        .expect("create temp table");
+
+    // Commit path: the inserted row survives.
+    conn.with_transaction(async |tx| {
+        tx.execute("INSERT INTO #t280 (v) VALUES (1)", &[]).await?;
+        Ok(())
+    })
+    .await
+    .expect("committed transaction");
+
+    // Rollback path: the closure errors, so its INSERT is undone.
+    let rolled_back = conn
+        .with_transaction(async |tx| {
+            tx.execute("INSERT INTO #t280 (v) VALUES (2)", &[]).await?;
+            Err::<(), _>(PoolError::ConnectionCreation(
+                "intentional abort".to_string(),
+            ))
+        })
+        .await;
+    assert!(rolled_back.is_err(), "closure error must surface");
+
+    // The connection is still usable (returned to `self` after each tx): only
+    // the committed row remains.
+    let rows = conn
+        .query("SELECT COUNT(*) AS n FROM #t280", &[])
+        .await
+        .expect("count query");
+    let counts: Vec<i32> = rows
+        .filter_map(|r| r.ok())
+        .map(|r| r.get(0).unwrap())
+        .collect();
+    assert_eq!(counts, vec![1], "only the committed row should remain");
+
+    // Returns to the pool on drop.
+    drop(conn);
+    let status = pool.status();
+    assert_eq!(status.in_use, 0);
+    assert_eq!(status.available, 1);
+
+    pool.close().await;
+}
+
+/// A connection used via `with_transaction` is the same one reused from the
+/// pool afterward (it was not detached).
+#[tokio::test]
+#[ignore = "Requires SQL Server"]
+async fn test_pool_with_transaction_keeps_connection_poolable() {
+    let client_config = get_test_config().expect("SQL Server config required");
+    let pool = Pool::builder()
+        .client_config(client_config)
+        .max_connections(1)
+        .build()
+        .await
+        .expect("Failed to create pool");
+
+    let mut conn = pool.get().await.expect("get connection");
+    let id_before = conn.metadata().id;
+    let value = conn
+        .with_transaction(async |tx| {
+            let rows = tx.query("SELECT 7 AS v", &[]).await?;
+            let v: Vec<i32> = rows
+                .filter_map(|r| r.ok())
+                .map(|r| r.get(0).unwrap())
+                .collect();
+            Ok(v[0])
+        })
+        .await
+        .expect("transaction");
+    assert_eq!(value, 7);
+    drop(conn);
+
+    // With max_connections=1, the next checkout must reuse the same connection,
+    // proving `with_transaction` returned it to the pool rather than detaching.
+    let conn2 = pool.get().await.expect("reuse connection");
+    assert_eq!(conn2.metadata().id, id_before, "connection must be reused");
+    drop(conn2);
+
+    pool.close().await;
+}

--- a/public-api/mssql-driver-pool.txt
+++ b/public-api/mssql-driver-pool.txt
@@ -539,6 +539,7 @@ pub fn mssql_driver_pool::pool::PooledConnection::detach(self) -> core::option::
 pub async fn mssql_driver_pool::pool::PooledConnection::execute(&mut self, &str, &[&(dyn mssql_types::to_sql::ToSql + core::marker::Sync)]) -> core::result::Result<u64, mssql_driver_pool::error::PoolError>
 pub fn mssql_driver_pool::pool::PooledConnection::metadata(&self) -> &mssql_driver_pool::lifecycle::ConnectionMetadata
 pub async fn mssql_driver_pool::pool::PooledConnection::query<'a>(&'a mut self, &str, &[&(dyn mssql_types::to_sql::ToSql + core::marker::Sync)]) -> core::result::Result<mssql_client::stream::QueryStream<'a>, mssql_driver_pool::error::PoolError>
+pub async fn mssql_driver_pool::pool::PooledConnection::with_transaction<F, T>(&mut self, F) -> core::result::Result<T, mssql_driver_pool::error::PoolError> where F: core::ops::async_function::AsyncFnOnce(&mut mssql_client::client::Client<mssql_client::state::InTransaction>) -> core::result::Result<T, mssql_driver_pool::error::PoolError>
 impl core::ops::drop::Drop for mssql_driver_pool::pool::PooledConnection
 pub fn mssql_driver_pool::pool::PooledConnection::drop(&mut self)
 impl core::marker::Freeze for mssql_driver_pool::pool::PooledConnection
@@ -1100,6 +1101,7 @@ pub fn mssql_driver_pool::pool::PooledConnection::detach(self) -> core::option::
 pub async fn mssql_driver_pool::pool::PooledConnection::execute(&mut self, &str, &[&(dyn mssql_types::to_sql::ToSql + core::marker::Sync)]) -> core::result::Result<u64, mssql_driver_pool::error::PoolError>
 pub fn mssql_driver_pool::pool::PooledConnection::metadata(&self) -> &mssql_driver_pool::lifecycle::ConnectionMetadata
 pub async fn mssql_driver_pool::pool::PooledConnection::query<'a>(&'a mut self, &str, &[&(dyn mssql_types::to_sql::ToSql + core::marker::Sync)]) -> core::result::Result<mssql_client::stream::QueryStream<'a>, mssql_driver_pool::error::PoolError>
+pub async fn mssql_driver_pool::pool::PooledConnection::with_transaction<F, T>(&mut self, F) -> core::result::Result<T, mssql_driver_pool::error::PoolError> where F: core::ops::async_function::AsyncFnOnce(&mut mssql_client::client::Client<mssql_client::state::InTransaction>) -> core::result::Result<T, mssql_driver_pool::error::PoolError>
 impl core::ops::drop::Drop for mssql_driver_pool::pool::PooledConnection
 pub fn mssql_driver_pool::pool::PooledConnection::drop(&mut self)
 impl core::marker::Freeze for mssql_driver_pool::pool::PooledConnection


### PR DESCRIPTION
## What

Closes **#280** (1.0-blocker, split from #167). A `PooledConnection` could not run a typed transaction and return to the pool: `begin_transaction` consumes the `Client` (`Ready` → `InTransaction`), and the only owned-access escape hatch was `detach()`, which removes the connection from the pool with no way back.

Adds **`PooledConnection::with_transaction`** — a scoped closure API:

```rust
let mut conn = pool.get().await?;
conn.with_transaction(async |tx| {
    tx.execute("UPDATE accounts SET balance = balance - @p1 WHERE id = @p2", &[&10i32, &1i32]).await?;
    tx.execute("UPDATE accounts SET balance = balance + @p1 WHERE id = @p2", &[&10i32, &2i32]).await?;
    Ok(())
}).await?;
// conn is still pooled — no detach
```

It begins a transaction, hands the closure a `&mut Client<InTransaction>` (the full transaction API), then **commits on `Ok` / rolls back on `Err`**, returning the connection to the pool either way.

## Design

- **`AsyncFnOnce` bound** (stable since 1.85; the crate is edition 2024 / MSRV 1.88) so the closure can borrow the transaction across `await` points — the case plain-generic async closures can't express.
- Closure returns `Result<T, PoolError>`, so `?` works directly on the transaction's `query`/`execute` (their `mssql_client::Error` converts via the existing `PoolError: From<Error>`).
- The closure receives `&mut Client<InTransaction>`, not the vestigial `transaction::Transaction` stub (a `PhantomData` marker that was never wired up).
- If begin / commit / rollback itself fails, the connection is dropped rather than returned to the pool, and the pool replaces it on the next checkout.
- **Scope:** default isolation level only. An isolation-level variant and a `Pool`-level convenience are follow-ups.

## Testing

- **Live** (`tests/integration.rs`):
  - `test_pool_with_transaction_commit_and_rollback` — a connection-scoped temp table proves commit keeps the row and a closure `Err` rolls its INSERT back (final count == 1), and the connection stays usable + returns to the pool.
  - `test_pool_with_transaction_keeps_connection_poolable` — with `max_connections=1`, the post-transaction checkout reuses the *same* connection id, proving it was returned (not detached).
- Full local gate green: `fmt --check` + **workspace** clippy `--all-features --all-targets -D warnings`, `cargo doc -D warnings`, `cargo xtask check-features` (all combos), typos, doctests (the `async |tx|` example compiles), and the full 27-test pool live suite (no regression).

## Public API

Adds only `PooledConnection::with_transaction` (snapshot updated; `mssql-driver-pool` is platform-independent, no Windows variant).