### PR TITLE
test(client): prove connect-retry reconnects past a transient failure

### DIFF
--- a/crates/mssql-testing/src/mock_server.rs
+++ b/crates/mssql-testing/src/mock_server.rs
@@ -331,6 +331,9 @@ pub struct MockServerConfig {
     login_routing_to_self: bool,
     /// Socket address to bind (default `127.0.0.1:0`).
     bind_addr: String,
+    /// Drop the first N accepted connections before any handshake, to
+    /// simulate transient connection failures (for connect-retry tests).
+    fail_first_n: usize,
 }
 
 /// Builder for `MockTdsServer`.
@@ -352,6 +355,7 @@ impl MockServerBuilder {
                 login_routing: None,
                 login_routing_to_self: false,
                 bind_addr: "127.0.0.1:0".to_string(),
+                fail_first_n: 0,
             },
         }
     }
@@ -398,6 +402,17 @@ impl MockServerBuilder {
     /// `127.0.0.1:0` (e.g. `[::1]:1433` to listen on the IPv6 loopback).
     pub fn with_bind_addr(mut self, addr: impl Into<String>) -> Self {
         self.config.bind_addr = addr.into();
+        self
+    }
+
+    /// Drop the first `n` accepted connections immediately, before any
+    /// handshake, to simulate transient connection failures. The `(n + 1)`th
+    /// connection is served normally. Every dropped attempt still increments
+    /// [`total_connection_count`](MockTdsServer::total_connection_count), so a
+    /// test can assert the client retried. Useful for exercising the client's
+    /// connect-retry loop.
+    pub fn fail_first_connections(mut self, n: usize) -> Self {
+        self.config.fail_first_n = n;
         self
     }
 
@@ -483,25 +498,34 @@ impl MockTdsServer {
                     result = listener.accept() => {
                         match result {
                             Ok((stream, _peer_addr)) => {
-                                let config = config.clone();
-                                let count = connection_count.clone();
-                                {
+                                let fail = {
                                     let mut t = total_connections.lock().await;
                                     *t += 1;
+                                    *t <= config.fail_first_n
+                                };
+                                if fail {
+                                    // Simulate a transient failure: close the
+                                    // socket before any handshake so the client
+                                    // sees a connection error and retries. The
+                                    // attempt is still counted above.
+                                    drop(stream);
+                                } else {
+                                    let config = config.clone();
+                                    let count = connection_count.clone();
+                                    tokio::spawn(async move {
+                                        {
+                                            let mut c = count.lock().await;
+                                            *c += 1;
+                                        }
+                                        if let Err(e) = handle_connection(stream, config).await {
+                                            tracing::debug!("Connection error: {}", e);
+                                        }
+                                        {
+                                            let mut c = count.lock().await;
+                                            *c = c.saturating_sub(1);
+                                        }
+                                    });
                                 }
-                                tokio::spawn(async move {
-                                    {
-                                        let mut c = count.lock().await;
-                                        *c += 1;
-                                    }
-                                    if let Err(e) = handle_connection(stream, config).await {
-                                        tracing::debug!("Connection error: {}", e);
-                                    }
-                                    {
-                                        let mut c = count.lock().await;
-                                        *c = c.saturating_sub(1);
-                                    }
-                                });
                             }
                             Err(e) => {
                                 tracing::error!("Accept error: {}", e);

--- a/crates/mssql-testing/tests/retry.rs
+++ b/crates/mssql-testing/tests/retry.rs
@@ -1,0 +1,75 @@
+//! Behavior tests for the connect-retry loop (ConnectRetryCount / Interval).
+//!
+//! The driver documents automatic retry of transient connection failures
+//! (`RetryPolicy`, wired from `ConnectRetryCount`/`ConnectRetryInterval`).
+//! These tests prove the reconnect loop against a mock TDS server that drops
+//! the first connection (a transient failure) then serves the next normally,
+//! so the whole path (transient classification -> backoff -> reconnect) runs
+//! without a live SQL Server. The backoff math itself is unit-tested; this is
+//! the missing end-to-end proof that the loop actually reconnects.
+//!
+//! These run in normal CI; no live SQL Server required.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+use mssql_client::{Client, Config};
+use mssql_testing::mock_server::MockTdsServer;
+
+fn mock_config(port: u16, retry_count: u32) -> Config {
+    // Plaintext-only mock (Encrypt=no_tls). ConnectRetryInterval=1 keeps the
+    // backoff to ~1s so the test stays fast.
+    Config::from_connection_string(&format!(
+        "Server=127.0.0.1,{port};User Id=sa;Password=test;Encrypt=no_tls;\
+         ConnectRetryCount={retry_count};ConnectRetryInterval=1"
+    ))
+    .expect("config parses")
+}
+
+/// With retries enabled, a transient connection failure (the server dropping
+/// the first socket before any handshake) must be retried, and the reconnect
+/// must succeed on the next attempt.
+#[tokio::test]
+async fn transient_failure_is_retried_and_reconnect_succeeds() {
+    let server = MockTdsServer::builder()
+        .fail_first_connections(1)
+        .build()
+        .await
+        .expect("server starts");
+
+    Client::connect(mock_config(server.port(), 1))
+        .await
+        .expect("connect must retry past the transient failure and succeed");
+
+    // The server saw exactly two attempts: the dropped one plus the successful
+    // reconnect.
+    assert_eq!(
+        server.total_connection_count().await,
+        2,
+        "one dropped attempt + one successful reconnect"
+    );
+}
+
+/// Control: with retries disabled, the SAME transient failure must surface as
+/// an error. This proves the retry loop — not something else — is what makes
+/// the test above succeed (the green only means something because this goes
+/// red).
+#[tokio::test]
+async fn no_retry_surfaces_the_transient_failure() {
+    let server = MockTdsServer::builder()
+        .fail_first_connections(1)
+        .build()
+        .await
+        .expect("server starts");
+
+    let result = Client::connect(mock_config(server.port(), 0)).await;
+
+    assert!(
+        result.is_err(),
+        "with ConnectRetryCount=0 the transient failure must not be retried"
+    );
+    assert_eq!(
+        server.total_connection_count().await,
+        1,
+        "exactly one attempt, no reconnect"
+    );
+}


### PR DESCRIPTION
## Summary

Follow-up to #374, closing the last "wired but never validated" gap the claim-reality audit named: the **RetryPolicy reconnect loop**. Only the backoff math was unit-tested; nothing asserted that a transient connection failure actually drives a reconnect. Since a sibling untested wiring (RESETCONNECTION, fixed in #374) turned out to have a real bug, this one was worth proving.

## Changes

- **Mock-server fail-injection**: `MockServerBuilder::fail_first_connections(n)` drops the first N accepted sockets before any handshake, simulating transient connection failures. Backward-compatible (defaults to 0, so existing mock tests are unaffected); every dropped attempt still increments `total_connection_count`, so a test can assert the client retried.
- **Two behavior tests** (`crates/mssql-testing/tests/retry.rs`, mock-based, run in normal CI):
  - `transient_failure_is_retried_and_reconnect_succeeds`: with `ConnectRetryCount=1`, `Client::connect` retries past a dropped connection and succeeds; the server saw exactly two attempts.
  - `no_retry_surfaces_the_transient_failure` (control): with `ConnectRetryCount=0`, the same drop surfaces as an error.

The pair is a genuine red/green proof — the control shows the transient drop *does* fail without retry, so the success case isn't vacuously green; the retry loop is what makes it pass.

## Result

No bug found — the reconnect loop works correctly across the transient-failure boundary. This is the coverage the audit flagged as missing.

## Testing

`just ci-all` + `just typos` + `just check-feature-flags` all green. The two new tests pass in ~1s (the `ConnectRetryInterval=1` backoff). The mock change is verified not to disturb the existing redirect/multi-subnet mock tests (full nextest run green).
