### PR TITLE
ci: run doctests in just ci-all so the local mirror matches CI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -386,7 +386,7 @@ When making changes here, remember:
 
 7. **Use issue/PR templates.** They ask the right questions. If you're opening an issue or PR, fill out the template completely — it helps the human reviewer and it helps future AI sessions parse the intent.
 
-8. **Run the full local CI mirror before every push; never trust a subset.** `cargo check` and unit tests do not catch the `-D warnings`-class failures CI rejects. This repo's gate is reproduced by `just ci-all` (fmt + clippy `--all-features --all-targets -D warnings` + nextest all-features + `cargo doc -D warnings` + examples). `ci-all` does NOT compose three gates CI enforces (spell-check, feature-flag validation, and the live suite), so the real pre-push command is:
+8. **Run the full local CI mirror before every push; never trust a subset.** `cargo check` and unit tests do not catch the `-D warnings`-class failures CI rejects. This repo's gate is reproduced by `just ci-all` (fmt + clippy `--all-features --all-targets -D warnings` + nextest all-features + **doctests (`cargo test --doc --workspace --all-features`)** + `cargo doc -D warnings` + examples). Note: nextest does NOT run doctests, so the `doctest-all` step is what catches broken examples — including the README, which the `doc-tests` crate compiles via `include_str!` (a scoped `cargo test --doc -p <crate>` silently skips it). `ci-all` does NOT compose three gates CI enforces (spell-check, feature-flag validation, and the live suite), so the real pre-push command is:
 
    ```bash
    just ci-all && just typos && just check-feature-flags && \

--- a/Justfile
+++ b/Justfile
@@ -679,6 +679,15 @@ nextest-locked-all:
     printf '{{green}}[OK]{{reset}}   All tests passed\n'
 
 [group('test')]
+[doc("Run doctests, ALL features (nextest does NOT run them; matches CI's `cargo test --doc` step)")]
+doctest-all:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    printf '\n{{bold}}{{blue}}══════ Running Doctests (all features) ══════{{reset}}\n\n'
+    {{cargo}} test --doc --workspace --all-features --locked
+    printf '{{green}}[OK]{{reset}}   All doctests passed\n'
+
+[group('test')]
 [doc("Run Miri tests for unsafe code detection (requires nightly)")]
 miri:
     #!/usr/bin/env bash
@@ -1236,7 +1245,7 @@ ci: fmt-check clippy nextest-locked doc-check examples
 
 [group('ci')]
 [doc("CI pipeline with ALL features (matches GitHub Actions on Linux)")]
-ci-all: fmt-check clippy-all nextest-locked-all doc-check-all examples-all
+ci-all: fmt-check clippy-all nextest-locked-all doctest-all doc-check-all examples-all
     #!/usr/bin/env bash
     set -euo pipefail
     printf '\n{{bold}}{{blue}}══════ CI Pipeline Complete (all features) ══════{{reset}}\n\n'


### PR DESCRIPTION
`just ci-all` omitted doctests: nextest doesn't run them and `cargo doc` only builds them, so a broken doctest (e.g. the README example compiled by the `doc-tests` crate via `include_str!`) only failed in CI's separate `cargo test --doc` step (#360). Adds a `doctest-all` recipe (`cargo test --doc --workspace --all-features --locked`) folded into `ci-all`, and updates the CLAUDE.md pre-push notes. Verified the recipe runs green; doctest gap closed.