### PR TITLE
test(client): guard save_point() name validation against injection

### DIFF
--- a/crates/mssql-client/tests/integration.rs
+++ b/crates/mssql-client/tests/integration.rs
@@ -29,7 +29,7 @@
     clippy::approx_constant
 )]
 
-use mssql_client::{Client, Config};
+use mssql_client::{Client, Config, Error};
 
 /// Helper to get test configuration from environment variables.
 fn get_test_config() -> Option<Config> {
@@ -836,6 +836,29 @@ async fn test_transaction_savepoint() {
     );
 
     client.close().await.expect("Failed to close");
+}
+
+#[tokio::test]
+#[ignore = "Requires SQL Server"]
+async fn test_savepoint_rejects_injection_name() {
+    // Regression guard for the save_point() -> validate_identifier() wiring.
+    // An injection/invalid savepoint name must be rejected client-side, before
+    // any SAVE TRANSACTION batch is sent. If the validate_identifier() call in
+    // save_point() is removed, the name reaches the server as raw SQL and the
+    // error type is no longer InvalidIdentifier, so this assertion fails.
+    let config = get_test_config().expect("SQL Server config required");
+    let client = Client::connect(config).await.expect("Failed to connect");
+
+    let mut tx = client.begin_transaction().await.expect("Begin failed");
+
+    let err = tx
+        .save_point("sp1; DROP TABLE users")
+        .await
+        .expect_err("save_point must reject an injection name");
+    assert!(
+        matches!(err, Error::InvalidIdentifier(_)),
+        "expected client-side InvalidIdentifier rejection, got: {err:?}"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

`save_point()` validates the savepoint name via `validate_identifier()` before building the `SAVE TRANSACTION` batch (`client.rs:2629`), but **no test exercised that wiring** — removing the validation call left the entire test suite green. This adds a regression guard that drives an injection name through the `save_point()` API and asserts a client-side `InvalidIdentifier` rejection.

## What this covers (and its limits)

- The test is **live-only / `#[ignore]`'d**, matching the existing savepoint tests, because `save_point()` requires a `Client<InTransaction>` (a real connection). So it guards the wiring in the **live/ignored CI suite**, not default `cargo nextest`. That is the honest protection level — `save_point` needs a connection, so a synchronous test isn't possible without refactoring the API, which this PR deliberately does not do.
- It does **not** change any production code.

## Verification (red → green, against a live SQL Server 2022 container)

- Validation **present** → test **passes** (`save_point("sp1; DROP TABLE users")` returns `Err(InvalidIdentifier)` before any batch is sent).
- Validation **removed** → test **fails**: the payload reaches the server and executes `DROP TABLE users` (server error 3701), so the `matches!(err, Error::InvalidIdentifier(_))` assertion turns red.

## Local gate

`just ci-all`, `just typos`, `just check-feature-flags` all pass. The new test itself was verified live red→green (above).

## Notes

- Found while building a claim-audit eval suite; this is the one real coverage gap that audit surfaced.
- MSRV bumps are NOT breaking changes (N/A here — test-only).