### PR TITLE
test: strengthen misnamed/assertion-free tests

### DIFF
--- a/crates/mssql-client/tests/error_handling.rs
+++ b/crates/mssql-client/tests/error_handling.rs
@@ -561,9 +561,12 @@ fn test_io_error_source() {
     let io_err = std::io::Error::other("inner error");
     let err = Error::from(io_err);
 
-    // The error should have a source
-    // Note: thiserror may or may not expose the source depending on definition
-    let _ = err.source();
+    // Error::Io wraps the io::Error via #[source], so it must be exposed.
+    assert!(
+        err.source()
+            .is_some_and(|s| s.to_string().contains("inner error")),
+        "Error::Io should expose the wrapped io::Error as its source"
+    );
 }
 
 // =============================================================================

--- a/crates/mssql-testing/tests/mock_fidelity.rs
+++ b/crates/mssql-testing/tests/mock_fidelity.rs
@@ -746,10 +746,3 @@ impl rustls::client::danger::ServerCertVerifier for DangerousVerifier {
 // =============================================================================
 // Comparison Tests Against Real SQL Server (require live SQL Server)
 // =============================================================================
-
-#[tokio::test]
-#[ignore = "Requires SQL Server for comparison"]
-async fn test_compare_with_real_server() {
-    // This test would compare mock and real SQL Server responses
-    // Requires both mock TLS support and a running SQL Server
-}

--- a/crates/tds-protocol/src/rpc.rs
+++ b/crates/tds-protocol/src/rpc.rs
@@ -1501,12 +1501,25 @@ mod tests {
     }
 
     #[test]
-    fn test_varchar_encode_round_trip() {
-        // Verify the encoded param can be serialized without panics
+    fn test_varchar_encode_includes_name_and_value() {
+        // Encoding must carry the VARCHAR value bytes (Windows-1252, ASCII here)
+        // and the UTF-16LE parameter name into the buffer — not merely produce
+        // non-empty output.
         let param = RpcParam::varchar("@val", "test value");
         let mut buf = bytes::BytesMut::new();
         param.encode(&mut buf);
-        assert!(!buf.is_empty());
+        let bytes = &buf[..];
+        assert!(
+            bytes.windows(10).any(|w| w == b"test value"),
+            "encoded buffer should contain the VARCHAR value"
+        );
+        let name_utf16: Vec<u8> = "@val".encode_utf16().flat_map(u16::to_le_bytes).collect();
+        assert!(
+            bytes
+                .windows(name_utf16.len())
+                .any(|w| w == name_utf16.as_slice()),
+            "encoded buffer should contain the UTF-16LE parameter name"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Second vacuous-cleanup pass from the audit. Three tests that looked like coverage but weren't:

- `test_varchar_encode_round_trip` never decoded/round-tripped — it only asserted `!buf.is_empty()`. Renamed to `test_varchar_encode_includes_name_and_value` and it now asserts the encoded buffer actually contains the VARCHAR value bytes and the UTF-16LE parameter name.
- `test_io_error_source` discarded `err.source()` with no assertion; now asserts `Error::Io` exposes the wrapped `io::Error`.
- Removed `test_compare_with_real_server`, an ignored empty-body placeholder that could never fail.

Unit-level; ci-all + typos + feature-flags green.