### PR TITLE
test: remove std tautologies, assert the multi-equals parser behavior

### DIFF
--- a/crates/mssql-client/tests/config.rs
+++ b/crates/mssql-client/tests/config.rs
@@ -59,12 +59,16 @@ fn test_missing_equals_sign() {
 
 #[test]
 fn test_multiple_equals_in_value() {
-    // Password with equals sign
-    let _config =
+    // ADO.NET splits each key=value pair on the FIRST '=', so a password
+    // containing '=' is preserved verbatim as the value.
+    let config =
         Config::from_connection_string("Server=localhost;Password=pass=word=with=equals;").unwrap();
 
-    // The current implementation splits on first '=', so everything after is the value
-    // Note: This may need fixing depending on desired behavior
+    if let mssql_client::Credentials::SqlServer { password, .. } = &config.credentials {
+        assert_eq!(password.as_ref(), "pass=word=with=equals");
+    } else {
+        unreachable!("expected SqlServer credentials");
+    }
 }
 
 #[test]

--- a/crates/mssql-client/tests/edge_cases.rs
+++ b/crates/mssql-client/tests/edge_cases.rs
@@ -27,19 +27,6 @@ fn test_null_value_creation() {
 }
 
 #[test]
-fn test_option_none_is_null() {
-    let value: Option<i32> = None;
-    assert!(value.is_none());
-}
-
-#[test]
-fn test_option_some_is_not_null() {
-    let value: Option<i32> = Some(42);
-    assert!(value.is_some());
-    assert_eq!(value, Some(42));
-}
-
-#[test]
 fn test_null_from_sql_to_option() {
     let null = SqlValue::Null;
     let result: Result<Option<i32>, _> = Option::<i32>::from_sql(&null);


### PR DESCRIPTION
Test-honesty hygiene from the audit. Removes two tests that only asserted standard-library facts (`None.is_none()`, `Some(42).is_some()`) and exercised no driver code. Strengthens `test_multiple_equals_in_value`, which parsed a password containing '=' but asserted nothing (its own comment described the split-on-first-'=' behavior it never checked); it now asserts the password is preserved verbatim via the public `Credentials::SqlServer`, so it's load-bearing.

Unit-level; ci-all + typos + feature-flags green.