### PR TITLE
chore(client): remove verified dead code

### DIFF
--- a/crates/mssql-client/src/client.rs
+++ b/crates/mssql-client/src/client.rs
@@ -142,7 +142,6 @@ pub struct Client<S: ConnectionState> {
 /// - TLS (TDS 8.0 strict mode) - requires `tls` feature
 /// - TLS with PreLogin wrapping (TDS 7.x style) - requires `tls` feature
 /// - Plain TCP (for internal networks or when `tls` feature is disabled)
-#[allow(dead_code)] // Connection will be used once query execution is implemented
 enum ConnectionHandle {
     /// TLS connection (TDS 8.0 strict mode - TLS before any TDS traffic)
     #[cfg(feature = "tls")]

--- a/crates/mssql-client/src/stream.rs
+++ b/crates/mssql-client/src/stream.rs
@@ -655,16 +655,6 @@ impl<'a> MultiResultStream<'a> {
         }
     }
 
-    /// Create an empty multi-result stream.
-    #[allow(dead_code)]
-    pub(crate) fn empty() -> Self {
-        Self {
-            result_sets: Vec::new(),
-            current_result: 0,
-            _marker: std::marker::PhantomData,
-        }
-    }
-
     /// Get the current result set index (0-based).
     #[must_use]
     pub fn current_result_index(&self) -> usize {


### PR DESCRIPTION
First item in the audit burn-down. Two dead items, confirmed by an adversarial dead-code audit and compile-verified before removal:

- The `#[allow(dead_code)]` on `ConnectionHandle` (client.rs) was stale — the comment ("once query execution is implemented") is obsolete; all three variants are constructed (connect.rs) and matched. Removing the allow is warning-clean under both `--all-features` and `--no-default-features`.
- `MultiResultStream::empty` (stream.rs) had zero callers repo-wide (its `QueryStream::empty` sibling is kept — a unit test uses it).

Pure subtraction. `just ci-all` + typos + feature-flags all green locally.