### PR TITLE
fix(deps): bump crossbeam-epoch to 0.9.20 (RUSTSEC-2026-0204)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1044,9 +1044,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
## What

Bumps `crossbeam-epoch` `0.9.18` → `0.9.20` in `Cargo.lock` to resolve **RUSTSEC-2026-0204** (invalid pointer dereference in the `fmt::Pointer` impl for `Atomic`/`Shared`).

## Why

The advisory published 2026-07-07 and now fails the required **Dependency Audit** check on every branch (main included). It reaches the tree as a **dev-dependency** only: `criterion → rayon → rayon-core → crossbeam-deque → crossbeam-epoch`. No runtime/shipping impact, but it blocks all PR merges until main's lockfile is fixed.

Solution per the advisory: upgrade to `>=0.9.20`.

## Change

Lockfile-only, two lines.

Unblocks #387 and #388 (both currently red solely on this audit).