### PR TITLE
perf(client): decode NVARCHAR into a capacity-reserved String (#323)

### DIFF
--- a/crates/mssql-client/src/column_parser.rs
+++ b/crates/mssql-client/src/column_parser.rs
@@ -1109,13 +1109,16 @@ fn parse_nvarchar(buf: &mut &[u8], col: &ColumnData) -> Result<SqlValue> {
         ));
     } else {
         let data = &buf[..len as usize];
-        // UTF-16LE to String
-        let utf16: Vec<u16> = data
-            .chunks_exact(2)
-            .map(|chunk| u16::from_le_bytes([chunk[0], chunk[1]]))
-            .collect();
-        let s = String::from_utf16(&utf16)
-            .map_err(|_| Error::Protocol("invalid UTF-16 in nvarchar".into()))?;
+        // UTF-16LE to String, decoded directly into a capacity-reserved String:
+        // no Vec<u16> intermediate and no realloc-growth churn (each is a heap
+        // allocation per cell). Char count <= code-unit count = len/2.
+        let mut s = String::with_capacity(len as usize / 2);
+        for unit in char::decode_utf16(
+            data.chunks_exact(2)
+                .map(|chunk| u16::from_le_bytes([chunk[0], chunk[1]])),
+        ) {
+            s.push(unit.map_err(|_| Error::Protocol("invalid UTF-16 in nvarchar".into()))?);
+        }
         buf.advance(len as usize);
         SqlValue::String(s)
     })


### PR DESCRIPTION
## What

First (low-risk, non-breaking) slice of **#323**. The buffered `NVARCHAR` decode arm (`parse_nvarchar`) collected the UTF-16LE code units into a `Vec<u16>` and then transcoded via `String::from_utf16` — **two allocations per cell**. This decodes directly into a `String` reserved to `len/2` (the char-count ceiling): no `Vec<u16>` intermediate and no realloc-growth churn, leaving the single unavoidable `String` allocation (UTF-16→UTF-8 must transcode).

## Measurement (the committed gauge)

`cargo bench -p mssql-client --bench buffered_decode --features bench` (64 cols × 1000 rows):

| | allocations/row |
|---|---|
| baseline | 72.02 |
| **this PR** | **53.65 (−25.5%)** |

## Why this instead of the breaking redesign

Scoping #323 overturned its premise. The issue proposes a breaking `Arc<str>`/`Bytes`-backed `SqlValue::String`, assuming it unlocks ~85% of the allocs. It doesn't:
- **NVARCHAR can't be zero-copy** — UTF-16LE→UTF-8 is a mandatory transcode, so a `String` is allocated regardless of the variant's backing type. (Note: the issue's "removing the `Vec<u16>` moved only 0.6%" was measuring the *other* decode stack; the buffered path is `column_parser.rs`, where reserving capacity is the actual fix — hence the 25.5% here.)
- **`Binary` is already a `Bytes` variant** — no breaking change needed.

So the achievable win is non-breaking, and `SqlValue`'s public API stays stable (a plus for the road to 1.0). The maintainer signed off on the non-breaking direction.

## Correctness

- 457 non-ignored tests pass; `fmt --check` + `clippy -p mssql-client --all-features` clean.
- 25 live string round-trips pass incl. **supplementary characters (surrogate pairs)**, BMP unicode, large varchar, and collation round-trips — `char::decode_utf16` handles surrogate pairs correctly.

## Follow-up

The remaining non-breaking win — slicing `VARBINARY` from the row's `Bytes` instead of `copy_from_slice` (~another 30%, toward the ~11/row floor) — is a separate PR (it threads the backing `Bytes` through the parser; the differential type matrix is its correctness net).