### PR TITLE
docs: correct verified drifts (crate dep graph, ADR-008 example, test taxonomy)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -92,35 +92,18 @@ mssql-driver/
 ### 2.2 Crate Dependency Graph
 
 ```
-                    ┌─────────────────┐
-                    │  mssql-client   │ ← Public API
-                    └────────┬────────┘
-                             │
-        ┌────────────────────┼────────────────────┐
-        │                    │                    │
-        ▼                    ▼                    ▼
-┌───────────────┐   ┌───────────────┐   ┌───────────────┐
-│  mssql-pool   │   │  mssql-auth   │   │ mssql-derive  │
-└───────┬───────┘   └───────┬───────┘   └───────────────┘
-        │                   │
-        └─────────┬─────────┘
-                  │
-                  ▼
-          ┌───────────────┐
-          │  mssql-codec  │
-          └───────┬───────┘
-                  │
-        ┌─────────┴─────────┐
-        │                   │
-        ▼                   ▼
-┌───────────────┐   ┌───────────────┐
-│   mssql-tls   │   │  mssql-types  │
-└───────┬───────┘   └───────────────┘
-        │
-        ▼
-┌───────────────┐
-│ tds-protocol  │ ← no_std compatible
-└───────────────┘
+mssql-pool                        built-in connection pooling
+└── mssql-client                  ← public API surface
+    ├── mssql-codec  ──►  tds-protocol
+    ├── mssql-auth                authentication strategies
+    ├── mssql-tls                 TLS negotiation
+    ├── mssql-types               SQL ↔ Rust type mapping
+    ├── mssql-derive              row-mapping proc macros
+    └── tds-protocol              no_std core TDS protocol
+
+Leaf crates (no workspace-internal dependencies):
+  tds-protocol, mssql-types, mssql-tls, mssql-auth, mssql-derive.
+mssql-codec depends only on tds-protocol; mssql-pool depends on mssql-client.
 ```
 
 ### 2.3 Crate Specifications
@@ -173,7 +156,7 @@ pub enum Token {
 - Certificate validation and hostname verification
 - TLS 1.2/1.3 protocol selection
 
-**Dependencies:** `rustls`, `webpki-roots`, `tokio-rustls`, `tds-protocol`
+**Dependencies:** `rustls`, `webpki-roots`, `tokio-rustls`
 
 **Rationale:** TDS TLS negotiation is sufficiently complex to warrant isolation. TDS 8.0 fundamentally changes the handshake order (TCP → TLS → TDS vs. TCP → TDS prelogin → TLS → TDS), and this crate encapsulates that complexity.
 
@@ -186,7 +169,7 @@ pub enum Token {
 - Packet continuation handling (large packets split across multiple TDS packets)
 - IO splitting for cancellation safety (see ADR-004)
 
-**Dependencies:** `tds-protocol`, `mssql-tls`, `tokio-util` (Codec), `bytes`, `tokio`
+**Dependencies:** `tds-protocol`, `tokio-util` (Codec), `bytes`, `tokio`
 
 #### `crates/mssql-types`
 
@@ -613,8 +596,7 @@ tx.commit().await?;
 
 // With isolation level
 let tx = client
-    .begin_transaction()
-    .isolation_level(IsolationLevel::Serializable)
+    .begin_transaction_with_isolation(IsolationLevel::Serializable)
     .await?;
 
 // Savepoints

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -303,6 +303,14 @@ Tests are organized by functional domain:
 | `protocol_conformance.rs` | MS-TDS specification compliance |
 | `collation_test.rs` | Character encoding and collation handling |
 | `edge_cases.rs` | Boundary conditions (empty results, large values, etc.) |
+| `bulk_insert.rs` | Bulk copy (BCP) round-trips |
+| `stored_procedure.rs` | Stored-procedure RPC and OUTPUT parameters |
+| `statement_cache_live.rs` | Opt-in prepared-statement cache |
+| `query_stream.rs` / `blob_stream.rs` | Incremental row and BLOB streaming |
+| `type_matrix.rs` | Differential type encode/decode vs the server |
+| `rpc_roundtrip.rs` | RPC parameter encoding |
+
+This table is representative; see `crates/mssql-client/tests/` for the full set.
 
 ### Test Patterns for Database Drivers
 


### PR DESCRIPTION
Doc-accuracy corrections found while re-auditing the plan against the ADRs (per the mod.rs miss). All verified against the manifests/code, not assumed:

- **Crate dependency graph (ARCHITECTURE.md)** was more than 'slightly imprecise' — it showed codec→tls/types, pool as a *dependency* of client (backwards), and tls→tds-protocol. Redrawn from the actual `[dependencies]`: codec depends only on tds-protocol; auth/tls/types/derive/tds-protocol are leaves; client depends on all of them; pool depends on client.
- **Prose dep lines** for mssql-tls (:176) and mssql-codec (:189) listed tds-protocol / mssql-tls, which aren't real deps.
- **ADR-008 example** used a non-existent `.isolation_level()` builder; corrected to `begin_transaction_with_isolation(...)`.
- **CONTRIBUTING test taxonomy** omitted ~7 files; added the main ones + a 'representative, not exhaustive' note to stop future drift.

Docs-only; doc-consistency (25/25) and typos green. Net-negative diff.