### PR TITLE
refactor(client)!: remove dead Error::PoolExhausted and the Transaction stub (#281)

### DIFF
--- a/crates/mssql-client/src/error.rs
+++ b/crates/mssql-client/src/error.rs
@@ -183,10 +183,6 @@ pub enum Error {
     #[error("invalid identifier: {0}")]
     InvalidIdentifier(String),
 
-    /// Connection pool exhausted.
-    #[error("connection pool exhausted")]
-    PoolExhausted,
-
     /// Query cancellation error.
     #[error("query cancellation failed: {0}")]
     Cancel(String),
@@ -297,7 +293,6 @@ impl Error {
             | Self::ConnectionClosed
             | Self::Connection(_)
             | Self::Routing { .. }
-            | Self::PoolExhausted
             | Self::Io(_) => true,
             Self::Server { number, .. } => Self::is_transient_server_error(*number),
             _ => false,
@@ -526,7 +521,6 @@ mod tests {
         );
         assert!(Error::CommandTimeout.is_transient());
         assert!(Error::ConnectionClosed.is_transient());
-        assert!(Error::PoolExhausted.is_transient());
         assert!(
             Error::Routing {
                 host: "test".into(),

--- a/crates/mssql-client/src/lib.rs
+++ b/crates/mssql-client/src/lib.rs
@@ -202,7 +202,7 @@ pub use stream::{
     ExecuteResult, MultiResultStream, OutputParam, ProcedureResult, QueryStream, ResultSet,
 };
 pub use to_params::{NamedParam, ParamList, ToParams};
-pub use transaction::{IsolationLevel, SavePoint, Transaction};
+pub use transaction::{IsolationLevel, SavePoint};
 pub use tvp::{Tvp, TvpColumn, TvpRow, TvpValue};
 
 // FILESTREAM support (Windows only)

--- a/crates/mssql-client/src/transaction.rs
+++ b/crates/mssql-client/src/transaction.rs
@@ -1,7 +1,7 @@
 //! Transaction support.
 //!
-//! This module provides transaction isolation levels, savepoint support,
-//! and transaction abstractions for SQL Server.
+//! This module provides transaction isolation levels and savepoint support
+//! for SQL Server.
 
 /// Transaction isolation level.
 ///
@@ -110,42 +110,6 @@ impl SavePoint {
     #[must_use]
     pub fn name(&self) -> &str {
         &self.name
-    }
-}
-
-/// A database transaction abstraction.
-///
-/// This is a higher-level transaction wrapper that can be used
-/// with closure-based APIs or as a standalone type.
-#[must_use = "a transaction must be committed or rolled back"]
-pub struct Transaction<'a> {
-    isolation_level: IsolationLevel,
-    _marker: std::marker::PhantomData<&'a ()>,
-}
-
-impl Transaction<'_> {
-    /// Create a new transaction with default isolation level.
-    #[allow(dead_code)] // Used when transaction begin is implemented
-    pub(crate) fn new() -> Self {
-        Self {
-            isolation_level: IsolationLevel::default(),
-            _marker: std::marker::PhantomData,
-        }
-    }
-
-    /// Create a new transaction with specified isolation level.
-    #[allow(dead_code)] // Used when transaction begin is implemented
-    pub(crate) fn with_isolation_level(level: IsolationLevel) -> Self {
-        Self {
-            isolation_level: level,
-            _marker: std::marker::PhantomData,
-        }
-    }
-
-    /// Get the isolation level of this transaction.
-    #[must_use]
-    pub fn isolation_level(&self) -> IsolationLevel {
-        self.isolation_level
     }
 }
 

--- a/crates/mssql-client/tests/error_handling.rs
+++ b/crates/mssql-client/tests/error_handling.rs
@@ -161,14 +161,6 @@ fn test_invalid_identifier_display() {
 }
 
 #[test]
-fn test_pool_exhausted_display() {
-    assert_eq!(
-        Error::PoolExhausted.to_string(),
-        "connection pool exhausted"
-    );
-}
-
-#[test]
 fn test_cancel_error_display() {
     let err = Error::Cancel("connection not found".into());
     let msg = err.to_string();
@@ -318,7 +310,6 @@ fn test_non_server_error_has_no_class() {
     );
     assert!(Error::Query("test".into()).class().is_none());
     assert!(Error::Config("test".into()).class().is_none());
-    assert!(Error::PoolExhausted.class().is_none());
 }
 
 // =============================================================================
@@ -549,7 +540,6 @@ fn test_all_error_variants_are_debug() {
         Error::TooManyRedirects { max: 1 },
         Error::from(std::io::Error::other("test")),
         Error::InvalidIdentifier("test".into()),
-        Error::PoolExhausted,
         Error::Cancel("test".into()),
         Error::Cancelled,
     ];
@@ -698,7 +688,6 @@ fn test_every_variant_classified() {
             },
             "transient",
         ),
-        (Error::PoolExhausted, "transient"),
         (Error::from(std::io::Error::other("test")), "transient"),
         (Error::InvalidIdentifier("test".into()), "terminal"),
         (Error::Cancel("test".into()), "terminal"),

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -434,7 +434,7 @@ dependencies = [
 
 [[package]]
 name = "mssql-auth"
-version = "0.19.2"
+version = "0.19.3"
 dependencies = [
  "async-trait",
  "bytes",
@@ -444,7 +444,7 @@ dependencies = [
 
 [[package]]
 name = "mssql-client"
-version = "0.19.2"
+version = "0.19.3"
 dependencies = [
  "bytes",
  "chrono",
@@ -467,7 +467,7 @@ dependencies = [
 
 [[package]]
 name = "mssql-codec"
-version = "0.19.2"
+version = "0.19.3"
 dependencies = [
  "bytes",
  "futures-core",
@@ -482,7 +482,7 @@ dependencies = [
 
 [[package]]
 name = "mssql-derive"
-version = "0.19.2"
+version = "0.19.3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -506,7 +506,7 @@ dependencies = [
 
 [[package]]
 name = "mssql-tls"
-version = "0.19.2"
+version = "0.19.3"
 dependencies = [
  "rustls",
  "thiserror",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "mssql-types"
-version = "0.19.2"
+version = "0.19.3"
 dependencies = [
  "bytes",
  "chrono",
@@ -911,7 +911,7 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tds-protocol"
-version = "0.19.2"
+version = "0.19.3"
 dependencies = [
  "bitflags",
  "bytes",

--- a/public-api/mssql-client.txt
+++ b/public-api/mssql-client.txt
@@ -1272,7 +1272,6 @@ pub mssql_client::error::Error::Io(mssql_client::error::SharedIoError)
 pub mssql_client::error::Error::LoginTimeout
 pub mssql_client::error::Error::LoginTimeout::host: alloc::string::String
 pub mssql_client::error::Error::LoginTimeout::port: u16
-pub mssql_client::error::Error::PoolExhausted
 pub mssql_client::error::Error::Protocol(alloc::string::String)
 pub mssql_client::error::Error::ProtocolError(tds_protocol::error::ProtocolError)
 pub mssql_client::error::Error::Query(alloc::string::String)
@@ -2885,41 +2884,6 @@ impl<T> typenum::type_operators::Same for mssql_client::transaction::SavePoint
 pub type mssql_client::transaction::SavePoint::Output = T
 impl<V, T> ppv_lite86::types::VZip<V> for mssql_client::transaction::SavePoint where V: ppv_lite86::types::MultiLane<T>
 pub fn mssql_client::transaction::SavePoint::vzip(self) -> V
-pub struct mssql_client::transaction::Transaction<'a>
-impl mssql_client::transaction::Transaction<'_>
-pub fn mssql_client::transaction::Transaction<'_>::isolation_level(&self) -> mssql_client::transaction::IsolationLevel
-impl<'a> core::marker::Freeze for mssql_client::transaction::Transaction<'a>
-impl<'a> core::marker::Send for mssql_client::transaction::Transaction<'a>
-impl<'a> core::marker::Sync for mssql_client::transaction::Transaction<'a>
-impl<'a> core::marker::Unpin for mssql_client::transaction::Transaction<'a>
-impl<'a> core::panic::unwind_safe::RefUnwindSafe for mssql_client::transaction::Transaction<'a>
-impl<'a> core::panic::unwind_safe::UnwindSafe for mssql_client::transaction::Transaction<'a>
-impl<T, U> core::convert::Into<U> for mssql_client::transaction::Transaction<'a> where U: core::convert::From<T>
-pub fn mssql_client::transaction::Transaction<'a>::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for mssql_client::transaction::Transaction<'a> where U: core::convert::Into<T>
-pub type mssql_client::transaction::Transaction<'a>::Error = core::convert::Infallible
-pub fn mssql_client::transaction::Transaction<'a>::try_from(U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for mssql_client::transaction::Transaction<'a> where U: core::convert::TryFrom<T>
-pub type mssql_client::transaction::Transaction<'a>::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn mssql_client::transaction::Transaction<'a>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for mssql_client::transaction::Transaction<'a> where T: 'static + ?core::marker::Sized
-pub fn mssql_client::transaction::Transaction<'a>::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for mssql_client::transaction::Transaction<'a> where T: ?core::marker::Sized
-pub fn mssql_client::transaction::Transaction<'a>::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for mssql_client::transaction::Transaction<'a> where T: ?core::marker::Sized
-pub fn mssql_client::transaction::Transaction<'a>::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for mssql_client::transaction::Transaction<'a>
-pub fn mssql_client::transaction::Transaction<'a>::from(T) -> T
-impl<T> opentelemetry::context::future_ext::FutureExt for mssql_client::transaction::Transaction<'a>
-impl<T> tower_http::follow_redirect::policy::PolicyExt for mssql_client::transaction::Transaction<'a> where T: ?core::marker::Sized
-pub fn mssql_client::transaction::Transaction<'a>::and<P, B, E>(self, P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
-pub fn mssql_client::transaction::Transaction<'a>::or<P, B, E>(self, P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
-impl<T> tracing::instrument::Instrument for mssql_client::transaction::Transaction<'a>
-impl<T> tracing::instrument::WithSubscriber for mssql_client::transaction::Transaction<'a>
-impl<T> typenum::type_operators::Same for mssql_client::transaction::Transaction<'a>
-pub type mssql_client::transaction::Transaction<'a>::Output = T
-impl<V, T> ppv_lite86::types::VZip<V> for mssql_client::transaction::Transaction<'a> where V: ppv_lite86::types::MultiLane<T>
-pub fn mssql_client::transaction::Transaction<'a>::vzip(self) -> V
 pub mod mssql_client::tvp
 pub struct mssql_client::tvp::TvpColumn
 pub mssql_client::tvp::TvpColumn::name: alloc::string::String
@@ -3229,7 +3193,6 @@ pub mssql_client::Error::Io(mssql_client::error::SharedIoError)
 pub mssql_client::Error::LoginTimeout
 pub mssql_client::Error::LoginTimeout::host: alloc::string::String
 pub mssql_client::Error::LoginTimeout::port: u16
-pub mssql_client::Error::PoolExhausted
 pub mssql_client::Error::Protocol(alloc::string::String)
 pub mssql_client::Error::ProtocolError(tds_protocol::error::ProtocolError)
 pub mssql_client::Error::Query(alloc::string::String)
@@ -5554,41 +5517,6 @@ impl<T> typenum::type_operators::Same for mssql_client::config::TimeoutConfig
 pub type mssql_client::config::TimeoutConfig::Output = T
 impl<V, T> ppv_lite86::types::VZip<V> for mssql_client::config::TimeoutConfig where V: ppv_lite86::types::MultiLane<T>
 pub fn mssql_client::config::TimeoutConfig::vzip(self) -> V
-pub struct mssql_client::Transaction<'a>
-impl mssql_client::transaction::Transaction<'_>
-pub fn mssql_client::transaction::Transaction<'_>::isolation_level(&self) -> mssql_client::transaction::IsolationLevel
-impl<'a> core::marker::Freeze for mssql_client::transaction::Transaction<'a>
-impl<'a> core::marker::Send for mssql_client::transaction::Transaction<'a>
-impl<'a> core::marker::Sync for mssql_client::transaction::Transaction<'a>
-impl<'a> core::marker::Unpin for mssql_client::transaction::Transaction<'a>
-impl<'a> core::panic::unwind_safe::RefUnwindSafe for mssql_client::transaction::Transaction<'a>
-impl<'a> core::panic::unwind_safe::UnwindSafe for mssql_client::transaction::Transaction<'a>
-impl<T, U> core::convert::Into<U> for mssql_client::transaction::Transaction<'a> where U: core::convert::From<T>
-pub fn mssql_client::transaction::Transaction<'a>::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for mssql_client::transaction::Transaction<'a> where U: core::convert::Into<T>
-pub type mssql_client::transaction::Transaction<'a>::Error = core::convert::Infallible
-pub fn mssql_client::transaction::Transaction<'a>::try_from(U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for mssql_client::transaction::Transaction<'a> where U: core::convert::TryFrom<T>
-pub type mssql_client::transaction::Transaction<'a>::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn mssql_client::transaction::Transaction<'a>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for mssql_client::transaction::Transaction<'a> where T: 'static + ?core::marker::Sized
-pub fn mssql_client::transaction::Transaction<'a>::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for mssql_client::transaction::Transaction<'a> where T: ?core::marker::Sized
-pub fn mssql_client::transaction::Transaction<'a>::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for mssql_client::transaction::Transaction<'a> where T: ?core::marker::Sized
-pub fn mssql_client::transaction::Transaction<'a>::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for mssql_client::transaction::Transaction<'a>
-pub fn mssql_client::transaction::Transaction<'a>::from(T) -> T
-impl<T> opentelemetry::context::future_ext::FutureExt for mssql_client::transaction::Transaction<'a>
-impl<T> tower_http::follow_redirect::policy::PolicyExt for mssql_client::transaction::Transaction<'a> where T: ?core::marker::Sized
-pub fn mssql_client::transaction::Transaction<'a>::and<P, B, E>(self, P) -> tower_http::follow_redirect::policy::and::And<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
-pub fn mssql_client::transaction::Transaction<'a>::or<P, B, E>(self, P) -> tower_http::follow_redirect::policy::or::Or<T, P> where T: tower_http::follow_redirect::policy::Policy<B, E>, P: tower_http::follow_redirect::policy::Policy<B, E>
-impl<T> tracing::instrument::Instrument for mssql_client::transaction::Transaction<'a>
-impl<T> tracing::instrument::WithSubscriber for mssql_client::transaction::Transaction<'a>
-impl<T> typenum::type_operators::Same for mssql_client::transaction::Transaction<'a>
-pub type mssql_client::transaction::Transaction<'a>::Output = T
-impl<V, T> ppv_lite86::types::VZip<V> for mssql_client::transaction::Transaction<'a> where V: ppv_lite86::types::MultiLane<T>
-pub fn mssql_client::transaction::Transaction<'a>::vzip(self) -> V
 pub struct mssql_client::TvpColumn
 pub mssql_client::TvpColumn::name: alloc::string::String
 pub mssql_client::TvpColumn::ordinal: usize

--- a/public-api/mssql-client.windows.txt
+++ b/public-api/mssql-client.windows.txt
@@ -1152,7 +1152,6 @@ pub mssql_client::error::Error::Io(mssql_client::error::SharedIoError)
 pub mssql_client::error::Error::LoginTimeout
 pub mssql_client::error::Error::LoginTimeout::host: alloc::string::String
 pub mssql_client::error::Error::LoginTimeout::port: u16
-pub mssql_client::error::Error::PoolExhausted
 pub mssql_client::error::Error::Protocol(alloc::string::String)
 pub mssql_client::error::Error::ProtocolError(tds_protocol::error::ProtocolError)
 pub mssql_client::error::Error::Query(alloc::string::String)
@@ -2702,37 +2701,6 @@ impl<T> typenum::type_operators::Same for mssql_client::transaction::SavePoint
 pub type mssql_client::transaction::SavePoint::Output = T
 impl<V, T> ppv_lite86::types::VZip<V> for mssql_client::transaction::SavePoint where V: ppv_lite86::types::MultiLane<T>
 pub fn mssql_client::transaction::SavePoint::vzip(self) -> V
-pub struct mssql_client::transaction::Transaction<'a>
-impl mssql_client::transaction::Transaction<'_>
-pub fn mssql_client::transaction::Transaction<'_>::isolation_level(&self) -> mssql_client::transaction::IsolationLevel
-impl<'a> core::marker::Freeze for mssql_client::transaction::Transaction<'a>
-impl<'a> core::marker::Send for mssql_client::transaction::Transaction<'a>
-impl<'a> core::marker::Sync for mssql_client::transaction::Transaction<'a>
-impl<'a> core::marker::Unpin for mssql_client::transaction::Transaction<'a>
-impl<'a> core::panic::unwind_safe::RefUnwindSafe for mssql_client::transaction::Transaction<'a>
-impl<'a> core::panic::unwind_safe::UnwindSafe for mssql_client::transaction::Transaction<'a>
-impl<T, U> core::convert::Into<U> for mssql_client::transaction::Transaction<'a> where U: core::convert::From<T>
-pub fn mssql_client::transaction::Transaction<'a>::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for mssql_client::transaction::Transaction<'a> where U: core::convert::Into<T>
-pub type mssql_client::transaction::Transaction<'a>::Error = core::convert::Infallible
-pub fn mssql_client::transaction::Transaction<'a>::try_from(U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for mssql_client::transaction::Transaction<'a> where U: core::convert::TryFrom<T>
-pub type mssql_client::transaction::Transaction<'a>::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn mssql_client::transaction::Transaction<'a>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for mssql_client::transaction::Transaction<'a> where T: 'static + ?core::marker::Sized
-pub fn mssql_client::transaction::Transaction<'a>::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for mssql_client::transaction::Transaction<'a> where T: ?core::marker::Sized
-pub fn mssql_client::transaction::Transaction<'a>::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for mssql_client::transaction::Transaction<'a> where T: ?core::marker::Sized
-pub fn mssql_client::transaction::Transaction<'a>::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for mssql_client::transaction::Transaction<'a>
-pub fn mssql_client::transaction::Transaction<'a>::from(T) -> T
-impl<T> tracing::instrument::Instrument for mssql_client::transaction::Transaction<'a>
-impl<T> tracing::instrument::WithSubscriber for mssql_client::transaction::Transaction<'a>
-impl<T> typenum::type_operators::Same for mssql_client::transaction::Transaction<'a>
-pub type mssql_client::transaction::Transaction<'a>::Output = T
-impl<V, T> ppv_lite86::types::VZip<V> for mssql_client::transaction::Transaction<'a> where V: ppv_lite86::types::MultiLane<T>
-pub fn mssql_client::transaction::Transaction<'a>::vzip(self) -> V
 pub mod mssql_client::tvp
 pub struct mssql_client::tvp::TvpColumn
 pub mssql_client::tvp::TvpColumn::name: alloc::string::String
@@ -3010,7 +2978,6 @@ pub mssql_client::Error::Io(mssql_client::error::SharedIoError)
 pub mssql_client::Error::LoginTimeout
 pub mssql_client::Error::LoginTimeout::host: alloc::string::String
 pub mssql_client::Error::LoginTimeout::port: u16
-pub mssql_client::Error::PoolExhausted
 pub mssql_client::Error::Protocol(alloc::string::String)
 pub mssql_client::Error::ProtocolError(tds_protocol::error::ProtocolError)
 pub mssql_client::Error::Query(alloc::string::String)
@@ -5201,37 +5168,6 @@ impl<T> typenum::type_operators::Same for mssql_client::config::TimeoutConfig
 pub type mssql_client::config::TimeoutConfig::Output = T
 impl<V, T> ppv_lite86::types::VZip<V> for mssql_client::config::TimeoutConfig where V: ppv_lite86::types::MultiLane<T>
 pub fn mssql_client::config::TimeoutConfig::vzip(self) -> V
-pub struct mssql_client::Transaction<'a>
-impl mssql_client::transaction::Transaction<'_>
-pub fn mssql_client::transaction::Transaction<'_>::isolation_level(&self) -> mssql_client::transaction::IsolationLevel
-impl<'a> core::marker::Freeze for mssql_client::transaction::Transaction<'a>
-impl<'a> core::marker::Send for mssql_client::transaction::Transaction<'a>
-impl<'a> core::marker::Sync for mssql_client::transaction::Transaction<'a>
-impl<'a> core::marker::Unpin for mssql_client::transaction::Transaction<'a>
-impl<'a> core::panic::unwind_safe::RefUnwindSafe for mssql_client::transaction::Transaction<'a>
-impl<'a> core::panic::unwind_safe::UnwindSafe for mssql_client::transaction::Transaction<'a>
-impl<T, U> core::convert::Into<U> for mssql_client::transaction::Transaction<'a> where U: core::convert::From<T>
-pub fn mssql_client::transaction::Transaction<'a>::into(self) -> U
-impl<T, U> core::convert::TryFrom<U> for mssql_client::transaction::Transaction<'a> where U: core::convert::Into<T>
-pub type mssql_client::transaction::Transaction<'a>::Error = core::convert::Infallible
-pub fn mssql_client::transaction::Transaction<'a>::try_from(U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
-impl<T, U> core::convert::TryInto<U> for mssql_client::transaction::Transaction<'a> where U: core::convert::TryFrom<T>
-pub type mssql_client::transaction::Transaction<'a>::Error = <U as core::convert::TryFrom<T>>::Error
-pub fn mssql_client::transaction::Transaction<'a>::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
-impl<T> core::any::Any for mssql_client::transaction::Transaction<'a> where T: 'static + ?core::marker::Sized
-pub fn mssql_client::transaction::Transaction<'a>::type_id(&self) -> core::any::TypeId
-impl<T> core::borrow::Borrow<T> for mssql_client::transaction::Transaction<'a> where T: ?core::marker::Sized
-pub fn mssql_client::transaction::Transaction<'a>::borrow(&self) -> &T
-impl<T> core::borrow::BorrowMut<T> for mssql_client::transaction::Transaction<'a> where T: ?core::marker::Sized
-pub fn mssql_client::transaction::Transaction<'a>::borrow_mut(&mut self) -> &mut T
-impl<T> core::convert::From<T> for mssql_client::transaction::Transaction<'a>
-pub fn mssql_client::transaction::Transaction<'a>::from(T) -> T
-impl<T> tracing::instrument::Instrument for mssql_client::transaction::Transaction<'a>
-impl<T> tracing::instrument::WithSubscriber for mssql_client::transaction::Transaction<'a>
-impl<T> typenum::type_operators::Same for mssql_client::transaction::Transaction<'a>
-pub type mssql_client::transaction::Transaction<'a>::Output = T
-impl<V, T> ppv_lite86::types::VZip<V> for mssql_client::transaction::Transaction<'a> where V: ppv_lite86::types::MultiLane<T>
-pub fn mssql_client::transaction::Transaction<'a>::vzip(self) -> V
 pub struct mssql_client::TvpColumn
 pub mssql_client::TvpColumn::name: alloc::string::String
 pub mssql_client::TvpColumn::ordinal: usize


### PR DESCRIPTION
Resolves the **dead/decorative public API** part of #281 (item 4) — a **breaking** change taken deliberately pre-1.0, when removing public API is a minor bump rather than a major one.

## Removed (both dead, both confirmed)
- **`Error::PoolExhausted`** — never constructed anywhere. Pooling moved to `mssql-driver-pool`'s own `PoolError`, so this variant could *never fire*. A public error users might `match` on that never occurs is misleading.
- **`transaction::Transaction`** — an exported-but-never-constructed stub (a `PhantomData` + isolation-level marker whose only constructors were `pub(crate)` + `#[allow(dead_code)] // Used when transaction begin is implemented`). The real transaction API is `Client<InTransaction>` (and the new pooled `with_transaction`); the stub only confused.

## Kept (deliberately — not dead)
- **`release_savepoint`** — a *correct* no-op: SQL Server has no `RELEASE SAVEPOINT` (savepoints release implicitly on commit/rollback). It consumes the `SavePoint` by value (real ownership semantics) and is honestly documented as such. Removing a correctly-behaving, honestly-documented API would be removal for its own sake. (Scoped and agreed before execution: 2 removals, not 3.)
- **`IsolationLevel` / `SavePoint`** — live exports, unchanged.

## Migration
- `PoolExhausted`: nothing returned it; pool errors surface as `mssql_driver_pool::PoolError`.
- `Transaction`: was never constructible — use `Client<InTransaction>` (via `begin_transaction`) or `PooledConnection::with_transaction`.

## Gate
Carries both the `!` subject marker and a `BREAKING CHANGE:` footer (release-plz → minor bump, v0.20.0). Workspace clippy `-D warnings`, `cargo doc -D warnings`, `cargo xtask check-features`, typos clean; 456 non-ignored tests pass. Public-api snapshot regenerated (Linux) and the Windows baseline hand-trimmed of the same platform-agnostic lines (per the #294 precedent) — **136 deletions, removal-only**. fuzz crate compiles (`cargo check --manifest-path fuzz/Cargo.toml`).