### PR TITLE
docs(migration): note the typed-error-vs-panic behavioral difference

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -450,6 +450,14 @@ match result {
 - Structured error with all server error fields
 - Error classification for retry logic
 
+**Behavioral difference — unexpected column types.** Tiberius decodes a fixed
+set of column types and `todo!()`-panics on the rest (`type_info.rs`), so a
+result set containing a `SQL_VARIANT` column (or another type it doesn't
+handle) aborts the task. This driver decodes `SQL_VARIANT` and legacy types,
+and where a value genuinely can't be decoded it returns a typed `Error` you can
+match on rather than panicking. Concretely: `SELECT CAST(42 AS SQL_VARIANT)`
+panics under Tiberius and returns `42` here.
+
 ## Type Mappings
 
 ### Key Differences


### PR DESCRIPTION
One concise, verified note added to MIGRATION.md's Error Handling section: Tiberius `todo!()`-panics on column types it doesn't decode (verified in its `type_info.rs:317`; `SQL_VARIANT`/`SSVariant` 0x62 is unhandled), while this driver decodes SQL_VARIANT and returns a typed `Error` otherwise. Concrete example: `SELECT CAST(42 AS SQL_VARIANT)` panics under Tiberius and returns `42` here (rmd side covered by the existing `test_data_type_sql_variant` live test).

Deliberately placed in MIGRATION.md, not the README — a competitor behavioral comparison belongs in the doc whose audience is Tiberius migrators, not the front page. Prose-only change (no compiled code); typos and doc-consistency green.